### PR TITLE
Add Org links for pi sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# shellcheck disable=all
 # pi-coding-agent Makefile
 
 EMACS ?= emacs
@@ -20,7 +21,7 @@ SELECTOR ?=
 # Example: make test VERBOSE=1
 VERBOSE ?=
 
-.PHONY: test test-unit test-core test-ui test-render test-table test-input test-menu test-build
+.PHONY: test test-unit test-core test-ui test-render test-table test-input test-menu test-org test-build
 .PHONY: test-integration test-integration-fake test-integration-real test-integration-ci test-integration-ci-real test-gui test-gui-ci test-all
 .PHONY: bench bench-batch
 .PHONY: check check-parens compile lint lint-checkdoc lint-package clean clean-cache help
@@ -35,6 +36,7 @@ help:
 	@echo "  make test-table       Table decoration tests only"
 	@echo "  make test-input       Input buffer tests only"
 	@echo "  make test-menu        Menu/session tests only"
+	@echo "  make test-org         Org link tests only"
 	@echo "  make test-build       Build/dependency helper tests only"
 	@echo "  make test-unit        Compile + all unit tests"
 	@echo "  make test-integration Shared integration tests (fake first, then real; local target starts Ollama for the real lane)"
@@ -93,6 +95,7 @@ test: .deps-stamp
 		-l pi-coding-agent-table-test \
 		-l pi-coding-agent-input-test \
 		-l pi-coding-agent-menu-test \
+		-l pi-coding-agent-org-test \
 		-l pi-coding-agent-build-test \
 		-l pi-coding-agent-fake-pi-test \
 		-l pi-coding-agent-gui-test-utils-test \
@@ -128,6 +131,9 @@ test-input: .deps-stamp
 	@$(BATCH_TEST) -l pi-coding-agent-input-test -f ert-run-tests-batch-and-exit
 test-menu: .deps-stamp
 	@$(BATCH_TEST) -l pi-coding-agent-menu-test -f ert-run-tests-batch-and-exit
+
+test-org: .deps-stamp
+	@$(BATCH_TEST) -l pi-coding-agent-org-test -f ert-run-tests-batch-and-exit
 
 test-build: .deps-stamp
 	@$(BATCH_TEST) -l pi-coding-agent-build-test -f ert-run-tests-batch-and-exit
@@ -265,7 +271,7 @@ ollama-status:
 
 check-parens:
 	@echo "=== Check Parens ==="
-	@OUTPUT=$$($(BATCH) --eval '(condition-case err (dolist (f (list "scripts/pi-coding-agent-build.el" "scripts/install-deps.el" "scripts/install-ts-grammars.el" "pi-coding-agent-core.el" "pi-coding-agent-grammars.el" "pi-coding-agent-ui.el" "pi-coding-agent-table.el" "pi-coding-agent-render.el" "pi-coding-agent-input.el" "pi-coding-agent-menu.el" "pi-coding-agent.el")) (with-current-buffer (find-file-noselect f) (check-parens) (message "%s OK" f))) (user-error (message "FAIL: %s" (error-message-string err)) (kill-emacs 1)))' 2>&1); \
+	@OUTPUT=$$($(BATCH) --eval '(condition-case err (dolist (f (list "scripts/pi-coding-agent-build.el" "scripts/install-deps.el" "scripts/install-ts-grammars.el" "pi-coding-agent-core.el" "pi-coding-agent-grammars.el" "pi-coding-agent-ui.el" "pi-coding-agent-table.el" "pi-coding-agent-render.el" "pi-coding-agent-input.el" "pi-coding-agent-menu.el" "pi-coding-agent-org.el" "pi-coding-agent.el")) (with-current-buffer (find-file-noselect f) (check-parens) (message "%s OK" f))) (user-error (message "FAIL: %s" (error-message-string err)) (kill-emacs 1)))' 2>&1); \
 	echo "$$OUTPUT" | grep -E "OK$$|FAIL:"; \
 	echo "$$OUTPUT" | grep -q "FAIL:" && exit 1 || true
 
