### PR TITLE
feat: display inline images from tool results in chat buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 # pi-coding-agent Makefile
 
 EMACS ?= emacs
+# Keep package state project-local so test/dep installs never pollute the
+# developer's real ~/.emacs.d/elpa (which may be managed by straight.el etc.).
+# Override with `make test PACKAGE_USER_DIR=...` if needed.
+PACKAGE_USER_DIR ?= $(abspath .cache/elpa)
 BATCH = $(EMACS) --batch -Q -L . \
+	--eval "(setq package-user-dir \"$(PACKAGE_USER_DIR)\")" \
 	--eval "(add-to-list 'treesit-extra-load-path (expand-file-name \"~/.emacs.d/tree-sitter\"))"
 # Keep this checkout first in load-path even after package-initialize.
 LOCAL_LOAD_PATH = --eval "(setq load-path (cons (expand-file-name \".\") load-path))"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
 # pi-coding-agent Makefile
 
 EMACS ?= emacs
+export EMACS
+# Keep package state project-local and separate incompatible bytecode by Emacs
+# major version so every child lane resolves the same dependency tree without
+# touching ~/.emacs.d/elpa.
+EMACS_MAJOR_VERSION := $(shell $(EMACS) --batch -Q --eval '(princ emacs-major-version)' 2>/dev/null)
+PACKAGE_USER_DIR ?= $(abspath .cache/elpa/$(EMACS_MAJOR_VERSION))
+export PACKAGE_USER_DIR
+PACKAGE_USER_DIR_INIT = --eval "(let ((dir (getenv \"PACKAGE_USER_DIR\"))) (when dir (setq package-user-dir (directory-file-name (expand-file-name dir)))))"
 BATCH = $(EMACS) --batch -Q -L . \
+	$(PACKAGE_USER_DIR_INIT) \
 	--eval "(add-to-list 'treesit-extra-load-path (expand-file-name \"~/.emacs.d/tree-sitter\"))"
 # Keep this checkout first in load-path even after package-initialize.
 LOCAL_LOAD_PATH = --eval "(setq load-path (cons (expand-file-name \".\") load-path))"
@@ -76,10 +85,18 @@ help:
 # Install package dependencies (sentinel file avoids re-running every time).
 # Requirements come from pi-coding-agent.el's Package-Requires header.
 # The helper upgrades built-in packages when Emacs ships an older version
-# than the package requires (for example transient on Emacs 29/30).
-.deps-stamp: Makefile scripts/install-deps.el scripts/pi-coding-agent-build.el pi-coding-agent.el
+# than the package requires (for example transient on Emacs 29/30).  Keep the
+# sentinel with the selected package directory so overrides cannot reuse a
+# stamp created for another dependency tree or Emacs lane.
+DEPS_STAMP = $(PACKAGE_USER_DIR)/.deps-stamp
+DEPS_INPUTS = Makefile scripts/install-deps.el scripts/pi-coding-agent-build.el pi-coding-agent.el
+.PHONY: .deps-stamp
+.deps-stamp: $(DEPS_STAMP)
+
+$(DEPS_STAMP): $(DEPS_INPUTS)
+	@mkdir -p "$(PACKAGE_USER_DIR)"
 	@$(BATCH) -L scripts -l scripts/install-deps.el
-	@touch $@
+	@touch "$@"
 
 deps: .deps-stamp
 
@@ -383,7 +400,7 @@ check: compile lint test
 # ============================================================
 
 clean:
-	@rm -f *.elc scripts/*.elc test/*.elc .deps-stamp
+	@rm -f *.elc scripts/*.elc test/*.elc .deps-stamp "$(DEPS_STAMP)"
 
 clean-cache:
 	@./scripts/ollama.sh stop 2>/dev/null || true

--- a/README.org
+++ b/README.org
@@ -178,6 +178,22 @@ tool block to expand or collapse it.  Long-running commands stream
 output live, file operations (=read=, =write=, =edit=) get syntax
 highlighting, and edit diffs highlight what changed.
 
+Image content returned by completed tool results is shown inline in graphical
+Emacs and as a useful type-and-size placeholder in terminals.  Pi's built-in
+=read= already returns raster images as image content.  For SVG, the preview is
+made only from complete, standalone SVG text returned by =read=; pi-coding-agent
+never reopens the argument path, and text with obvious scripts or external
+resources is left as text.  Previews are *display-only*: outgoing prompts have
+no image field, so prompt image attachments remain separate
+[[https://github.com/dnouri/pi-coding-agent/issues/261][issue #261]] work.
+
+Current limits: images in partial tool updates appear when the final result
+arrives; custom tools can return animated or highly compressed data whose
+decoder cost is not bounded by the source-byte cap (Pi's built-in =read=
+resizes raster images to at most 2000x2000).  Moving a terminal-rendered chat to
+a GUI, resizing previews, or applying a later extension replacement may require
+a toggle or history reload.
+
 Markdown pipe tables get a display-only treatment: wide tables are
 wrapped and drawn to neatly fit window width, with cleaner separators,
 while the underlying buffer text remains ordinary Markdown.
@@ -487,6 +503,11 @@ Less common tuning knobs:
 ;; Show more tool output before it collapses, counted in visual lines:
 ;; (setopt pi-coding-agent-tool-preview-lines 20)
 ;; (setopt pi-coding-agent-bash-preview-lines 10)
+
+;; Cap inline image previews to 640 pixels as well as the chat window width;
+;; lower the 10 MiB per-image returned-source limit if desired:
+;; (setopt pi-coding-agent-image-preview-max-width 640)
+;; (setopt pi-coding-agent-image-preview-max-bytes (* 5 1024 1024))
 
 ;; Lower context warning/error colors in the header line:
 ;; (setopt pi-coding-agent-context-warning-threshold 40)

--- a/bench/run-bench.sh
+++ b/bench/run-bench.sh
@@ -15,6 +15,12 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EMACS_BIN="${EMACS:-emacs}"
+if [ -z "${PACKAGE_USER_DIR:-}" ]; then
+    EMACS_MAJOR_VERSION=$("$EMACS_BIN" --batch -Q \
+        --eval '(princ emacs-major-version)')
+    export PACKAGE_USER_DIR="$PROJECT_DIR/.cache/elpa/$EMACS_MAJOR_VERSION"
+fi
 
 BATCH=0
 REPS=5
@@ -30,6 +36,7 @@ done
 EMACS_INIT=(
     -Q -L "$PROJECT_DIR"
     --eval "(require 'package)"
+    --eval "(let ((dir (getenv \"PACKAGE_USER_DIR\"))) (when dir (setq package-user-dir (directory-file-name (expand-file-name dir)))))"
     --eval "(package-initialize)"
     --eval "(setq load-path (cons (expand-file-name \"$PROJECT_DIR\") load-path))"
     -l "$SCRIPT_DIR/pi-coding-agent-bench.el"
@@ -41,7 +48,7 @@ echo "Project: $PROJECT_DIR"
 if [ "$BATCH" = "1" ]; then
     echo "Mode: batch (secondary lane), $REPS reps"
     echo ""
-    emacs "${EMACS_INIT[@]}" --batch \
+    "$EMACS_BIN" "${EMACS_INIT[@]}" --batch \
         -f pi-coding-agent-bench-run-batch -c "$REPS" 2>&1
 else
     echo "Mode: GUI via xvfb (primary lane), $REPS reps"
@@ -51,7 +58,7 @@ else
         exit 1
     fi
     xvfb-run -a env GDK_BACKEND=x11 PATH="$PATH" \
-        emacs "${EMACS_INIT[@]}" \
+        "$EMACS_BIN" "${EMACS_INIT[@]}" \
         --eval "(progn
                   (let ((standard-output #'external-debugging-output))
                     (pi-coding-agent-bench-run $REPS))

--- a/bench/run-reload-resume-bench.sh
+++ b/bench/run-reload-resume-bench.sh
@@ -19,6 +19,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EMACS_BIN="${EMACS:-emacs}"
+if [ -z "${PACKAGE_USER_DIR:-}" ]; then
+    EMACS_MAJOR_VERSION=$("$EMACS_BIN" --batch -Q \
+        --eval '(princ emacs-major-version)')
+    export PACKAGE_USER_DIR="$PROJECT_DIR/.cache/elpa/$EMACS_MAJOR_VERSION"
+fi
 
 BATCH=0
 REPS=5
@@ -174,6 +180,7 @@ EMACS_INIT=(
     -Q -L "$PROJECT_DIR"
     --eval "(setq inhibit-startup-screen t)"
     --eval "(require 'package)"
+    --eval "(let ((dir (getenv \"PACKAGE_USER_DIR\"))) (when dir (setq package-user-dir (directory-file-name (expand-file-name dir)))))"
     --eval "(package-initialize)"
     --eval "(setq load-path (cons (expand-file-name \"$PROJECT_DIR\") load-path))"
     -l "$SCRIPT_DIR/pi-coding-agent-reload-resume-bench.el"
@@ -221,7 +228,7 @@ for scenario in "${SCENARIOS[@]}"; do
 
         printf '[%s/%s] running\n' "$scenario" "$iter"
         if [[ "$BATCH" = "1" ]]; then
-            if ! emacs --batch "${EMACS_INIT[@]}" \
+            if ! "$EMACS_BIN" --batch "${EMACS_INIT[@]}" \
                 -f pi-coding-agent-rr-bench-run-batch \
                 > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
                 cat "$run_dir/stdout.log"
@@ -230,7 +237,7 @@ for scenario in "${SCENARIOS[@]}"; do
             fi
         else
             if ! xvfb-run -a env GDK_BACKEND=x11 PATH="$PATH" \
-                emacs --geometry 120x40 "${EMACS_INIT[@]}" \
+                "$EMACS_BIN" --geometry 120x40 "${EMACS_INIT[@]}" \
                 --eval "(let ((standard-output #'external-debugging-output)) (kill-emacs (if (pi-coding-agent-rr-bench-run) 0 1)))" \
                 </dev/null > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
                 cat "$run_dir/stdout.log"

--- a/bench/run-tool-update-bench.sh
+++ b/bench/run-tool-update-bench.sh
@@ -23,6 +23,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EMACS_BIN="${EMACS:-emacs}"
+if [ -z "${PACKAGE_USER_DIR:-}" ]; then
+    EMACS_MAJOR_VERSION=$("$EMACS_BIN" --batch -Q \
+        --eval '(princ emacs-major-version)')
+    export PACKAGE_USER_DIR="$PROJECT_DIR/.cache/elpa/$EMACS_MAJOR_VERSION"
+fi
 
 BATCH=0
 REPS=3
@@ -196,6 +202,7 @@ EMACS_INIT=(
     -Q -L "$PROJECT_DIR"
     --eval '(setq inhibit-startup-screen t)'
     --eval '(require (quote package))'
+    --eval '(let ((dir (getenv "PACKAGE_USER_DIR"))) (when dir (setq package-user-dir (directory-file-name (expand-file-name dir)))))'
     --eval '(package-initialize)'
     --eval '(let ((project (getenv "PI_TU_BENCH_PROJECT_DIR"))) (unless project (error "PI_TU_BENCH_PROJECT_DIR is unset")) (setq load-path (cons (expand-file-name project) load-path)))'
     -l "$SCRIPT_DIR/pi-coding-agent-tool-update-bench.el"
@@ -238,7 +245,7 @@ for scenario in "${SCENARIOS[@]}"; do
 
         printf '[%s/%s] running\n' "$scenario" "$iter"
         if [[ "$BATCH" = "1" ]]; then
-            if ! emacs --batch "${EMACS_INIT[@]}" \
+            if ! "$EMACS_BIN" --batch "${EMACS_INIT[@]}" \
                 -f pi-coding-agent-tu-bench-run-batch \
                 > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
                 cat "$run_dir/stdout.log"
@@ -247,7 +254,7 @@ for scenario in "${SCENARIOS[@]}"; do
             fi
         else
             if ! xvfb-run -a env GDK_BACKEND=x11 PATH="$PATH" \
-                emacs --geometry 120x40 "${EMACS_INIT[@]}" \
+                "$EMACS_BIN" --geometry 120x40 "${EMACS_INIT[@]}" \
                 --eval '(let ((standard-output (function external-debugging-output))) (kill-emacs (pi-coding-agent-tu-bench--exit-status (pi-coding-agent-tu-bench-run))))' \
                 </dev/null > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
                 cat "$run_dir/stdout.log"

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1360,7 +1360,8 @@ are left alone."
   path
   offset
   line-map
-  last-tail)
+  last-tail
+  image-blocks)
 
 (defun pi-coding-agent--ensure-live-tool-blocks ()
   "Return the live tool block registry for the current buffer."
@@ -1500,6 +1501,67 @@ needed for compatibility, the current non-keyed pending block."
     (setf (pi-coding-agent--tool-block-last-tail block) last-tail)
     (pi-coding-agent--tool-block-refresh-overlay block))
   block)
+
+(defun pi-coding-agent--tool-block-set-image-blocks (block image-blocks)
+  "Store IMAGE-BLOCKS on BLOCK for re-insertion after toggle."
+  (when block
+    (setf (pi-coding-agent--tool-block-image-blocks block) image-blocks))
+  block)
+
+(defun pi-coding-agent--mime-to-image-type (mime-type)
+  "Convert MIME-TYPE string to Emacs image type symbol.
+Returns nil for unsupported types."
+  (pcase mime-type
+    ((or "image/jpeg" "image/jpg") 'jpeg)
+    ("image/png" 'png)
+    ("image/gif" 'gif)
+    ("image/webp" 'webp)
+    (_ nil)))
+
+(defun pi-coding-agent--insert-inline-image (data mime-type)
+  "Insert inline image decoded from base64 DATA with MIME-TYPE.
+In GUI Emacs with the required image type support, decodes DATA and
+inserts a scaled image via `insert-image'.  Otherwise inserts a text
+placeholder.  Returns non-nil if a graphical image was inserted."
+  (condition-case nil
+      (let* ((type (pi-coding-agent--mime-to-image-type mime-type))
+             (gui-p (and type
+                        (display-images-p)
+                        (image-type-available-p type)))
+             (raw (base64-decode-string data)))
+        (if (and gui-p (> (length raw) 0))
+            (let ((img (create-image raw type t
+                         :max-width (truncate
+                                     (* 0.9 (max 400 (window-pixel-width))))
+                         :max-height (truncate
+                                      (* 0.5 (max 300 (window-pixel-height)))))))
+              (insert-image img "[image]")
+              t)
+          (insert (propertize
+                   (format "[Image: %s, %s]"
+                           (or mime-type "unknown")
+                           (file-size-human-readable (length raw)))
+                   'face 'pi-coding-agent-tool-header
+                   'pi-coding-agent-no-fontify t))
+          nil))
+    (error
+     (insert (propertize
+              (format "[Image: %s, decode error]" (or mime-type "unknown"))
+              'face 'pi-coding-agent-tool-header
+              'pi-coding-agent-no-fontify t))
+     nil)))
+
+(defun pi-coding-agent--insert-tool-images (content)
+  "Insert inline images from CONTENT blocks at point.
+CONTENT is a sequence of content block plists.  Only blocks with
+:type \"image\" are processed.  A newline is inserted before each image."
+  (seq-doseq (block content)
+    (when (equal (plist-get block :type) "image")
+      (let ((data (plist-get block :data))
+            (mime (plist-get block :mimeType)))
+        (when (and data (> (length data) 0))
+          (insert "\n")
+          (pi-coding-agent--insert-inline-image data mime))))))
 
 (defun pi-coding-agent--tool-block-create
     (tool-name args &optional tool-call-id order preview-state)
@@ -1995,6 +2057,9 @@ if none exists, render the result at point without a live overlay."
                  (string-trim-right display-content "\n+")
                  lang
                  is-edit-diff))
+              ;; Insert any image content blocks after text
+              (pi-coding-agent--insert-tool-images content)
+              (pi-coding-agent--tool-block-set-image-blocks block content)
               (set-marker end-marker (point))
               (pi-coding-agent--tool-block-refresh-overlay block)
               ;; Note: no [error] badge — error content in the block is sufficient,
@@ -2021,6 +2086,8 @@ if none exists, render the result at point without a live overlay."
                (string-trim-right display-content "\n+")
                lang
                is-edit-diff))
+            ;; Insert any image content blocks after text
+            (pi-coding-agent--insert-tool-images content)
             (insert "\n")))))))
 
 (defun pi-coding-agent--ranges-excluding-property (start end prop)
@@ -2085,6 +2152,10 @@ Preserves window scroll position during the toggle."
           ;; Toggle: if currently expanded, show collapsed (and vice versa)
           (pi-coding-agent--insert-tool-content-with-toggle
            preview-content full-content lang is-edit-diff hidden-count (not expanded))
+          ;; Re-insert any image blocks stored on the tool block struct
+          (when-let* ((block (pi-coding-agent--tool-block-from-overlay ov))
+                      (img-content (pi-coding-agent--tool-block-image-blocks block)))
+            (pi-coding-agent--insert-tool-images img-content))
           ;; Ensure fontification of inserted content (JIT font-lock is lazy)
           ;; while excluding metadata-like details payload.
           (pi-coding-agent--font-lock-ensure-excluding-property

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -45,6 +45,7 @@
 (require 'pi-coding-agent-table)
 (require 'cl-lib)
 (require 'ansi-color)
+(require 'image)
 
 ;; Forward references for functions in other modules
 (declare-function pi-coding-agent-compact "pi-coding-agent-menu" (&optional custom-instructions))
@@ -1479,7 +1480,8 @@ overlays are left alone."
   path-error
   offset
   line-map
-  last-tail)
+  last-tail
+  image-previews)
 
 (cl-defstruct (pi-coding-agent--toolcall-stream
                (:conc-name pi-coding-agent--tool-stream-)
@@ -1802,6 +1804,113 @@ path/error metadata for `pi-coding-agent-visit-file'."
     (setf (pi-coding-agent--tool-block-last-tail block) last-tail)
     (pi-coding-agent--tool-block-refresh-overlay block))
   block)
+
+(defun pi-coding-agent--tool-block-set-image-previews (block previews)
+  "Store rendered image PREVIEWS on BLOCK for toggling and cooling."
+  (when block
+    (setf (pi-coding-agent--tool-block-image-previews block) previews))
+  block)
+
+(defun pi-coding-agent--image-type-for-mime (mime-type)
+  "Return the Emacs image type for MIME-TYPE, or nil when unsupported."
+  (pcase mime-type
+    ((or "image/jpeg" "image/jpg") 'jpeg)
+    ("image/png" 'png)
+    ("image/gif" 'gif)
+    ("image/webp" 'webp)))
+
+(defun pi-coding-agent--image-preview-pixel-limits ()
+  "Return window-relative image preview size properties."
+  (let ((window (or (pi-coding-agent--chat-display-window)
+                    (selected-window))))
+    (list :max-width
+          (max 1 (truncate (* 0.9 (window-pixel-width window))))
+          :max-height
+          (max 1 (truncate (* 0.5 (window-pixel-height window)))))))
+
+(defun pi-coding-agent--image-preview-string (fallback &optional image)
+  "Return FALLBACK marked as an image preview, displaying IMAGE when non-nil."
+  (apply #'propertize fallback
+         (append
+          (list 'face 'pi-coding-agent-tool-header
+                'pi-coding-agent-no-fontify t
+                'pi-coding-agent-image-preview t
+                'rear-nonsticky t
+                'help-echo fallback)
+          (when image (list 'display image)))))
+
+(defun pi-coding-agent--image-preview-label (mime-type description)
+  "Return an image placeholder for MIME-TYPE and DESCRIPTION."
+  (format "[Image: %s, %s]" (or mime-type "unknown") description))
+
+(defun pi-coding-agent--render-tool-image-preview (block)
+  "Return a rendered preview string for tool-result image BLOCK."
+  (let* ((mime-type (or (plist-get block :mimeType)
+                        (plist-get block :mime-type)))
+         (data (plist-get block :data))
+         (type (pi-coding-agent--image-type-for-mime mime-type)))
+    (cond
+     ((or (null data) (and (stringp data) (string-empty-p data)))
+      (pi-coding-agent--image-preview-string
+       (pi-coding-agent--image-preview-label mime-type "empty data")))
+     ((not (stringp data))
+      (pi-coding-agent--image-preview-string
+       (pi-coding-agent--image-preview-label mime-type "decode error")))
+     (t
+      (condition-case nil
+          (let* ((raw (base64-decode-string data))
+                 (size (file-size-human-readable
+                        (length raw) 'iec " " "B")))
+            (cond
+             ((string-empty-p raw)
+              (pi-coding-agent--image-preview-string
+               (pi-coding-agent--image-preview-label mime-type "empty data")))
+             ((not type)
+              (pi-coding-agent--image-preview-string
+               (pi-coding-agent--image-preview-label
+                mime-type (format "%s, unsupported type" size))))
+             ((not (display-images-p))
+              (pi-coding-agent--image-preview-string
+               (pi-coding-agent--image-preview-label mime-type size)))
+             ((not (image-type-available-p type))
+              (pi-coding-agent--image-preview-string
+               (pi-coding-agent--image-preview-label
+                mime-type (format "%s, unavailable" size))))
+             (t
+              (condition-case nil
+                  (let ((image (apply #'create-image raw type t
+                                      (pi-coding-agent--image-preview-pixel-limits))))
+                    (if image
+                        (pi-coding-agent--image-preview-string
+                         (pi-coding-agent--image-preview-label mime-type size)
+                         image)
+                      (pi-coding-agent--image-preview-string
+                       (pi-coding-agent--image-preview-label
+                        mime-type "display error"))))
+                (error
+                 (pi-coding-agent--image-preview-string
+                  (pi-coding-agent--image-preview-label
+                   mime-type "display error")))))))
+        (error
+         (pi-coding-agent--image-preview-string
+          (pi-coding-agent--image-preview-label mime-type "decode error"))))))))
+
+(defun pi-coding-agent--tool-result-image-previews (content-blocks)
+  "Render image previews from normalized tool result CONTENT-BLOCKS."
+  (mapcar #'pi-coding-agent--render-tool-image-preview
+          (seq-filter
+           (lambda (block) (equal (plist-get block :type) "image"))
+           content-blocks)))
+
+(defun pi-coding-agent--insert-image-previews (previews)
+  "Insert rendered image PREVIEWS at point, one per line."
+  (dolist (preview previews)
+    (insert preview "\n")))
+
+(defun pi-coding-agent--image-previews-text (previews)
+  "Return rendered PREVIEWS as newline-terminated text, or nil."
+  (when previews
+    (concat (mapconcat #'identity previews "\n") "\n")))
 
 (defun pi-coding-agent--tool-block-create
     (tool-name args &optional tool-call-id order preview-state path-metadata-policy)
@@ -2938,6 +3047,8 @@ if none exists, render the result at point without a live overlay."
                                   (pi-coding-agent--render-safe-string
                                    (plist-get c :text)))
                                 text-blocks "\n"))
+         (image-previews
+          (pi-coding-agent--tool-result-image-previews content-blocks))
          ;; Determine language for syntax highlighting
          (lang (pi-coding-agent--path-to-language
                 (pi-coding-agent--tool-path-string
@@ -2989,6 +3100,9 @@ if none exists, render the result at point without a live overlay."
                  (string-trim-right display-content "\n+")
                  lang
                  is-edit-diff))
+              (pi-coding-agent--insert-image-previews image-previews)
+              (pi-coding-agent--tool-block-set-image-previews
+               block image-previews)
               (set-marker end-marker (point))
               (pi-coding-agent--tool-block-refresh-overlay block)
               ;; Note: no [error] badge — error content in the block is sufficient,
@@ -3015,6 +3129,7 @@ if none exists, render the result at point without a live overlay."
                (string-trim-right display-content "\n+")
                lang
                is-edit-diff))
+            (pi-coding-agent--insert-image-previews image-previews)
             (insert "\n")))))))
 
 (defun pi-coding-agent--ranges-excluding-property (start end prop)
@@ -3052,8 +3167,7 @@ Preserves window scroll position during the toggle."
          (lang (button-get button 'pi-coding-agent-lang))
          (is-edit-diff (button-get button 'pi-coding-agent-is-edit-diff))
          (hidden-count (button-get button 'hidden-count))
-         (btn-start (button-start button))
-         (btn-end (button-end button)))
+         (btn-start (button-start button)))
     (save-excursion
       ;; Find the tool overlay
       (goto-char btn-start)
@@ -3067,6 +3181,10 @@ Preserves window scroll position during the toggle."
         ;; Emacs 29's `font-lock-ensure' requires integer bounds below.
         (let* ((content-start (marker-position header-end))
                (block-start (car bounds))
+               (record (pi-coding-agent--tool-block-from-overlay ov))
+               (image-previews
+                (and record
+                     (pi-coding-agent--tool-block-image-previews record)))
                (saved-windows
                 (mapcar (lambda (w)
                           (let ((ws (window-start w)))
@@ -3074,18 +3192,25 @@ Preserves window scroll position during the toggle."
                                   ;; Flag: was window-start before content area?
                                   (< ws content-start))))
                         (get-buffer-window-list (current-buffer) nil t))))
-          ;; Delete from content start to after button
-          (delete-region content-start (1+ btn-end))
+          ;; Replace the complete body, including any image previews after the
+          ;; button, so each toggle keeps exactly one copy inside the overlay.
+          (delete-region content-start (overlay-end ov))
           (goto-char content-start)
           ;; Toggle: if currently expanded, show collapsed (and vice versa)
           (pi-coding-agent--insert-tool-content-with-toggle
            preview-content full-content lang is-edit-diff hidden-count (not expanded))
+          (pi-coding-agent--insert-image-previews image-previews)
           ;; Ensure fontification of inserted content (JIT font-lock is lazy)
           ;; while excluding metadata-like details payload.
           (pi-coding-agent--font-lock-ensure-excluding-property
            content-start (point) 'pi-coding-agent-no-fontify)
-          ;; Update overlay to include new content
-          (move-overlay ov block-start (point))
+          ;; Update both typed and overlay bounds after replacing the body.
+          (if record
+              (progn
+                (set-marker (pi-coding-agent--tool-block-end-marker record)
+                            (point))
+                (pi-coding-agent--tool-block-refresh-overlay record))
+            (move-overlay ov block-start (point)))
           ;; Restore window positions
           (dolist (win-state saved-windows)
             (let ((win (nth 0 win-state))
@@ -3416,7 +3541,11 @@ count because cold history must stay preview-only."
   (when-let* ((visible-body (pi-coding-agent--tool-overlay-visible-body overlay))
               (header-end (marker-position
                            (overlay-get overlay 'pi-coding-agent-header-end))))
-    (let* ((button (pi-coding-agent--find-toggle-button-in-region
+    (let* ((record (pi-coding-agent--tool-block-from-overlay overlay))
+           (image-previews
+            (and record
+                 (pi-coding-agent--tool-block-image-previews record)))
+           (button (pi-coding-agent--find-toggle-button-in-region
                     header-end (overlay-end overlay)))
            (collapsed (and button
                            (not (button-get button
@@ -3424,6 +3553,7 @@ count because cold history must stay preview-only."
            (hidden-count (and collapsed
                               (button-get button 'hidden-count))))
       (list :visible-body visible-body
+            :image-previews image-previews
             :target-metadata
             (pi-coding-agent--cold-tool-target-metadata
              overlay header-end collapsed)
@@ -3442,10 +3572,12 @@ diff annotations."
                              (overlay-get overlay 'pi-coding-agent-header-end))))
       (let* ((inhibit-read-only t)
              (hidden-count (plist-get metadata :hidden-count))
+             (image-previews (plist-get metadata :image-previews))
              (target-metadata (plist-get metadata :target-metadata))
              (cold-body (concat
                          (pi-coding-agent--wrap-in-src-block visible-body nil)
                          "\n"
+                         (pi-coding-agent--image-previews-text image-previews)
                          (when hidden-count
                            (concat (pi-coding-agent--tool-hidden-line-label hidden-count)
                                    "\n"))))

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1311,7 +1311,11 @@ Updates buffer-local state and renders display updates."
      (pi-coding-agent--set-activity-phase "thinking")
      (let* ((tool-call-id (plist-get event :toolCallId))
             (result (plist-get event :result))
-            (block (pi-coding-agent--tool-block-get tool-call-id))
+            ;; A keyed miss must not finalize an unrelated legacy block.
+            (block (or (pi-coding-agent--tool-block-get tool-call-id)
+                       (and (pi-coding-agent--tool-call-id-p tool-call-id)
+                            (pi-coding-agent--display-tool-start
+                             (plist-get event :toolName) nil tool-call-id))))
             ;; Retrieve cached args since tool_execution_end doesn't include args
             (args (when (and tool-call-id pi-coding-agent--tool-args-cache)
                     (prog1 (gethash tool-call-id pi-coding-agent--tool-args-cache)
@@ -1817,22 +1821,52 @@ path/error metadata for `pi-coding-agent-visit-file'."
     ((or "image/jpeg" "image/jpg") 'jpeg)
     ("image/png" 'png)
     ("image/gif" 'gif)
-    ("image/webp" 'webp)))
+    ("image/webp" 'webp)
+    ("image/svg+xml" 'svg)))
+
+(defun pi-coding-agent--image-preview-window ()
+  "Return the window whose frame and dimensions govern image previews."
+  (or (pi-coding-agent--chat-display-window)
+      (selected-window)))
+
+(defun pi-coding-agent--image-display-capable-p ()
+  "Return non-nil when the image preview window is graphical."
+  (display-images-p
+   (window-frame (pi-coding-agent--image-preview-window))))
 
 (defun pi-coding-agent--image-preview-pixel-limits ()
   "Return window-relative image preview size properties."
-  (let ((window (or (pi-coding-agent--chat-display-window)
-                    (selected-window))))
-    (list :max-width
-          (max 1 (truncate (* 0.9 (window-pixel-width window))))
+  (let* ((window (pi-coding-agent--image-preview-window))
+         (window-width
+          (max 1 (truncate (* 0.9 (window-pixel-width window)))))
+         (configured-width
+          (if (natnump pi-coding-agent-image-preview-max-width)
+              (max 1 pi-coding-agent-image-preview-max-width)
+            window-width)))
+    (list :max-width (min window-width configured-width)
           :max-height
           (max 1 (truncate (* 0.5 (window-pixel-height window)))))))
+
+(defconst pi-coding-agent--image-previews-per-tool-limit 8
+  "Maximum tool-result image blocks rendered for one tool invocation.")
+
+(defun pi-coding-agent--image-preview-byte-limit ()
+  "Return the nonnegative source-byte limit for one image preview."
+  (if (natnump pi-coding-agent-image-preview-max-bytes)
+      pi-coding-agent-image-preview-max-bytes
+    (* 10 1024 1024)))
+
+(defun pi-coding-agent--image-preview-safe-field (value &optional fallback)
+  "Return VALUE as control-safe placeholder text, or FALLBACK when nil."
+  (pi-coding-agent--escape-control-chars-for-display
+   (pi-coding-agent--render-safe-string value fallback)))
 
 (defun pi-coding-agent--image-preview-string (fallback &optional image)
   "Return FALLBACK marked as an image preview, displaying IMAGE when non-nil."
   (apply #'propertize fallback
          (append
           (list 'face 'pi-coding-agent-tool-header
+                'fontified t
                 'pi-coding-agent-no-fontify t
                 'pi-coding-agent-image-preview t
                 'rear-nonsticky t
@@ -1841,14 +1875,28 @@ path/error metadata for `pi-coding-agent-visit-file'."
 
 (defun pi-coding-agent--image-preview-label (mime-type description)
   "Return an image placeholder for MIME-TYPE and DESCRIPTION."
-  (format "[Image: %s, %s]" (or mime-type "unknown") description))
+  (format "Image: %s, %s"
+          (pi-coding-agent--image-preview-safe-field mime-type "unknown")
+          description))
+
+(defun pi-coding-agent--image-too-large-description (limit)
+  "Return a placeholder description for an image exceeding LIMIT bytes."
+  (format "too large (limit %s)"
+          (file-size-human-readable limit 'iec " " "B")))
+
+(defun pi-coding-agent--image-data-matches-type-p (data type)
+  "Return non-nil when Emacs recognizes DATA as the expected image TYPE."
+  (eq type (condition-case nil
+               (image-type-from-data data)
+             (error nil))))
 
 (defun pi-coding-agent--render-tool-image-preview (block)
   "Return a rendered preview string for tool-result image BLOCK."
   (let* ((mime-type (or (plist-get block :mimeType)
                         (plist-get block :mime-type)))
          (data (plist-get block :data))
-         (type (pi-coding-agent--image-type-for-mime mime-type)))
+         (type (pi-coding-agent--image-type-for-mime mime-type))
+         (limit (pi-coding-agent--image-preview-byte-limit)))
     (cond
      ((or (null data) (and (stringp data) (string-empty-p data)))
       (pi-coding-agent--image-preview-string
@@ -1856,20 +1904,32 @@ path/error metadata for `pi-coding-agent-visit-file'."
      ((not (stringp data))
       (pi-coding-agent--image-preview-string
        (pi-coding-agent--image-preview-label mime-type "decode error")))
+     ((> (string-bytes data) (* 2 limit))
+      (pi-coding-agent--image-preview-string
+       (pi-coding-agent--image-preview-label
+        mime-type (pi-coding-agent--image-too-large-description limit))))
      (t
       (condition-case nil
           (let* ((raw (base64-decode-string data))
-                 (size (file-size-human-readable
-                        (length raw) 'iec " " "B")))
+                 (raw-bytes (length raw))
+                 (size (file-size-human-readable raw-bytes 'iec " " "B")))
             (cond
              ((string-empty-p raw)
               (pi-coding-agent--image-preview-string
                (pi-coding-agent--image-preview-label mime-type "empty data")))
+             ((> raw-bytes limit)
+              (pi-coding-agent--image-preview-string
+               (pi-coding-agent--image-preview-label
+                mime-type (pi-coding-agent--image-too-large-description limit))))
              ((not type)
               (pi-coding-agent--image-preview-string
                (pi-coding-agent--image-preview-label
                 mime-type (format "%s, unsupported type" size))))
-             ((not (display-images-p))
+             ((not (pi-coding-agent--image-data-matches-type-p raw type))
+              (pi-coding-agent--image-preview-string
+               (pi-coding-agent--image-preview-label
+                mime-type (format "%s, invalid data" size))))
+             ((not (pi-coding-agent--image-display-capable-p))
               (pi-coding-agent--image-preview-string
                (pi-coding-agent--image-preview-label mime-type size)))
              ((not (image-type-available-p type))
@@ -1896,11 +1956,88 @@ path/error metadata for `pi-coding-agent-visit-file'."
           (pi-coding-agent--image-preview-label mime-type "decode error"))))))))
 
 (defun pi-coding-agent--tool-result-image-previews (content-blocks)
-  "Render image previews from normalized tool result CONTENT-BLOCKS."
-  (mapcar #'pi-coding-agent--render-tool-image-preview
+  "Render a bounded number of images from tool result CONTENT-BLOCKS."
+  (let* ((blocks
           (seq-filter
            (lambda (block) (equal (plist-get block :type) "image"))
-           content-blocks)))
+           content-blocks))
+         (limit (max 0 pi-coding-agent--image-previews-per-tool-limit))
+         (shown (seq-take blocks limit))
+         (omitted (- (length blocks) (length shown))))
+    (append
+     (mapcar #'pi-coding-agent--render-tool-image-preview shown)
+     (when (> omitted 0)
+       (list
+        (pi-coding-agent--image-preview-string
+         (format "Image: %d additional preview%s omitted"
+                 omitted (if (= omitted 1) "" "s"))))))))
+
+(defun pi-coding-agent--svg-fragment-links-only-p (source)
+  "Return non-nil when every href in SVG SOURCE is a local fragment."
+  (let ((case-fold-search t)
+        (without-local-links source)
+        (local-link-re
+         "\\_<\\(?:[[:alnum:]_.-]+:\\)?href[[:space:]]*=[[:space:]]*\\([\"']\\)#[^\"']*\\1"))
+    (setq without-local-links
+          (replace-regexp-in-string local-link-re "" without-local-links))
+    (not (string-match-p
+          "\\_<\\(?:[[:alnum:]_.-]+:\\)?href[[:space:]]*="
+          without-local-links))))
+
+(defun pi-coding-agent--standalone-svg-p (source)
+  "Return non-nil for a complete SVG SOURCE without obvious resources."
+  (let ((case-fold-search t))
+    (and (eq 'svg (condition-case nil
+                      (image-type-from-data source)
+                    (error nil)))
+         (or (string-match-p "</svg[[:space:]]*>[[:space:]]*\\'" source)
+             (string-match-p "<svg\\_>[^>]*?/>[[:space:]]*\\'" source))
+         (not (string-match-p
+               "\\(?:<[[:space:]]*\\(?:script\\|foreignobject\\|image\\|feimage\\)\\_>\\|url[[:space:]]*(\\|@import\\|<!doctype\\|<!entity\\)"
+               source))
+         (pi-coding-agent--svg-fragment-links-only-p source))))
+
+(defun pi-coding-agent--read-svg-preview
+    (tool-name args raw-output details is-error)
+  "Render a complete standalone SVG returned as READ's RAW-OUTPUT.
+TOOL-NAME, ARGS, DETAILS, and IS-ERROR describe the completed result."
+  (when (and (equal tool-name "read")
+             (not is-error)
+             (not (pi-coding-agent--tool-arg-get args :offset))
+             (not (pi-coding-agent--tool-arg-get args :limit))
+             (let ((truncation
+                    (pi-coding-agent--tool-arg-get details :truncation)))
+               (or (null truncation)
+                   (pi-coding-agent--json-null-p truncation)))
+             (stringp raw-output)
+             (pi-coding-agent--standalone-svg-p raw-output))
+    (let* ((bytes (string-bytes raw-output))
+           (limit (pi-coding-agent--image-preview-byte-limit))
+           (size (file-size-human-readable bytes 'iec " " "B"))
+           (fallback (pi-coding-agent--image-preview-label
+                      "image/svg+xml" size)))
+      (cond
+       ((> bytes limit)
+        (pi-coding-agent--image-preview-string
+         (pi-coding-agent--image-preview-label
+          "image/svg+xml" (pi-coding-agent--image-too-large-description limit))))
+       ((not (pi-coding-agent--image-display-capable-p))
+        (pi-coding-agent--image-preview-string fallback))
+       ((not (image-type-available-p 'svg))
+        (pi-coding-agent--image-preview-string
+         (pi-coding-agent--image-preview-label
+          "image/svg+xml" (format "%s, unavailable" size))))
+       (t
+        (condition-case nil
+            (let ((image
+                   (apply #'create-image raw-output 'svg t
+                          (append (pi-coding-agent--image-preview-pixel-limits)
+                                  '(:base-uri "data:" :scale 1)))))
+              (pi-coding-agent--image-preview-string fallback image))
+          (error
+           (pi-coding-agent--image-preview-string
+            (pi-coding-agent--image-preview-label
+             "image/svg+xml" (format "%s, display error" size))))))))))
 
 (defun pi-coding-agent--insert-image-previews (previews)
   "Insert rendered image PREVIEWS at point, one per line."
@@ -3047,8 +3184,14 @@ if none exists, render the result at point without a live overlay."
                                   (pi-coding-agent--render-safe-string
                                    (plist-get c :text)))
                                 text-blocks "\n"))
-         (image-previews
+         (content-image-previews
           (pi-coding-agent--tool-result-image-previews content-blocks))
+         (svg-preview
+          (and (null content-image-previews)
+               (pi-coding-agent--read-svg-preview
+                tool-name args raw-output details is-error)))
+         (image-previews
+          (if svg-preview (list svg-preview) content-image-previews))
          ;; Determine language for syntax highlighting
          (lang (pi-coding-agent--path-to-language
                 (pi-coding-agent--tool-path-string

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -200,6 +200,18 @@ Prevents huge single-line outputs from blowing up the chat buffer."
   :type 'natnum
   :group 'pi-coding-agent)
 
+(defcustom pi-coding-agent-image-preview-max-width 900
+  "Maximum pixel width for inline image previews.
+Previews are also constrained to the visible chat window."
+  :type 'natnum
+  :group 'pi-coding-agent)
+
+(defcustom pi-coding-agent-image-preview-max-bytes (* 10 1024 1024)
+  "Maximum source bytes retained for one inline image preview.
+Larger tool-result images use a textual placeholder."
+  :type 'natnum
+  :group 'pi-coding-agent)
+
 (defcustom pi-coding-agent-context-warning-threshold 70
   "Context usage percentage at which to show warning color."
   :type 'natnum

--- a/test/pi-coding-agent-build-test.el
+++ b/test/pi-coding-agent-build-test.el
@@ -145,6 +145,8 @@
                         "-L" pi-coding-agent-test-build--repo-root
                         "-L" scripts-dir
                         "--eval" "(require 'package)"
+                        "--eval"
+                        "(let ((dir (getenv \"PACKAGE_USER_DIR\")))\n  (when dir\n    (setq package-user-dir\n          (directory-file-name (expand-file-name dir)))))"
                         "--eval" "(package-initialize)"
                         "--eval"
                         (format "(setq load-path (cons %S load-path))"

--- a/test/pi-coding-agent-gui-tests.el
+++ b/test/pi-coding-agent-gui-tests.el
@@ -451,6 +451,34 @@ logical block and should not start following later streamed output."
             (should (> (cdr size) 0))))
       (kill-buffer buffer))))
 
+(ert-deftest pi-coding-agent-gui-test-read-svg-has-real-display-property ()
+  "A complete standalone SVG returned by read renders graphically."
+  (unless (and (display-images-p) (image-type-available-p 'svg))
+    (ert-skip "This Emacs display cannot render SVG images"))
+  (let ((buffer (get-buffer-create "*pi-gui-svg-preview*"))
+        (source
+         "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"2\" height=\"1\"><rect width=\"2\" height=\"1\" fill=\"#369\"/></svg>"))
+    (unwind-protect
+        (progn
+          (switch-to-buffer buffer)
+          (pi-coding-agent-chat-mode)
+          (pi-coding-agent--display-tool-end
+           "read" '(:path "/missing/returned.svg")
+           (list (list :type "text" :text source)) nil nil)
+          (redisplay)
+          (let* ((position
+                  (text-property-any (point-min) (point-max)
+                                     'pi-coding-agent-image-preview t))
+                 (display (and position
+                               (get-text-property position 'display)))
+                 (size (and display (image-size display t))))
+            (should position)
+            (should (eq 'image (car-safe display)))
+            (should (consp size))
+            (should (> (car size) 0))
+            (should (> (cdr size) 0))))
+      (kill-buffer buffer))))
+
 (ert-deftest pi-coding-agent-gui-test-content-tool-output-shown ()
   "Test that fake-backed tool output appears in chat and in the tool block."
   (pi-coding-agent-gui-test-with-fresh-session

--- a/test/pi-coding-agent-gui-tests.el
+++ b/test/pi-coding-agent-gui-tests.el
@@ -420,6 +420,37 @@ logical block and should not start following later streamed output."
 
 ;;;; Content Tests
 
+(ert-deftest pi-coding-agent-gui-test-tool-result-image-has-real-display-property ()
+  "A real PNG result inserts an image display property in graphical Emacs."
+  (unless (and (display-images-p) (image-type-available-p 'png))
+    (ert-skip "This Emacs display cannot render PNG images"))
+  (let ((buffer (get-buffer-create "*pi-gui-image-preview*")))
+    (unwind-protect
+        (progn
+          (switch-to-buffer buffer)
+          (pi-coding-agent-chat-mode)
+          (let ((block (pi-coding-agent--display-tool-start
+                        "generate" nil "gui-image")))
+            (pi-coding-agent--display-tool-end
+             "generate" nil
+             '((:type "image"
+                :mimeType "image/png"
+                :data "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAADklEQVR4nGP4z8DwHwQBEPgD/U6VwW8AAAAASUVORK5CYII="))
+             nil nil block))
+          (redisplay)
+          (let* ((position
+                  (text-property-any (point-min) (point-max)
+                                     'pi-coding-agent-image-preview t))
+                 (display (and position
+                               (get-text-property position 'display)))
+                 (size (and display (image-size display t))))
+            (should position)
+            (should (eq 'image (car-safe display)))
+            (should (consp size))
+            (should (> (car size) 0))
+            (should (> (cdr size) 0))))
+      (kill-buffer buffer))))
+
 (ert-deftest pi-coding-agent-gui-test-content-tool-output-shown ()
   "Test that fake-backed tool output appears in chat and in the tool block."
   (pi-coding-agent-gui-test-with-fresh-session

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -2701,6 +2701,22 @@ Pi handles command expansion on the server side."
           (should (equal (plist-get rpc-message :message) "/greet world")))
       (delete-process fake-proc))))
 
+(ert-deftest pi-coding-agent-test-image-preview-does-not-add-prompt-images ()
+  "Display previews do not add an images field to outgoing prompts."
+  (let* ((rpc-message nil)
+         (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                   (lambda () fake-proc))
+                  ((symbol-function 'pi-coding-agent--rpc-async)
+                   (lambda (_proc message _callback)
+                     (setq rpc-message message))))
+          (pi-coding-agent--send-prompt "/tmp/screenshot.png")
+          (should (equal "/tmp/screenshot.png"
+                         (plist-get rpc-message :message)))
+          (should-not (plist-member rpc-message :images)))
+      (delete-process fake-proc))))
+
 (ert-deftest pi-coding-agent-test-send-prompt-marks-sending-until-preflight-fails ()
   "pi-coding-agent--send-prompt closes the local pre-agent_start idle gap."
   (let* ((rpc-callback nil)

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -6191,5 +6191,171 @@ events where the header text hasn't changed."
       (goto-char (marker-position pi-coding-agent--hot-tail-start))
       (should (looking-at "Assistant")))))
 
+;;; Inline Image Display
+
+(ert-deftest pi-coding-agent-test-mime-to-image-type ()
+  "MIME type conversion covers backend types and rejects unknowns."
+  (should (eq (pi-coding-agent--mime-to-image-type "image/png") 'png))
+  (should (eq (pi-coding-agent--mime-to-image-type "image/jpeg") 'jpeg))
+  (should (eq (pi-coding-agent--mime-to-image-type "image/jpg") 'jpeg))
+  (should (eq (pi-coding-agent--mime-to-image-type "image/gif") 'gif))
+  (should (eq (pi-coding-agent--mime-to-image-type "image/webp") 'webp))
+  (should-not (pi-coding-agent--mime-to-image-type "image/tga"))
+  (should-not (pi-coding-agent--mime-to-image-type "text/plain")))
+
+(ert-deftest pi-coding-agent-test-insert-inline-image-placeholder ()
+  "insert-inline-image produces a placeholder in batch mode."
+  ;; In batch mode display-images-p is nil, so we always get the placeholder.
+  (with-temp-buffer
+    (pi-coding-agent--insert-inline-image "iVBORw0KGgo=" "image/png")
+    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+      ;; Should contain MIME type and a size indicator
+      (should (string-match-p "Image:" content))
+      (should (string-match-p "image/png" content)))))
+
+(ert-deftest pi-coding-agent-test-insert-inline-image-error-path ()
+  "insert-inline-image handles corrupt base64 gracefully."
+  (with-temp-buffer
+    (pi-coding-agent--insert-inline-image "!!!invalid!!!" "image/png")
+    (should (string-match-p "decode error"
+                            (buffer-substring-no-properties
+                             (point-min) (point-max))))))
+
+(ert-deftest pi-coding-agent-test-tool-end-image-block-renders ()
+  "Image content block in tool result is displayed."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "photo.png")
+     '((:type "text" :text "Read image file [image/png]")
+       (:type "image" :data "iVBORw0KGgo=" :mimeType "image/png"))
+     nil nil)
+    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+      (should (string-match-p "Read image file" content))
+      ;; In batch: placeholder text; in GUI: [image] fallback from insert-image
+      (should (or (string-match-p "\\[Image:" content)
+                  (string-match-p "\\[image\\]" content))))))
+
+(ert-deftest pi-coding-agent-test-tool-end-text-only-no-image ()
+  "Tool result with only text blocks has no image placeholder."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-end
+     "bash" '(:command "ls")
+     '((:type "text" :text "file1\nfile2"))
+     nil nil)
+    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+      (should (string-match-p "file1" content))
+      (should-not (string-match-p "\\[Image:" content))
+      (should-not (string-match-p "\\[image\\]" content)))))
+
+(ert-deftest pi-coding-agent-test-tool-end-image-inside-overlay ()
+  "Image content is contained within the tool block overlay."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((block (pi-coding-agent--display-tool-start
+                  "read" '(:path "photo.png"))))
+      (pi-coding-agent--display-tool-end
+       "read" '(:path "photo.png")
+       '((:type "text" :text "Read image file [image/png]")
+         (:type "image" :data "iVBORw0KGgo=" :mimeType "image/png"))
+       nil nil block)
+      (let ((ov (seq-find (lambda (o) (overlay-get o 'pi-coding-agent-tool-block))
+                          (overlays-in (point-min) (point-max)))))
+        (should ov)
+        (let ((ov-content (buffer-substring-no-properties
+                           (overlay-start ov) (overlay-end ov))))
+          (should (or (string-match-p "\\[Image:" ov-content)
+                      (string-match-p "\\[image\\]" ov-content))))))))
+
+(ert-deftest pi-coding-agent-test-tool-end-image-blocks-stored ()
+  "Image content blocks are stored on the tool block struct."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((block (pi-coding-agent--display-tool-start
+                  "read" '(:path "photo.png"))))
+      (pi-coding-agent--display-tool-end
+       "read" '(:path "photo.png")
+       '((:type "text" :text "Read image")
+         (:type "image" :data "iVBORw0KGgo=" :mimeType "image/png"))
+       nil nil block)
+      (should (pi-coding-agent--tool-block-image-blocks block))
+      ;; Content should include image block
+      (should (seq-some (lambda (b) (equal (plist-get b :type) "image"))
+                        (pi-coding-agent--tool-block-image-blocks block))))))
+
+(ert-deftest pi-coding-agent-test-tool-end-multiple-images ()
+  "Multiple image blocks each produce output."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "photo.png")
+     '((:type "text" :text "Two images")
+       (:type "image" :data "iVBORw0KGgo=" :mimeType "image/png")
+       (:type "image" :data "/9j/4AAQ" :mimeType "image/jpeg"))
+     nil nil)
+    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+      ;; Both image indicators should be present
+      (should (or (>= (length (split-string content "\\[Image:\\|\\[image\\]" t)) 2)
+                  ;; GUI mode: two [image] from insert-image
+                  (string-match-p "\\[image\\].*\\[image\\]" content))))))
+
+(ert-deftest pi-coding-agent-test-tool-end-image-only ()
+  "Tool result with only image blocks, no text, still renders."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "photo.png")
+     '((:type "image" :data "iVBORw0KGgo=" :mimeType "image/png"))
+     nil nil)
+    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+      (should (or (string-match-p "\\[Image:" content)
+                  (string-match-p "\\[image\\]" content))))))
+
+(ert-deftest pi-coding-agent-test-tool-end-unknown-mime-type ()
+  "Unknown MIME type produces a placeholder, not an error."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "file.tga")
+     '((:type "text" :text "Read image")
+       (:type "image" :data "AAAA" :mimeType "image/tga"))
+     nil nil)
+    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+      (should (string-match-p "image/tga" content)))))
+
+(ert-deftest pi-coding-agent-test-history-tool-with-image ()
+  "History replay renders image from tool result."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((messages [(:role "assistant"
+                      :content [(:type "toolCall" :id "tc1"
+                                 :name "read"
+                                 :arguments (:path "photo.png"))]
+                      :timestamp 1704067200000)
+                     (:role "toolResult" :toolCallId "tc1"
+                      :toolName "read"
+                      :content [(:type "text" :text "Read image file [image/png]")
+                                (:type "image" :data "iVBORw0KGgo=" :mimeType "image/png")]
+                      :isError :json-false
+                      :timestamp 1704067201000)]))
+      (pi-coding-agent--display-history-messages messages))
+    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+      (should (or (string-match-p "\\[Image:.*image/png" content)
+                  (string-match-p "\\[image\\]" content))))))
+
+(ert-deftest pi-coding-agent-test-tool-end-image-with-vector-content ()
+  "Image blocks work when content is a vector (JSON parse format)."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "photo.png")
+     [(:type "text" :text "Read image")
+      (:type "image" :data "iVBORw0KGgo=" :mimeType "image/png")]
+     nil nil)
+    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+      (should (or (string-match-p "\\[Image:" content)
+                  (string-match-p "\\[image\\]" content))))))
+
 (provide 'pi-coding-agent-render-test)
 ;;; pi-coding-agent-render-test.el ends here

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -2590,6 +2590,10 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
                 (point-max))))
     (nreverse positions)))
 
+(defconst pi-coding-agent-test--png-base64
+  "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAADklEQVR4nGP4z8DwHwQBEPgD/U6VwW8AAAAASUVORK5CYII="
+  "Base64 for a two-by-one PNG used by image preview tests.")
+
 (ert-deftest pi-coding-agent-test-tool-result-image-has-terminal-placeholder ()
   "An image result is useful text inside its tool block in a terminal."
   (with-temp-buffer
@@ -2599,8 +2603,9 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
       (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) nil)))
         (pi-coding-agent--display-tool-end
          "custom_image" '(:label "preview")
-         [(:type "text" :text "generated")
-          (:type "image" :data "UE5H" :mimeType "image/png")]
+         `[(:type "text" :text "generated")
+           (:type "image" :data ,pi-coding-agent-test--png-base64
+            :mimeType "image/png")]
          nil nil block))
       (let* ((overlay (pi-coding-agent--tool-block-overlay block))
              (positions (pi-coding-agent-test--image-preview-positions))
@@ -2611,7 +2616,7 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
         (should (get-text-property position 'pi-coding-agent-no-fontify))
         (should-not (get-text-property position 'display))
         (should (string-match-p
-                 "\\[Image: image/png, 3 B\\]"
+                 "Image: image/png, 71 B"
                  (buffer-substring-no-properties position (overlay-end overlay))))))))
 
 (ert-deftest pi-coding-agent-test-tool-result-image-inserts-scaled-display-property ()
@@ -2632,14 +2637,17 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
                    'image-display-spec)))
         (pi-coding-agent--display-tool-end
          "custom_image" nil
-         '((:type "image" :data "UE5H" :mimeType "image/png"))
+         `((:type "image" :data ,pi-coding-agent-test--png-base64
+            :mimeType "image/png"))
          nil nil))
       (let* ((positions (pi-coding-agent-test--image-preview-positions))
              (position (car positions)))
         (should (= 1 (length positions)))
         (should (eq 'image-display-spec
                     (get-text-property position 'display)))
-        (should (equal '("PNG" png t (:max-width 720 :max-height 300))
+        (should (equal (list (base64-decode-string
+                              pi-coding-agent-test--png-base64)
+                             'png t '(:max-width 720 :max-height 300))
                        created))))))
 
 (ert-deftest pi-coding-agent-test-tool-result-image-edge-cases-stay-visible ()
@@ -2650,19 +2658,46 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
               ((symbol-function 'image-type-available-p) (lambda (_type) nil)))
       (pi-coding-agent--display-tool-end
        "custom_image" nil
-       [(:type "image" :data "UE5H" :mimeType "image/png")
-        (:type "image" :data "SlBFRw==" :mimeType "image/jpeg")
-        (:type "image" :data "%%%" :mimeType "image/gif")
-        (:type "image" :data "AAAA" :mimeType "image/tga")
-        (:type "image" :data "" :mimeType "image/webp")]
+       `[(:type "image" :data ,pi-coding-agent-test--png-base64
+          :mimeType "image/png")
+         (:type "image" :data "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+          :mimeType "image/gif")
+         (:type "image" :data "%%%" :mimeType "image/jpeg")
+         (:type "image" :data "AAAA" :mimeType "image/tga")
+         (:type "image" :data "" :mimeType "image/webp")]
        nil nil))
     (should (= 5 (length (pi-coding-agent-test--image-preview-positions))))
     (let ((text (buffer-substring-no-properties (point-min) (point-max))))
-      (should (string-match-p "image/png, 3 B, unavailable" text))
-      (should (string-match-p "image/jpeg, 4 B, unavailable" text))
-      (should (string-match-p "image/gif, decode error" text))
+      (should (string-match-p "image/png, 71 B, unavailable" text))
+      (should (string-match-p "image/gif, 34 B, unavailable" text))
+      (should (string-match-p "image/jpeg, decode error" text))
       (should (string-match-p "image/tga, 3 B, unsupported type" text))
       (should (string-match-p "image/webp, empty data" text)))))
+
+(ert-deftest pi-coding-agent-test-tool-result-images-obey-source-and-count-caps ()
+  "Oversized and excess images become textual placeholders."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-image-preview-max-bytes 2)
+          (pi-coding-agent--image-previews-per-tool-limit 2))
+      (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) t))
+                ((symbol-function 'create-image)
+                 (lambda (&rest _)
+                   (ert-fail "Oversized image reached create-image"))))
+        (pi-coding-agent--display-tool-end
+         "generate" nil
+         `((:type "image" :mimeType "image/png"
+            :data ,pi-coding-agent-test--png-base64)
+           (:type "image" :mimeType "image/png"
+            :data ,pi-coding-agent-test--png-base64)
+           (:type "image" :mimeType "image/png"
+            :data ,pi-coding-agent-test--png-base64))
+         nil nil)))
+    (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+      (should (= 2 (seq-count
+                    (lambda (line) (string-match-p "too large (limit 2 B)" line))
+                    (split-string text "\n" t))))
+      (should (string-match-p "1 additional preview omitted" text)))))
 
 (ert-deftest pi-coding-agent-test-tool-result-image-history-replays-preview ()
   "History replay renders image result blocks as previews."
@@ -2670,12 +2705,13 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
     (pi-coding-agent-chat-mode)
     (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) nil)))
       (pi-coding-agent--display-history-messages
-       [(:role "assistant"
-         :content [(:type "toolCall" :id "image-history" :name "generate"
-                    :arguments (:prompt "chart"))])
-        (:role "toolResult" :toolCallId "image-history" :toolName "generate"
-         :content [(:type "image" :data "UE5H" :mimeType "image/png")]
-         :isError :json-false)]))
+       `[(:role "assistant"
+          :content [(:type "toolCall" :id "image-history" :name "generate"
+                     :arguments (:prompt "chart"))])
+         (:role "toolResult" :toolCallId "image-history" :toolName "generate"
+          :content [(:type "image" :data ,pi-coding-agent-test--png-base64
+                     :mimeType "image/png")]
+          :isError :json-false)]))
     (should (= 1 (length (pi-coding-agent-test--image-preview-positions))))
     (should (string-match-p "Image: image/png"
                             (buffer-substring-no-properties
@@ -2700,7 +2736,9 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
           (pi-coding-agent--display-tool-end
            "generate" nil
            (list (list :type "text" :text body)
-                 '(:type "image" :data "UE5H" :mimeType "image/png"))
+                 (list :type "image"
+                       :data pi-coding-agent-test--png-base64
+                       :mimeType "image/png"))
            nil nil block)
           (dotimes (_ 2)
             (let* ((overlay (pi-coding-agent--tool-block-overlay block))
@@ -2731,8 +2769,9 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
                       "generate" nil "cooled-image")))
           (pi-coding-agent--display-tool-end
            "generate" nil
-           '((:type "text" :text "done")
-             (:type "image" :data "UE5H" :mimeType "image/png"))
+           `((:type "text" :text "done")
+             (:type "image" :data ,pi-coding-agent-test--png-base64
+              :mimeType "image/png"))
            nil nil block)
           (pi-coding-agent--cool-completed-tool-blocks
            (list (pi-coding-agent--tool-block-overlay block)))))
@@ -2744,6 +2783,98 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
                     (get-text-property position 'display)))
         (should (get-text-property position 'pi-coding-agent-cold-tool-block))
         (should-not (pi-coding-agent-test--all-tool-overlays))))))
+
+(ert-deftest pi-coding-agent-test-read-svg-uses-complete-returned-text ()
+  "A complete standalone SVG returned by read becomes the preview source."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((source "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"2\" height=\"1\"><rect width=\"2\" height=\"1\"/></svg>")
+          created)
+      (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) t))
+                ((symbol-function 'image-type-available-p)
+                 (lambda (type) (eq type 'svg)))
+                ((symbol-function 'window-pixel-width)
+                 (lambda (&optional _window) 1200))
+                ((symbol-function 'window-pixel-height)
+                 (lambda (&optional _window) 600))
+                ((symbol-function 'create-image)
+                 (lambda (data type data-p &rest properties)
+                   (setq created (list data type data-p properties))
+                   'returned-svg-spec)))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/does/not/exist.svg")
+         (list (list :type "text" :text source))
+         '(:truncation :null) nil))
+      (let ((position (car (pi-coding-agent-test--image-preview-positions))))
+        (should position)
+        (should (eq 'returned-svg-spec
+                    (get-text-property position 'display)))
+        (should (equal source (car created)))
+        (should (equal '(svg t (:max-width 900 :max-height 300
+                               :base-uri "data:" :scale 1))
+                       (cdr created)))))))
+
+(ert-deftest pi-coding-agent-test-read-svg-refuses-truncated-result ()
+  "A non-null truncation record keeps complete-looking SVG as text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "/remote/truncated.svg")
+     '((:type "text"
+        :text "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect/></svg>"))
+     '(:truncation (:originalBytes 2048 :returnedBytes 1024)) nil)
+    (should-not (pi-coding-agent-test--image-preview-positions))
+    (should (string-match-p "<svg" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-read-svg-history-and-resource-refusal ()
+  "History previews standalone SVG text but leaves resource-backed SVG as text."
+  (let ((simple "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"1\" height=\"1\"/></svg>")
+        (resource "<svg xmlns=\"http://www.w3.org/2000/svg\"><image href=\"file:///tmp/x.png\"/></svg>"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) nil)))
+        (pi-coding-agent--display-history-messages
+         `[( :role "assistant"
+             :content [(:type "toolCall" :id "svg-history" :name "read"
+                        :arguments (:path "gone.svg"))])
+           (:role "toolResult" :toolCallId "svg-history" :toolName "read"
+            :content [(:type "text" :text ,simple)] :isError :json-false)]))
+      (should (= 1 (length (pi-coding-agent-test--image-preview-positions))))
+      (should (string-match-p (regexp-quote "Image: image/svg+xml")
+                              (buffer-substring-no-properties
+                               (point-min) (point-max)))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (cl-letf (((symbol-function 'create-image)
+                 (lambda (&rest _)
+                   (ert-fail "Resource-backed SVG reached create-image"))))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/tmp/x.svg")
+         (list (list :type "text" :text resource)) nil nil))
+      (should-not (pi-coding-agent-test--image-preview-positions))
+      (should (string-match-p "file:///tmp/x.png" (buffer-string))))))
+
+(ert-deftest pi-coding-agent-test-keyed-final-does-not-use-legacy-tool-block ()
+  "A keyed final miss creates its own block instead of using the legacy block."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let* ((legacy (pi-coding-agent--display-tool-start "bash" nil))
+           (legacy-overlay (pi-coding-agent--tool-block-overlay legacy)))
+      (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) nil)))
+        (pi-coding-agent--handle-display-event
+         `(:type "tool_execution_end" :toolCallId "late-image"
+           :toolName "generate" :isError nil
+           :result (:content [(:type "image" :mimeType "image/png"
+                               :data ,pi-coding-agent-test--png-base64)]))))
+      (let* ((position (car (pi-coding-agent-test--image-preview-positions)))
+             (result-overlay
+              (seq-find (lambda (overlay)
+                          (overlay-get overlay 'pi-coding-agent-tool-block))
+                        (overlays-at position))))
+        (should result-overlay)
+        (should-not (eq result-overlay legacy-overlay))
+        (should-not (and (<= (overlay-start legacy-overlay) position)
+                         (< position (overlay-end legacy-overlay))))))))
 
 (ert-deftest pi-coding-agent-test-text-only-tool-result-adds-no-image-preview ()
   "Ordinary tool output remains ordinary fenced text."

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -2576,6 +2576,186 @@ See https://github.com/dnouri/pi-coding-agent/issues/176."
                           nil nil)
     (should (string-match-p "file1" (buffer-string)))))
 
+(defun pi-coding-agent-test--image-preview-positions ()
+  "Return buffer positions carrying rendered image previews."
+  (let ((position (point-min))
+        positions)
+    (while (setq position
+                 (text-property-any position (point-max)
+                                    'pi-coding-agent-image-preview t))
+      (push position positions)
+      (setq position
+            (or (next-single-property-change
+                 position 'pi-coding-agent-image-preview nil (point-max))
+                (point-max))))
+    (nreverse positions)))
+
+(ert-deftest pi-coding-agent-test-tool-result-image-has-terminal-placeholder ()
+  "An image result is useful text inside its tool block in a terminal."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((block (pi-coding-agent--display-tool-start
+                  "custom_image" '(:label "preview") "image-call")))
+      (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) nil)))
+        (pi-coding-agent--display-tool-end
+         "custom_image" '(:label "preview")
+         [(:type "text" :text "generated")
+          (:type "image" :data "UE5H" :mimeType "image/png")]
+         nil nil block))
+      (let* ((overlay (pi-coding-agent--tool-block-overlay block))
+             (positions (pi-coding-agent-test--image-preview-positions))
+             (position (car positions)))
+        (should (= 1 (length positions)))
+        (should (<= (overlay-start overlay) position))
+        (should (< position (overlay-end overlay)))
+        (should (get-text-property position 'pi-coding-agent-no-fontify))
+        (should-not (get-text-property position 'display))
+        (should (string-match-p
+                 "\\[Image: image/png, 3 B\\]"
+                 (buffer-substring-no-properties position (overlay-end overlay))))))))
+
+(ert-deftest pi-coding-agent-test-tool-result-image-inserts-scaled-display-property ()
+  "A graphical result carries one scaled image display property."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let (created)
+      (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) t))
+                ((symbol-function 'image-type-available-p)
+                 (lambda (type) (eq type 'png)))
+                ((symbol-function 'window-pixel-width)
+                 (lambda (&optional _window) 800))
+                ((symbol-function 'window-pixel-height)
+                 (lambda (&optional _window) 600))
+                ((symbol-function 'create-image)
+                 (lambda (data type data-p &rest properties)
+                   (setq created (list data type data-p properties))
+                   'image-display-spec)))
+        (pi-coding-agent--display-tool-end
+         "custom_image" nil
+         '((:type "image" :data "UE5H" :mimeType "image/png"))
+         nil nil))
+      (let* ((positions (pi-coding-agent-test--image-preview-positions))
+             (position (car positions)))
+        (should (= 1 (length positions)))
+        (should (eq 'image-display-spec
+                    (get-text-property position 'display)))
+        (should (equal '("PNG" png t (:max-width 720 :max-height 300))
+                       created))))))
+
+(ert-deftest pi-coding-agent-test-tool-result-image-edge-cases-stay-visible ()
+  "Multiple, corrupt, unknown, unavailable, and empty images degrade to text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) t))
+              ((symbol-function 'image-type-available-p) (lambda (_type) nil)))
+      (pi-coding-agent--display-tool-end
+       "custom_image" nil
+       [(:type "image" :data "UE5H" :mimeType "image/png")
+        (:type "image" :data "SlBFRw==" :mimeType "image/jpeg")
+        (:type "image" :data "%%%" :mimeType "image/gif")
+        (:type "image" :data "AAAA" :mimeType "image/tga")
+        (:type "image" :data "" :mimeType "image/webp")]
+       nil nil))
+    (should (= 5 (length (pi-coding-agent-test--image-preview-positions))))
+    (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+      (should (string-match-p "image/png, 3 B, unavailable" text))
+      (should (string-match-p "image/jpeg, 4 B, unavailable" text))
+      (should (string-match-p "image/gif, decode error" text))
+      (should (string-match-p "image/tga, 3 B, unsupported type" text))
+      (should (string-match-p "image/webp, empty data" text)))))
+
+(ert-deftest pi-coding-agent-test-tool-result-image-history-replays-preview ()
+  "History replay renders image result blocks as previews."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) nil)))
+      (pi-coding-agent--display-history-messages
+       [(:role "assistant"
+         :content [(:type "toolCall" :id "image-history" :name "generate"
+                    :arguments (:prompt "chart"))])
+        (:role "toolResult" :toolCallId "image-history" :toolName "generate"
+         :content [(:type "image" :data "UE5H" :mimeType "image/png")]
+         :isError :json-false)]))
+    (should (= 1 (length (pi-coding-agent-test--image-preview-positions))))
+    (should (string-match-p "Image: image/png"
+                            (buffer-substring-no-properties
+                             (point-min) (point-max))))))
+
+(ert-deftest pi-coding-agent-test-tool-result-image-toggle-reuses-preview ()
+  "Collapse and expand preserve one decoded preview inside stable bounds."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-tool-preview-lines 2)
+          (create-count 0)
+          (body (mapconcat (lambda (number) (format "line-%d" number))
+                           (number-sequence 1 12) "\n")))
+      (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) t))
+                ((symbol-function 'image-type-available-p) (lambda (_type) t))
+                ((symbol-function 'create-image)
+                 (lambda (&rest _)
+                   (setq create-count (1+ create-count))
+                   'persistent-image-spec)))
+        (let ((block (pi-coding-agent--display-tool-start
+                      "generate" nil "toggle-image")))
+          (pi-coding-agent--display-tool-end
+           "generate" nil
+           (list (list :type "text" :text body)
+                 '(:type "image" :data "UE5H" :mimeType "image/png"))
+           nil nil block)
+          (dotimes (_ 2)
+            (let* ((overlay (pi-coding-agent--tool-block-overlay block))
+                   (button (pi-coding-agent--find-toggle-button-in-region
+                            (overlay-start overlay) (overlay-end overlay))))
+              (should button)
+              (pi-coding-agent--toggle-tool-output button)
+              (let ((position (car (pi-coding-agent-test--image-preview-positions))))
+                (should position)
+                (should (< position (overlay-end overlay)))
+                (should (eq 'persistent-image-spec
+                            (get-text-property position 'display))))))
+          (should (= 1 create-count))
+          (should (= 1 (length (pi-coding-agent-test--image-preview-positions)))))))))
+
+(ert-deftest pi-coding-agent-test-tool-result-image-survives-cooling ()
+  "Cooling history keeps the preview property while dropping heavy hot state."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((create-count 0))
+      (cl-letf (((symbol-function 'display-images-p) (lambda (&rest _) t))
+                ((symbol-function 'image-type-available-p) (lambda (_type) t))
+                ((symbol-function 'create-image)
+                 (lambda (&rest _)
+                   (setq create-count (1+ create-count))
+                   'cooled-image-spec)))
+        (let ((block (pi-coding-agent--display-tool-start
+                      "generate" nil "cooled-image")))
+          (pi-coding-agent--display-tool-end
+           "generate" nil
+           '((:type "text" :text "done")
+             (:type "image" :data "UE5H" :mimeType "image/png"))
+           nil nil block)
+          (pi-coding-agent--cool-completed-tool-blocks
+           (list (pi-coding-agent--tool-block-overlay block)))))
+      (let* ((positions (pi-coding-agent-test--image-preview-positions))
+             (position (car positions)))
+        (should (= 1 create-count))
+        (should (= 1 (length positions)))
+        (should (eq 'cooled-image-spec
+                    (get-text-property position 'display)))
+        (should (get-text-property position 'pi-coding-agent-cold-tool-block))
+        (should-not (pi-coding-agent-test--all-tool-overlays))))))
+
+(ert-deftest pi-coding-agent-test-text-only-tool-result-adds-no-image-preview ()
+  "Ordinary tool output remains ordinary fenced text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-end
+     "bash" '(:command "printf ok")
+     '((:type "text" :text "ok")) nil nil)
+    (should-not (pi-coding-agent-test--image-preview-positions))
+    (should (string-match-p (regexp-quote "```\nok\n```")
+                            (buffer-string)))))
+
 (ert-deftest pi-coding-agent-test-bash-output-wrapped-in-bare-fence ()
   "Bash output is wrapped in a bare fence (no language tag)."
   (with-temp-buffer

--- a/test/pi-coding-agent-test-common.el
+++ b/test/pi-coding-agent-test-common.el
@@ -108,28 +108,42 @@ nil.  FAKE-EXTRA-ARGS are appended after the generated fake-pi scenario args."
 
 ;;;; Batch Emacs Helpers
 
+(defconst pi-coding-agent-test--batch-result-marker
+  "\n\036PI-CODING-AGENT-BATCH-RESULT-8F3D6A\037\n"
+  "Marker separating child Emacs diagnostics from its Lisp result.")
+
 (defun pi-coding-agent-test--read-batch-emacs-result (expression)
-  "Evaluate EXPRESSION in a fresh batch Emacs and read its printed result.
+  "Evaluate EXPRESSION in a fresh batch Emacs and return its Lisp result.
 Initializes packages, then re-prepends the current project root to
-`load-path' so the checkout under test wins over any installed copy."
+`load-path' so the checkout under test wins over any installed copy.
+Diagnostic output before the framed result is ignored."
   (let* ((emacs (expand-file-name invocation-name invocation-directory))
          (repo-root (file-name-directory (locate-library "pi-coding-agent")))
          (output-buffer (generate-new-buffer " *pi-coding-agent-batch-emacs*"))
          (exit-code (call-process emacs nil output-buffer nil
                                   "--batch" "-Q" "-L" repo-root
                                   "--eval" "(require 'package)"
+                                  "--eval"
+                                  "(let ((dir (getenv \"PACKAGE_USER_DIR\")))\n  (when dir\n    (setq package-user-dir\n          (directory-file-name (expand-file-name dir)))))"
                                   "--eval" "(package-initialize)"
                                   "--eval" "(setq load-prefer-newer t)"
                                   "--eval"
                                   (format "(setq load-path (cons %S load-path))"
                                           repo-root)
-                                  "--eval" expression)))
+                                  "--eval"
+                                  (format "(prin1 (prog1 %s (princ %S)))"
+                                          expression
+                                          pi-coding-agent-test--batch-result-marker))))
     (unwind-protect
         (progn
           (unless (eq 0 exit-code)
             (error "Batch Emacs exited with %s" exit-code))
           (with-current-buffer output-buffer
             (goto-char (point-min))
+            (unless (search-forward pi-coding-agent-test--batch-result-marker
+                                    nil t)
+              (error "Batch Emacs result marker missing: %s"
+                     (buffer-string)))
             (read (current-buffer))))
       (kill-buffer output-buffer))))
 

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -1738,6 +1738,38 @@ must decide whether this is a no-op."
         (ignore-errors (kill-buffer "*pi-coding-agent-test-non-pi*"))
         (delete-other-windows)))))
 
+(ert-deftest pi-coding-agent-test-batch-emacs-loads-overridden-package-directory ()
+  "A child Emacs loads dependencies from the caller's package directory."
+  (let* ((root (make-temp-file "pi-child-package-" t))
+         (package-user-dir (expand-file-name "elpa" root))
+         (package-dir (expand-file-name "pi-child-dependency-1.0"
+                                        package-user-dir)))
+    (unwind-protect
+        (progn
+          (make-directory package-dir t)
+          (with-temp-file (expand-file-name "pi-child-dependency-pkg.el"
+                                             package-dir)
+            (insert "(define-package \"pi-child-dependency\" \"1.0\" \"Test dependency\")\n"))
+          (with-temp-file (expand-file-name "pi-child-dependency-autoloads.el"
+                                             package-dir)
+            (insert "(add-to-list 'load-path\n"
+                    "             (directory-file-name\n"
+                    "              (file-name-directory\n"
+                    "               (or load-file-name buffer-file-name))))\n"))
+          (with-temp-file (expand-file-name "pi-child-dependency.el" package-dir)
+            (insert "(defconst pi-child-dependency-value 'loaded-from-override)\n"
+                    "(provide 'pi-child-dependency)\n"))
+          (let ((process-environment (copy-sequence process-environment)))
+            (setenv "PACKAGE_USER_DIR" package-user-dir)
+            (should
+             (eq 'loaded-from-override
+                 (pi-coding-agent-test--read-batch-emacs-result
+                  "(progn
+  (display-warning 'pi-coding-agent-test \"injected child warning\")
+  (require 'pi-child-dependency)
+  (prin1 pi-child-dependency-value))")))))
+      (delete-directory root t))))
+
 (ert-deftest pi-coding-agent-test-transient-warning-explains-built-in-upgrade ()
   "Loading the menu with an old transient explains how to upgrade it."
   (let* ((expression

--- a/test/run-gui-tests.sh
+++ b/test/run-gui-tests.sh
@@ -24,6 +24,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 HEADLESS="${PI_HEADLESS:-0}"
+EMACS_BIN="${EMACS:-emacs}"
+if [ -z "${PACKAGE_USER_DIR:-}" ]; then
+    EMACS_MAJOR_VERSION=$("$EMACS_BIN" --batch -Q \
+        --eval '(princ emacs-major-version)')
+    export PACKAGE_USER_DIR="$PROJECT_DIR/.cache/elpa/$EMACS_MAJOR_VERSION"
+fi
 SELECTOR="\"pi-coding-agent-gui-test-\""
 
 # Parse args
@@ -67,8 +73,12 @@ cat >> "$RUNNER_FILE" << EOF
 (add-to-list 'load-path "$PROJECT_DIR")
 (add-to-list 'load-path "$PROJECT_DIR/test")
 
-;; Initialize packages to find transient
+;; Initialize the same project-local packages as the parent test lane.
 (require 'package)
+(let ((dir (getenv "PACKAGE_USER_DIR")))
+  (when dir
+    (setq package-user-dir
+          (directory-file-name (expand-file-name dir)))))
 (push '("melpa" . "https://melpa.org/packages/") package-archives)
 (package-initialize)
 
@@ -170,9 +180,10 @@ set +e
 if [ "$HEADLESS" = "1" ]; then
     # GDK_BACKEND=x11 forces GTK/PGTK to use X11 instead of auto-detecting Wayland
     # </dev/null prevents "standard input is not a tty" error in CI
-    xvfb-run -a env GDK_BACKEND=x11 PATH="$PATH" emacs -Q -l "$RUNNER_FILE" </dev/null 2>&1
+    xvfb-run -a env GDK_BACKEND=x11 PATH="$PATH" \
+        "$EMACS_BIN" -Q -l "$RUNNER_FILE" </dev/null 2>&1
 else
-    emacs -Q -l "$RUNNER_FILE" 2>&1
+    "$EMACS_BIN" -Q -l "$RUNNER_FILE" 2>&1
 fi
 EXIT_CODE=$?
 set -e


### PR DESCRIPTION
When a tool (e.g. read) returns image content blocks alongside text, the images are now rendered inline inside the tool block overlay.

In GUI Emacs: decoded and displayed via create-image/insert-image with max-width/max-height scaling to fit the window.

In terminal Emacs: a text placeholder showing MIME type and size.

Implementation:
- New struct slot: tool-block.image-blocks stores content for toggle
- pi-coding-agent--mime-to-image-type: MIME string to Emacs type symbol
- pi-coding-agent--insert-inline-image: decode + insert or placeholder
- pi-coding-agent--insert-tool-images: iterate content, insert images
- display-tool-end: calls insert-tool-images after text rendering
- toggle-tool-output: re-inserts images from stored blocks after toggle

Handles: corrupt base64, unknown MIME types, empty data, vectors and lists, multiple image blocks, image-only results (no text).

12 new tests covering all paths. 942/942 full suite passes.