@@ -277,7 +283,7 @@ compile: .deps-stamp
 		--eval "(package-initialize)" \
 		$(LOCAL_LOAD_PATH) \
 		--eval "(setq byte-compile-error-on-warn t)" \
-		-f batch-byte-compile scripts/pi-coding-agent-build.el scripts/install-deps.el scripts/install-ts-grammars.el pi-coding-agent-core.el pi-coding-agent-grammars.el pi-coding-agent-ui.el pi-coding-agent-table.el pi-coding-agent-render.el pi-coding-agent-input.el pi-coding-agent-menu.el pi-coding-agent.el
+		-f batch-byte-compile scripts/pi-coding-agent-build.el scripts/install-deps.el scripts/install-ts-grammars.el pi-coding-agent-core.el pi-coding-agent-grammars.el pi-coding-agent-ui.el pi-coding-agent-table.el pi-coding-agent-render.el pi-coding-agent-input.el pi-coding-agent-menu.el pi-coding-agent-org.el pi-coding-agent.el
 
 lint: lint-checkdoc lint-package
 
@@ -296,6 +302,7 @@ lint-checkdoc:
 		--eval "(checkdoc-file \"pi-coding-agent-render.el\")" \
 		--eval "(checkdoc-file \"pi-coding-agent-input.el\")" \
 		--eval "(checkdoc-file \"pi-coding-agent-menu.el\")" \
+		--eval "(checkdoc-file \"pi-coding-agent-org.el\")" \
 		--eval "(checkdoc-file \"pi-coding-agent.el\")" 2>&1); \
 	WARNINGS=$$(echo "$$OUTPUT" | grep -A1 "^Warning" | grep -v "^Warning\|^--$$"); \
 	if [ -n "$$WARNINGS" ]; then echo "$$WARNINGS"; exit 1; else echo "OK"; fi
@@ -311,7 +318,7 @@ lint-package:
 		          (package-install 'package-lint))" \
 		--eval "(require 'package-lint)" \
 		--eval "(setq package-lint-main-file \"pi-coding-agent.el\")" \
-		-f package-lint-batch-and-exit pi-coding-agent.el pi-coding-agent-ui.el pi-coding-agent-table.el pi-coding-agent-render.el pi-coding-agent-input.el pi-coding-agent-menu.el pi-coding-agent-core.el pi-coding-agent-grammars.el
+		-f package-lint-batch-and-exit pi-coding-agent.el pi-coding-agent-ui.el pi-coding-agent-table.el pi-coding-agent-render.el pi-coding-agent-input.el pi-coding-agent-menu.el pi-coding-agent-org.el pi-coding-agent-core.el pi-coding-agent-grammars.el
 
 check: compile lint test
 

--- a/README.org
+++ b/README.org
@@ -332,6 +332,36 @@ transcript on disk. Saving does not interrupt or replace the live pi session.
 If you want a shareable export instead, use HTML export (=C-c C-p e= or
 =/export=).
 
+** 🗂 Org links
+
+pi-coding-agent includes optional Org link support in =pi-coding-agent-org.el=.
+Load it from your Org configuration if you want =pi:= links:
+
+#+begin_src emacs-lisp
+(with-eval-after-load 'org
+  (require 'pi-coding-agent-org))
+#+end_src
+
+From a pi chat or input buffer, use =org-store-link= (normally =C-c l=, or
+=C-c n l= in some Doom setups) to store a link to the current session. Insert
+it later in Org with =org-insert-link=.
+
+Durable session-file links open that session directly:
+
+#+begin_src org
+[[pi:session?file=/abs/path/to/.pi/sessions/session.jsonl][Open pi session]]
+#+end_src
+
+Links can also target a project directory and named session:
+
+#+begin_src org
+[[pi:session?dir=/abs/path/to/project/&name=feature-try][Open pi session]]
+#+end_src
+
+When a link opens a different session in a directory that already has a pi
+buffer, pi-coding-agent uses a separate named session buffer, like =C-u M-x
+pi-coding-agent=.
+
 ** 🌿 Forking and Context Management
 
 When a conversation gets long, the AI's context window fills up. The menu

--- a/pi-coding-agent-org.el
+++ b/pi-coding-agent-org.el
@@ -1,0 +1,145 @@
+;;; pi-coding-agent-org.el --- Org links for pi coding agent -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Daniel Nouri
+
+;; Author: Daniel Nouri <daniel.nouri@gmail.com>
+;; Maintainer: Daniel Nouri <daniel.nouri@gmail.com>
+;; URL: https://github.com/dnouri/pi-coding-agent
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Optional Org link support for pi-coding-agent sessions.
+;; Loading the base pi-coding-agent package does not require Org; users can load
+;; this file from `org-mode' configuration to enable pi: links.
+
+;;; Code:
+
+(require 'pi-coding-agent)
+(require 'org)
+(require 'subr-x)
+(require 'url-util)
+
+(defun pi-coding-agent-org--query-encode (value)
+  "URL-encode VALUE for a pi Org link query parameter."
+  (url-hexify-string (or value "")))
+
+(defun pi-coding-agent-org--query-decode (value)
+  "URL-decode VALUE from a pi Org link query parameter."
+  (url-unhex-string (replace-regexp-in-string "+" " " (or value ""))))
+
+(defun pi-coding-agent-org--parse-link (path)
+  "Parse a pi Org link PATH.
+Returns a plist with :kind and decoded query parameter keys such as :file,
+:dir, and :name."
+  (let* ((parts (split-string path "\\?" t))
+         (kind (car parts))
+         (query (cadr parts))
+         (plist (list :kind kind)))
+    (when query
+      (dolist (part (split-string query "&" t))
+        (when (string-match "\\`\\([^=]+\\)=\\(.*\\)\\'" part)
+          (let ((key (intern (concat ":" (match-string 1 part))))
+                (value (pi-coding-agent-org--query-decode
+                        (match-string 2 part))))
+            (setq plist (plist-put plist key value))))))
+    plist))
+
+(defun pi-coding-agent-org-session-link-target (&optional file dir name)
+  "Return a pi: session link target from FILE or DIR and NAME.
+FILE is preferred as the durable session identity.  DIR and NAME are used for
+links to named sessions that do not yet have a known durable session file."
+  (concat
+   "session?"
+   (cond
+    ((and file (not (string-empty-p file)))
+     (concat "file=" (pi-coding-agent-org--query-encode
+                      (expand-file-name file))
+             (when dir
+               (concat "&dir=" (pi-coding-agent-org--query-encode
+                                (file-name-as-directory
+                                 (expand-file-name dir)))))
+             (when (and name (not (string-empty-p name)))
+               (concat "&name=" (pi-coding-agent-org--query-encode name)))))
+    ((and dir name (not (string-empty-p name)))
+     (concat "dir=" (pi-coding-agent-org--query-encode
+                     (file-name-as-directory (expand-file-name dir)))
+             "&name=" (pi-coding-agent-org--query-encode name)))
+    (dir
+     (concat "dir=" (pi-coding-agent-org--query-encode
+                     (file-name-as-directory (expand-file-name dir)))))
+    (t
+     (user-error "No pi session file or directory known")))))
+
+(defun pi-coding-agent-org-session-link (&optional file dir name description)
+  "Return an Org bracket link for a pi session.
+FILE, DIR, and NAME are passed to `pi-coding-agent-org-session-link-target'.
+DESCRIPTION defaults to a generic session label."
+  (format "[[pi:%s][%s]]"
+          (pi-coding-agent-org-session-link-target file dir name)
+          (or description "Open pi session")))
+
+(defun pi-coding-agent-org--current-session-link-data (&optional chat-buffer)
+  "Return Org link data for CHAT-BUFFER or the current pi session.
+The result is a plist with :link and :description, or nil when point is not in
+a pi chat/input session buffer."
+  (let ((chat-buf (or chat-buffer (pi-coding-agent--get-chat-buffer))))
+    (when (and (buffer-live-p chat-buf)
+               (with-current-buffer chat-buf
+                 (derived-mode-p 'pi-coding-agent-chat-mode)))
+      (with-current-buffer chat-buf
+        (let* ((file (pi-coding-agent-session-file chat-buf))
+               (dir (pi-coding-agent--chat-session-directory chat-buf))
+               (name (pi-coding-agent-session-display-name chat-buf))
+               (target (pi-coding-agent-org-session-link-target file dir name))
+               (description (if (and name (not (string-empty-p name)))
+                                (format "pi session: %s" name)
+                              "pi session")))
+          (list :link (concat "pi:" target)
+                :description description))))))
+
+(defun pi-coding-agent-org-store-session-link (&optional _interactive)
+  "Store an Org link to the current pi session.
+This is used by `org-store-link' from pi chat and input buffers."
+  (when-let* ((data (pi-coding-agent-org--current-session-link-data)))
+    (org-link-store-props :type "pi"
+                          :link (plist-get data :link)
+                          :description (plist-get data :description))
+    t))
+
+;;;###autoload
+(defun pi-coding-agent-org-open-link (path _)
+  "Open pi Org link PATH."
+  (let* ((info (pi-coding-agent-org--parse-link path))
+         (kind (plist-get info :kind)))
+    (pcase kind
+      ("session"
+       (cond
+        ((plist-get info :file)
+         (pi-coding-agent-session-open-file
+          (plist-get info :file)
+          (plist-get info :dir)
+          (plist-get info :name)))
+        ((plist-get info :dir)
+         (pi-coding-agent-session-open
+          (plist-get info :dir)
+          (plist-get info :name)))
+        (t
+         (user-error "pi session link lacks file or dir"))))
+      (_
+       (user-error "Unsupported pi link kind: %s" kind)))))
+
+(defun pi-coding-agent-org-export-link (path description _backend)
+  "Export pi Org link PATH with DESCRIPTION."
+  (or description (format "pi:%s" path)))
+
+(org-link-set-parameters "pi"
+                         :follow #'pi-coding-agent-org-open-link
+                         :export #'pi-coding-agent-org-export-link
+                         :store #'pi-coding-agent-org-store-session-link)
+
+(provide 'pi-coding-agent-org)
+;;; pi-coding-agent-org.el ends here

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -678,6 +678,11 @@ still uses this name to find the live conversation.")
 Project lookup, window toggling, and path completion use this directory even
 when the buffer is also backed by a transcript file elsewhere.")
 
+(defvar-local pi-coding-agent--canonical-session-name nil
+  "Stable named-session suffix for this chat buffer.
+This is the optional SESSION passed to `pi-coding-agent--setup-session', not
+necessarily the persisted pi session display name.")
+
 (defvar pi-coding-agent--chat-buffer)
 
 (defun pi-coding-agent--chat-session-buffer-name (&optional buffer)
@@ -701,6 +706,8 @@ DIR is the session directory and SESSION is the optional named-session suffix."
   (setq pi-coding-agent--canonical-buffer-name
         (pi-coding-agent--buffer-name :chat dir session)
         pi-coding-agent--canonical-session-directory dir
+        pi-coding-agent--canonical-session-name
+        (and session (not (string-empty-p session)) session)
         default-directory dir))
 
 (defun pi-coding-agent--restore-chat-buffer-read-only ()

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -83,6 +83,158 @@
 
 (require 'pi-coding-agent-menu)
 (require 'pi-coding-agent-input)
+(require 'json)
+
+;;;; Public Session API
+
+(defun pi-coding-agent--session-file-cwd (session-file)
+  "Return the recorded cwd from SESSION-FILE, or nil if unavailable."
+  (when (file-readable-p session-file)
+    (with-temp-buffer
+      (insert-file-contents session-file nil 0 4096)
+      (goto-char (point-min))
+      (when-let* ((line (buffer-substring-no-properties
+                         (line-beginning-position)
+                         (line-end-position))))
+        (ignore-errors
+          (let ((event (json-parse-string line :object-type 'plist)))
+            (when (equal (plist-get event :type) "session")
+              (plist-get event :cwd))))))))
+
+(defun pi-coding-agent--session-file-project-directory (session-file)
+  "Return a likely project directory for SESSION-FILE.
+This prefers the cwd recorded inside the session file, then the nearest
+ancestor containing .git, falling back to the session file's containing
+directory."
+  (let* ((file (expand-file-name session-file))
+         (dir (file-name-directory file)))
+    (file-name-as-directory
+     (expand-file-name
+      (or (pi-coding-agent--session-file-cwd file)
+          (locate-dominating-file dir ".git")
+          dir)))))
+
+(defun pi-coding-agent--find-session-file-buffer (session-file)
+  "Return a live chat buffer currently displaying SESSION-FILE, or nil."
+  (let ((target (expand-file-name session-file))
+        found)
+    (dolist (buffer (buffer-list) found)
+      (when (and (not found)
+                 (buffer-live-p buffer))
+        (with-current-buffer buffer
+          (when (and (derived-mode-p 'pi-coding-agent-chat-mode)
+                     (let ((file (plist-get pi-coding-agent--state
+                                            :session-file)))
+                       (and (stringp file)
+                            (equal (expand-file-name
+                                    file
+                                    (or (pi-coding-agent--chat-session-directory)
+                                        default-directory))
+                                   target))))
+            (setq found buffer)))))))
+
+;;;###autoload
+(defun pi-coding-agent-session-open (dir &optional display-name)
+  "Open or create a pi session in DIR with optional DISPLAY-NAME.
+The normal pi chat/input UI is shown and the chat buffer is returned."
+  (interactive
+   (list (read-directory-name "Pi directory: " nil nil t)
+         (let ((name (read-string "Session name (optional): ")))
+           (and (not (string-empty-p (string-trim name))) name))))
+  (pi-coding-agent--check-dependencies)
+  (let* ((dir (file-name-as-directory (expand-file-name dir)))
+         (name (and display-name (string-trim display-name)))
+         (name (and name (not (string-empty-p name)) name))
+         (chat-buf (pi-coding-agent--setup-session dir name))
+         (input-buf (buffer-local-value 'pi-coding-agent--input-buffer chat-buf)))
+    (pi-coding-agent--display-buffers chat-buf input-buf)
+    (when name
+      (with-current-buffer chat-buf
+        (when (and pi-coding-agent--process
+                   (process-live-p pi-coding-agent--process))
+          (pi-coding-agent-set-session-name name))))
+    chat-buf))
+
+(defun pi-coding-agent--session-buffer-for-dir-p (dir)
+  "Return non-nil when a live chat buffer already exists for DIR."
+  (let ((target (file-name-as-directory (expand-file-name dir)))
+        found)
+    (dolist (buffer (buffer-list) found)
+      (when (and (not found)
+                 (buffer-live-p buffer))
+        (with-current-buffer buffer
+          (when (and (derived-mode-p 'pi-coding-agent-chat-mode)
+                     (equal (file-name-as-directory
+                             (expand-file-name
+                              (pi-coding-agent--chat-session-directory)))
+                            target))
+            (setq found t)))))))
+
+(defun pi-coding-agent--session-file-buffer-session-name (session-file)
+  "Return a stable buffer session name for SESSION-FILE."
+  (let ((name (file-name-base (directory-file-name session-file))))
+    (if (string-empty-p name) "session" name)))
+
+;;;###autoload
+(defun pi-coding-agent-session-open-file (session-file &optional dir display-name)
+  "Open durable pi SESSION-FILE, optionally running pi in DIR.
+When DIR is nil, a likely project directory is inferred from SESSION-FILE.
+DISPLAY-NAME names the Emacs session buffer.  When another pi session is
+already open for DIR, a distinct named buffer is used, matching the named
+multi-session behavior of `pi-coding-agent'.  The normal pi chat/input UI is
+shown and the chat buffer is returned."
+  (interactive (list (read-file-name "Pi session file: " nil nil t)))
+  (pi-coding-agent--check-dependencies)
+  (let* ((session-file (expand-file-name session-file))
+         (dir (file-name-as-directory
+               (expand-file-name
+                (or dir (pi-coding-agent--session-file-project-directory
+                         session-file)))))
+         (existing (pi-coding-agent--find-session-file-buffer session-file))
+         (trimmed-name (and display-name (string-trim display-name)))
+         (display-name (and trimmed-name
+                            (not (string-empty-p trimmed-name))
+                            trimmed-name))
+         (session-name (and (not existing)
+                            (or display-name
+                                (and (pi-coding-agent--session-buffer-for-dir-p dir)
+                                     (pi-coding-agent--session-file-buffer-session-name
+                                      session-file)))))
+         (chat-buf (or existing (pi-coding-agent--setup-session dir session-name)))
+         (input-buf (buffer-local-value 'pi-coding-agent--input-buffer chat-buf))
+         (proc (buffer-local-value 'pi-coding-agent--process chat-buf)))
+    (pi-coding-agent--display-buffers chat-buf input-buf)
+    (when (and (not existing)
+               proc
+               (process-live-p proc)
+               (pi-coding-agent--session-transition-ready-p chat-buf "resume"))
+      (pi-coding-agent--resume-selected-session proc chat-buf session-file))
+    chat-buf))
+
+;;;###autoload
+(defun pi-coding-agent-session-file (&optional chat-buffer)
+  "Return the durable session file for CHAT-BUFFER, if it exists."
+  (let ((chat-buf (or chat-buffer (pi-coding-agent--get-chat-buffer))))
+    (when (buffer-live-p chat-buf)
+      (with-current-buffer chat-buf
+        (when-let* ((file (plist-get pi-coding-agent--state :session-file))
+                    ((stringp file))
+                    ((not (string-empty-p file)))
+                    (expanded (expand-file-name
+                               file
+                               (or (pi-coding-agent--chat-session-directory)
+                                   default-directory)))
+                    ((file-readable-p expanded)))
+          expanded)))))
+
+;;;###autoload
+(defun pi-coding-agent-session-display-name (&optional chat-buffer)
+  "Return the human-readable display name for CHAT-BUFFER, if known."
+  (let ((chat-buf (or chat-buffer (pi-coding-agent--get-chat-buffer))))
+    (and (buffer-live-p chat-buf)
+         (or (buffer-local-value 'pi-coding-agent--session-name chat-buf)
+             (buffer-local-value 'pi-coding-agent--canonical-session-name
+                                 chat-buf)))))
 
 (declare-function dired-get-filename "dired" (&optional localp no-error-if-not-filep))
 

--- a/test/pi-coding-agent-org-test.el
+++ b/test/pi-coding-agent-org-test.el
@@ -1,0 +1,201 @@
+;;; pi-coding-agent-org-test.el --- Tests for pi-coding-agent Org links -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Unit tests for pi-coding-agent Org link parsing, generation, and opening.
+
+;;; Code:
+
+(require 'ert)
+(require 'org)
+(require 'pi-coding-agent-org)
+(require 'pi-coding-agent-test-common)
+
+(ert-deftest pi-coding-agent-org-test-parse-session-link-query ()
+  "Session links decode query-style file, dir, and name parameters."
+  (let ((file-link (pi-coding-agent-org--parse-link
+                    "session?file=%2Ftmp%2Fpi%20session.jsonl"))
+        (named-link (pi-coding-agent-org--parse-link
+                     "session?dir=%2Ftmp%2Fproject%2F&name=my+session")))
+    (should (equal (plist-get file-link :kind) "session"))
+    (should (equal (plist-get file-link :file) "/tmp/pi session.jsonl"))
+    (should (equal (plist-get named-link :dir) "/tmp/project/"))
+    (should (equal (plist-get named-link :name) "my session"))))
+
+(ert-deftest pi-coding-agent-org-test-session-link-prefers-file ()
+  "Generated session links prefer durable session files over names."
+  (should (equal (pi-coding-agent-org-session-link
+                  "/tmp/project/.pi/sessions/abc.jsonl"
+                  "/tmp/project/"
+                  "display")
+                 "[[pi:session?file=%2Ftmp%2Fproject%2F.pi%2Fsessions%2Fabc.jsonl&dir=%2Ftmp%2Fproject%2F&name=display][Open pi session]]")))
+
+(ert-deftest pi-coding-agent-org-test-store-link-from-chat-buffer ()
+  "Org link storing records the current pi chat session."
+  (let ((dir (make-temp-file "pi-coding-agent-org-store-" t)))
+    (unwind-protect
+        (with-temp-buffer
+          (let ((session-file (expand-file-name ".pi/sessions/abc.jsonl" dir)))
+            (make-directory (file-name-directory session-file) t)
+            (write-region "{\"type\":\"session\"}\n" nil session-file nil 'silent))
+          (pi-coding-agent-chat-mode)
+          (pi-coding-agent--set-chat-session-identity dir "demo")
+          (setq pi-coding-agent--state '(:session-file ".pi/sessions/abc.jsonl")
+                pi-coding-agent--session-name "demo")
+          (let ((expected-link
+                 (concat "pi:session?file="
+                         (pi-coding-agent-org--query-encode
+                          (expand-file-name ".pi/sessions/abc.jsonl" dir))
+                         "&dir="
+                         (pi-coding-agent-org--query-encode
+                          (file-name-as-directory dir))
+                         "&name=demo"))
+                org-store-link-plist)
+            (should (pi-coding-agent-org-store-session-link nil))
+            (should (equal (plist-get org-store-link-plist :type) "pi"))
+            (should (equal (plist-get org-store-link-plist :link)
+                           expected-link))
+            (should (equal (plist-get org-store-link-plist :description)
+                           "pi session: demo"))
+            (should (equal (org-store-link nil nil)
+                           (format "[[%s][pi session: demo]]"
+                                   expected-link)))))
+      (ignore-errors (delete-directory dir t)))))
+
+(ert-deftest pi-coding-agent-org-test-store-link-from-named-buffer-without-metadata ()
+  "Org link storing preserves named-session buffers before metadata exists."
+  (let ((dir (make-temp-file "pi-coding-agent-org-store-named-" t)))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (pi-coding-agent--set-chat-session-identity dir "demo")
+          (let (org-store-link-plist)
+            (should (pi-coding-agent-org-store-session-link nil))
+            (should (equal (plist-get org-store-link-plist :link)
+                           (concat "pi:session?dir="
+                                   (pi-coding-agent-org--query-encode
+                                    (file-name-as-directory dir))
+                                   "&name=demo")))
+            (should (equal (plist-get org-store-link-plist :description)
+                           "pi session: demo"))))
+      (ignore-errors (delete-directory dir t)))))
+
+(ert-deftest pi-coding-agent-org-test-store-link-ignores-unflushed-session-file ()
+  "Org link storing falls back to dir/name when the session file is absent."
+  (let ((dir (make-temp-file "pi-coding-agent-org-store-missing-file-" t)))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (pi-coding-agent--set-chat-session-identity dir "demo")
+          (setq pi-coding-agent--state '(:session-file ".pi/sessions/unflushed.jsonl"))
+          (let (org-store-link-plist)
+            (should (pi-coding-agent-org-store-session-link nil))
+            (should (equal (plist-get org-store-link-plist :link)
+                           (concat "pi:session?dir="
+                                   (pi-coding-agent-org--query-encode
+                                    (file-name-as-directory dir))
+                                   "&name=demo")))))
+      (ignore-errors (delete-directory dir t)))))
+
+(ert-deftest pi-coding-agent-org-test-store-link-from-input-buffer ()
+  "Org link storing also works from the pi input buffer."
+  (let ((dir (make-temp-file "pi-coding-agent-org-store-input-" t))
+        (chat (generate-new-buffer " *pi-org-chat*"))
+        (input (generate-new-buffer " *pi-org-input*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--set-chat-session-identity dir "demo")
+            (setq pi-coding-agent--session-name "demo"))
+          (with-current-buffer input
+            (pi-coding-agent-input-mode)
+            (pi-coding-agent--set-chat-buffer chat)
+            (let (org-store-link-plist)
+              (should (pi-coding-agent-org-store-session-link nil))
+              (should (equal (plist-get org-store-link-plist :link)
+                             (concat "pi:session?dir="
+                                     (pi-coding-agent-org--query-encode
+                                      (file-name-as-directory dir))
+                                     "&name=demo"))))))
+      (kill-buffer chat)
+      (kill-buffer input)
+      (ignore-errors (delete-directory dir t)))))
+
+(ert-deftest pi-coding-agent-org-test-open-file-link-uses-session-cwd ()
+  "Opening a file-only link runs pi from the cwd recorded in the session."
+  (let* ((repo-dir (make-temp-file "pi-coding-agent-org-repo-" t))
+         (session-dir (make-temp-file "pi-coding-agent-org-session-" t))
+         (session-file (expand-file-name "abc.jsonl" session-dir))
+         (opened-dir nil)
+         (opened-chat (generate-new-buffer " *pi-org-opened-cwd-chat*")))
+    (unwind-protect
+        (progn
+          (write-region
+           (json-encode (list :type "session" :version 3 :cwd repo-dir))
+           nil session-file nil 'silent)
+          (with-current-buffer opened-chat
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--input-buffer (generate-new-buffer
+                                                 " *pi-org-opened-cwd-input*")))
+          (cl-letf (((symbol-function 'pi-coding-agent--check-dependencies)
+                     #'ignore)
+                    ((symbol-function 'pi-coding-agent--setup-session)
+                     (lambda (dir _session)
+                       (setq opened-dir dir)
+                       opened-chat))
+                    ((symbol-function 'pi-coding-agent--display-buffers)
+                     #'ignore))
+            (should (eq (pi-coding-agent-org-open-link
+                         (concat "session?file="
+                                 (pi-coding-agent-org--query-encode
+                                  session-file))
+                         nil)
+                        opened-chat))
+            (should (equal opened-dir (file-name-as-directory repo-dir)))))
+      (when (buffer-live-p opened-chat)
+        (let ((input (buffer-local-value 'pi-coding-agent--input-buffer
+                                         opened-chat)))
+          (when (buffer-live-p input) (kill-buffer input))))
+      (when (buffer-live-p opened-chat) (kill-buffer opened-chat))
+      (ignore-errors (delete-directory repo-dir t))
+      (ignore-errors (delete-directory session-dir t)))))
+
+(ert-deftest pi-coding-agent-org-test-open-file-link-uses-named-buffer-when-dir-open ()
+  "Opening a different session file in an open dir uses named-session buffers."
+  (let* ((dir (make-temp-file "pi-coding-agent-org-open-" t))
+         (session-file (expand-file-name ".pi/sessions/abc.jsonl" dir))
+         (existing-chat (generate-new-buffer " *pi-org-existing-chat*"))
+         (opened-chat (generate-new-buffer " *pi-org-opened-chat*"))
+         (opened-session nil))
+    (unwind-protect
+        (progn
+          (make-directory (file-name-directory session-file) t)
+          (with-current-buffer existing-chat
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--set-chat-session-identity dir nil))
+          (with-current-buffer opened-chat
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--input-buffer (generate-new-buffer
+                                                 " *pi-org-opened-input*")))
+          (cl-letf (((symbol-function 'pi-coding-agent--check-dependencies)
+                     #'ignore)
+                    ((symbol-function 'pi-coding-agent--setup-session)
+                     (lambda (_dir session)
+                       (setq opened-session session)
+                       opened-chat))
+                    ((symbol-function 'pi-coding-agent--display-buffers)
+                     #'ignore))
+            (should (eq (pi-coding-agent-session-open-file session-file dir)
+                        opened-chat))
+            (should (equal opened-session "abc"))))
+      (when (buffer-live-p opened-chat)
+        (let ((input (buffer-local-value 'pi-coding-agent--input-buffer
+                                         opened-chat)))
+          (when (buffer-live-p input) (kill-buffer input))))
+      (when (buffer-live-p existing-chat) (kill-buffer existing-chat))
+      (when (buffer-live-p opened-chat) (kill-buffer opened-chat))
+      (ignore-errors (delete-directory dir t)))))
+
+(provide 'pi-coding-agent-org-test)
+;;; pi-coding-agent-org-test.el ends here


### PR DESCRIPTION
Add optional pi-coding-agent-org support for storing and following pi:
Org links. Links encode session files, project directories, and optional
session names as query parameters.

Expose session-open helpers for opening by directory/name or resuming a
durable session file, including cwd inference from session headers and
separate named buffers when needed.

Preserve named-buffer identity for Org links before session metadata
exists, and only prefer file links when the reported session file is
readable so fresh sessions fall back to dir/name.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>