### PR TITLE
Coalesce rendering of tool_execution_update events

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,6 +30,10 @@ jobs:
         run: |
           set -o pipefail
           ./bench/run-reload-resume-bench.sh --batch --scenario smoke -c 1 --out-dir tmp/reload-resume-bench-ci | tee reload-resume-bench-output.txt
+      - name: Run tool-update storm benchmarks (batch smoke)
+        run: |
+          set -o pipefail
+          ./bench/run-tool-update-bench.sh --batch --scenario smoke -c 1 --out-dir tmp/tool-update-bench-ci | tee tool-update-bench-output.txt
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
@@ -38,6 +42,7 @@ jobs:
           path: |
             bench-output.txt
             reload-resume-bench-output.txt
+            tool-update-bench-output.txt
             tmp/reload-resume-bench-ci/summary.csv
             tmp/reload-resume-bench-ci/summary.md
             tmp/reload-resume-bench-ci/**/report.md
@@ -45,3 +50,10 @@ jobs:
             tmp/reload-resume-bench-ci/**/times.tsv
             tmp/reload-resume-bench-ci/**/stdout.log
             tmp/reload-resume-bench-ci/**/stderr.log
+            tmp/tool-update-bench-ci/summary.csv
+            tmp/tool-update-bench-ci/summary.md
+            tmp/tool-update-bench-ci/**/report.md
+            tmp/tool-update-bench-ci/**/result.json
+            tmp/tool-update-bench-ci/**/times.tsv
+            tmp/tool-update-bench-ci/**/stdout.log
+            tmp/tool-update-bench-ci/**/stderr.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,9 @@ module, direct `setq` is fine.
 | `bench/pi-coding-agent-reload-resume-bench.el` | Synthetic reload/resume benchmark harness |
 | `bench/fake-pi-reload-resume.py` | Fake JSON-over-stdio pi backend for reload/resume benchmarks |
 | `bench/run-reload-resume-bench.sh` | Reload/resume benchmark runner; GUI uses `xvfb-run`, `--batch` for headless lane |
+| `bench/pi-coding-agent-tool-update-bench.el` | Synthetic tool-update storm benchmark harness |
+| `bench/fake-pi-tool-update-storm.py` | Fake JSON-over-stdio pi backend emitting a tool-update storm |
+| `bench/run-tool-update-bench.sh` | Tool-update storm benchmark runner; GUI uses `xvfb-run`, `--batch` for headless lane |
 | `bench/fixtures/tables.md` | Sample pipe tables used by the table benchmark |
 | `scripts/check.sh` | Pre-commit hook: byte-compile + lint + tests |
 | `scripts/pi-coding-agent-build.el` | Shared batch helpers for dependency and grammar installation |
@@ -143,13 +146,19 @@ make bench-batch                   # table batch lane (no display, secondary)
 make bench-reload-resume           # reload/resume GUI lane via xvfb (primary)
 make bench-reload-resume-batch     # reload/resume batch lane (secondary)
 make bench-reload-resume-smoke     # cheap synthetic correctness smoke
+make bench-tool-update             # tool-update storm GUI lane via xvfb (primary)
+make bench-tool-update-batch       # tool-update storm batch lane (secondary)
+make bench-tool-update-smoke       # cheap synthetic correctness smoke
 ```
 
 The GUI lanes are the primary measurements; batch lanes are quick sanity
 checks and CI artifact generators.  Reload/resume benchmarks use synthetic
 JSONL fixtures only and fail on correctness errors, not timing thresholds.
-Table fixtures live in `bench/fixtures/tables.md`. Reload/resume artifacts are
-written under `tmp/reload-resume-bench/` by default.
+Tool-update storm benchmarks replay a deterministic synthetic
+`tool_execution_update` storm against a fake pi and likewise fail only on
+correctness errors.  Table fixtures live in `bench/fixtures/tables.md`.
+Reload/resume artifacts are written under `tmp/reload-resume-bench/` and
+tool-update artifacts under `tmp/tool-update-bench/` by default.
 
 ## Linting
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ VERBOSE ?=
 .PHONY: test test-unit test-core test-ui test-render test-table test-input test-menu test-build
 .PHONY: test-integration test-integration-fake test-integration-real test-integration-ci test-integration-ci-real test-gui test-gui-ci test-all
 .PHONY: bench bench-batch bench-reload-resume bench-reload-resume-batch bench-reload-resume-smoke
+.PHONY: bench-tool-update bench-tool-update-batch bench-tool-update-smoke
 .PHONY: check check-parens compile lint lint-checkdoc lint-package clean clean-cache help
 .PHONY: ollama-start ollama-stop ollama-status setup-pi install-hooks
 
@@ -46,6 +47,9 @@ help:
 	@echo "  make bench-reload-resume           Reload/resume benchmarks (GUI via xvfb)"
 	@echo "  make bench-reload-resume-batch     Reload/resume benchmarks (batch, secondary lane)"
 	@echo "  make bench-reload-resume-smoke     Reload/resume smoke benchmark (batch, no timing thresholds)"
+	@echo "  make bench-tool-update             Tool-update storm benchmarks (GUI via xvfb)"
+	@echo "  make bench-tool-update-batch       Tool-update storm benchmarks (batch, secondary lane)"
+	@echo "  make bench-tool-update-smoke       Tool-update storm smoke benchmark (batch, no timing thresholds)"
 	@echo "  make lint             Checkdoc + package-lint"
 	@echo "  make check            Compile, lint, unit tests (pre-commit)"
 	@echo "  make install-hooks    Set up git pre-commit hook"
@@ -261,6 +265,19 @@ bench-reload-resume-batch: .deps-stamp
 # Cheap correctness/regression smoke; no timing thresholds are enforced.
 bench-reload-resume-smoke: .deps-stamp
 	@./bench/run-reload-resume-bench.sh --batch --scenario smoke -c 1
+
+# Primary lane: GUI via xvfb; measures rendering of tool_execution_update
+# storms against the stock frontend plus main-thread blocking.
+bench-tool-update: .deps-stamp
+	@./bench/run-tool-update-bench.sh
+
+# Secondary lane: batch mode; useful for CI artifacts and quick comparisons.
+bench-tool-update-batch: .deps-stamp
+	@./bench/run-tool-update-bench.sh --batch
+
+# Cheap correctness/regression smoke; no timing thresholds are enforced.
+bench-tool-update-smoke: .deps-stamp
+	@./bench/run-tool-update-bench.sh --batch --scenario smoke -c 1
 
 # ============================================================
 # Ollama management (local development)

--- a/bench/fake-pi-tool-update-storm.py
+++ b/bench/fake-pi-tool-update-storm.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+"""Fake pi JSON-over-stdio server emitting a tool_execution_update storm.
+
+Drives the pi-coding-agent tool-update benchmark.  On ``prompt`` the server
+replays one deterministic synthetic agent turn in two phases:
+
+Fill phase
+    Completed bash/read/write/edit tool executions (default 58/5/2/1), each
+    with ~20 lines of synthetic output and a preceding small thinking block
+    (thinking_start/delta/end).  This builds a realistic long-session chat
+    buffer before the storm starts.  All content is synthetic (for example
+    "line 0042 of bash block 003"); no real paths or session text are used.
+
+Storm phase
+    ``--parallel-tools`` parallel ``subagent`` tool executions in one
+    assistant message, then ``--updates`` ``tool_execution_update`` events
+    distributed round-robin across them, then ``tool_execution_end`` for
+    each (with a final result text), then ``message_end`` and ``agent_end``.
+    Update payloads mimic pi-submarine progress text (150-300 characters,
+    changing every update) and carry a small ``details.run`` object.
+
+Storm gap pattern (deterministic, seeded PRNG; stable for a fixed Python
+version):
+
+* updates arrive in bursts of 5-10 events;
+* inside a burst, gaps are uniform in 1-5 ms and are NEVER scaled -- these
+  reproduce the machine-gun micro-bursts observed in real subagent sessions
+  (median inter-update gap ~1 ms, peaks above 40 updates/s);
+* between bursts, pauses are uniform in 200-400 ms;
+* every 8th burst boundary adds a turn pause, uniform in 1500-2500 ms
+  (mimics a subagent completing a turn before the next activity flush);
+* ``--gap-scale`` multiplies only the inter-burst and turn pauses.
+
+With defaults (400 updates, scale 1.0) the storm phase takes ~30 s of wall
+time, so a full run finishes in roughly 30-45 s.  Use ``--gap-scale`` below
+1.0 to compress wall time (for example the smoke scenario) or above 1.0 to
+dilate toward a real session's average cadence (~3.5 updates/s across the
+busiest 120 s of an observed session, which this pattern runs hotter than
+by default to keep benchmark wall time practical).
+
+Configuration comes from ``PI_TU_BENCH_*`` environment variables, with CLI
+flags taking precedence; ``--size smoke`` selects a tiny fast preset before
+other overrides apply.  The Emacs harness reads the same environment to
+derive expected event counts, so a runner must export matching values.
+
+The optional ``--log-file`` records command names, event counts, and
+configuration only; it never records message content.
+
+Handshake shapes mirror test/support/fake_pi.py: get_state, get_commands,
+get_session_stats, get_fork_messages, get_last_assistant_text, prompt,
+abort, steer, new_session, plus ``--version`` argv handling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+MODEL = {
+    "id": "fake-model",
+    "name": "Fake Model",
+    "provider": "fake",
+    "api": "fake-api",
+    "contextWindow": 200000,
+    "maxTokens": 4096,
+}
+
+# Synthetic activity labels cycled by the storm phase.  Generic on purpose.
+ACTIVITIES = (
+    "subagent: thinking",
+    "subagent: responding",
+    "subagent: running bash tool",
+    "subagent: reading files",
+    "subagent: applying edit",
+    "subagent: compacting context",
+)
+
+# Millisecond timestamp base shared with the reload/resume bench fixtures
+# (2024-01-01T00:00:00Z); keeps synthetic timestamps boring and sortable.
+TIMESTAMP_BASE_MS = 1704067200000
+
+_WRITE_LOCK = threading.Lock()
+
+FULL_DEFAULTS: JsonDict = {
+    "fill_bash": 58,
+    "fill_read": 5,
+    "fill_write": 2,
+    "fill_edit": 1,
+    "fill_output_lines": 20,
+    "updates": 400,
+    "parallel_tools": 3,
+    "gap_scale": 1.0,
+    "seed": 20240817,
+}
+
+SMOKE_DEFAULTS: JsonDict = {
+    "fill_bash": 6,
+    "fill_read": 2,
+    "fill_write": 1,
+    "fill_edit": 1,
+    "fill_output_lines": 8,
+    "updates": 30,
+    "parallel_tools": 2,
+    "gap_scale": 0.2,
+    "seed": 20240817,
+}
+
+
+def os_environ_get(name: str) -> str | None:
+    value = os.environ.get(name)
+    return value if value else None
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os_environ_get(name)
+    return int(raw) if raw else default
+
+
+def env_float(name: str, default: float) -> float:
+    raw = os_environ_get(name)
+    return float(raw) if raw else default
+
+
+def log_line(log_file: Path | None, payload: JsonDict) -> None:
+    if log_file is None:
+        return
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    with log_file.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, separators=(",", ":"), ensure_ascii=False) + "\n")
+
+
+def write_json(payload: JsonDict) -> None:
+    with _WRITE_LOCK:
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        sys.stdout.flush()
+
+
+def respond(command: JsonDict, data: JsonDict | None = None) -> None:
+    response: JsonDict = {
+        "type": "response",
+        "command": command.get("type"),
+        "success": True,
+    }
+    if "id" in command:
+        response["id"] = command["id"]
+    if data is not None:
+        response["data"] = data
+    write_json(response)
+
+
+def state_rpc() -> JsonDict:
+    return {
+        "model": MODEL,
+        "thinkingLevel": "medium",
+        "isStreaming": False,
+        "isCompacting": False,
+        "steeringMode": "one-at-a-time",
+        "followUpMode": "one-at-a-time",
+        "sessionFile": "",
+        "sessionId": "fake-tool-update-session",
+        "autoCompactionEnabled": False,
+        "messageCount": 0,
+        "pendingMessageCount": 0,
+    }
+
+
+def stats_rpc() -> JsonDict:
+    return {
+        "totalCost": 0.42,
+        "totalTokens": 123456,
+        "inputTokens": 1000,
+        "outputTokens": 2000,
+        "cacheReadTokens": 100000,
+        "cacheWriteTokens": 20000,
+        "contextTokens": 50000,
+        "contextWindow": 200000,
+        "messageCount": 42,
+    }
+
+
+def tool_result(text: str, details: JsonDict | None = None) -> JsonDict:
+    result: JsonDict = {"content": [{"type": "text", "text": text}]}
+    if details is not None:
+        result["details"] = details
+    return result
+
+
+def iso_timestamp(offset_ms: int) -> str:
+    seconds, millis = divmod(TIMESTAMP_BASE_MS + offset_ms, 1000)
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(seconds)) + f".{millis:03d}Z"
+
+
+def fill_output(tool: str, block_index: int, lines: int) -> str:
+    return "\n".join(
+        f"line {n:04d} of {tool} block {block_index:03d}: "
+        f"synthetic benchmark output row with deterministic width"
+        for n in range(lines)
+    )
+
+
+def fill_thinking(block_index: int) -> str:
+    return (
+        f"Synthetic thinking for fill block {block_index:03d}. "
+        + "Considering the next deterministic step. " * 3
+    )
+
+
+def fill_tool_call(block_index: int, tool: str, output_lines: int) -> tuple[JsonDict, str]:
+    """Return (arguments, result_text) for one synthetic fill tool call."""
+    if tool == "bash":
+        return (
+            {"command": f"synthetic-scan --block {block_index:03d} --verbose"},
+            fill_output("bash", block_index, output_lines),
+        )
+    if tool == "read":
+        return (
+            {"path": f"synthetic/fill/file-{block_index:03d}.txt"},
+            fill_output("read", block_index, output_lines),
+        )
+    if tool == "write":
+        content = fill_output("write", block_index, output_lines)
+        return (
+            {"path": f"synthetic/fill/out-{block_index:03d}.txt", "content": content},
+            f"Wrote synthetic/fill/out-{block_index:03d}.txt ({len(content)} bytes)",
+        )
+    return (
+        {
+            "path": f"synthetic/fill/file-{block_index:03d}.txt",
+            "oldText": f"old synthetic text {block_index:03d}",
+            "newText": f"new synthetic text {block_index:03d}",
+        },
+        f"Edited synthetic/fill/file-{block_index:03d}.txt",
+    )
+
+
+def fill_plan(config: JsonDict) -> list[str]:
+    """Return fill tool names interleaved round-robin for realism."""
+    remaining = {
+        "bash": int(config["fill_bash"]),
+        "read": int(config["fill_read"]),
+        "write": int(config["fill_write"]),
+        "edit": int(config["fill_edit"]),
+    }
+    plan: list[str] = []
+    while any(remaining.values()):
+        for tool in ("bash", "read", "write", "edit"):
+            if remaining[tool] > 0:
+                plan.append(tool)
+                remaining[tool] -= 1
+    return plan
+
+
+def emit_fill_block(block_index: int, tool: str, output_lines: int) -> None:
+    """Emit one completed fill tool execution with surrounding events."""
+    tool_call_id = f"call-fill-{block_index:04d}"
+    arguments, result_text = fill_tool_call(block_index, tool, output_lines)
+    thinking = fill_thinking(block_index)
+    tool_call = {
+        "type": "toolCall",
+        "id": tool_call_id,
+        "name": tool,
+        "arguments": arguments,
+    }
+    message: JsonDict = {"role": "assistant", "content": [tool_call]}
+    write_json({"type": "message_start", "message": message})
+    write_json(
+        {
+            "type": "message_update",
+            "message": message,
+            "assistantMessageEvent": {"type": "thinking_start", "contentIndex": 0},
+        }
+    )
+    write_json(
+        {
+            "type": "message_update",
+            "message": message,
+            "assistantMessageEvent": {
+                "type": "thinking_delta",
+                "contentIndex": 0,
+                "delta": thinking,
+            },
+        }
+    )
+    write_json(
+        {
+            "type": "message_update",
+            "message": message,
+            "assistantMessageEvent": {
+                "type": "thinking_end",
+                "contentIndex": 0,
+                "content": thinking,
+            },
+        }
+    )
+    write_json(
+        {
+            "type": "message_update",
+            "message": message,
+            "assistantMessageEvent": {"type": "toolcall_start", "contentIndex": 0},
+        }
+    )
+    write_json(
+        {
+            "type": "message_update",
+            "message": message,
+            "assistantMessageEvent": {
+                "type": "toolcall_delta",
+                "contentIndex": 0,
+                "delta": json.dumps(arguments),
+            },
+        }
+    )
+    write_json(
+        {
+            "type": "tool_execution_start",
+            "toolCallId": tool_call_id,
+            "toolName": tool,
+            "args": arguments,
+        }
+    )
+    write_json(
+        {
+            "type": "tool_execution_end",
+            "toolCallId": tool_call_id,
+            "toolName": tool,
+            "result": tool_result(result_text),
+            "isError": False,
+        }
+    )
+    write_json({"type": "message_end", "message": message})
+
+
+def gap_schedule(updates: int, gap_scale: float, rng: random.Random) -> list[float]:
+    """Return per-update delays in seconds; delay i sleeps before update i.
+
+    See the module docstring for the documented burst/pause pattern.  Only
+    inter-burst and turn pauses are multiplied by ``gap_scale``; intra-burst
+    1-5 ms gaps are never scaled.
+    """
+    if updates <= 0:
+        return []
+    bursts: list[int] = []
+    left = updates
+    while left > 0:
+        burst = min(rng.randint(5, 10), left)
+        bursts.append(burst)
+        left -= burst
+    delays = [0.0]
+    for burst_index, burst in enumerate(bursts):
+        for _ in range(burst - 1):
+            delays.append(rng.uniform(1.0, 5.0) / 1000.0)
+        if burst_index < len(bursts) - 1:
+            pause_ms = rng.uniform(200.0, 400.0)
+            if (burst_index + 1) % 8 == 0:
+                pause_ms += rng.uniform(1500.0, 2500.0)
+            delays.append(pause_ms * gap_scale / 1000.0)
+    return delays
+
+
+def storm_tool_ids(parallel_tools: int) -> list[str]:
+    return [f"call-storm-{index:02d}" for index in range(parallel_tools)]
+
+
+def progress_text(seq: int, tool_id: str, turn: int, activity: str) -> str:
+    """Return deterministic 150-300 character progress text for update SEQ."""
+    base = (
+        f"[u{seq:04d}] {tool_id} (turn {turn:02d}, ctx {30 + seq % 41}%): "
+        f"{activity}; scanned {seq * 7 % 500} synthetic files, "
+        f"{seq * 13 % 97} candidate matches. "
+    )
+    target = 150 + (seq * 37) % 151
+    text = base
+    filler = f"progress-{seq % 10}-"
+    while len(text) < target:
+        text += filler
+    return text[:target]
+
+
+def run_details(tool_id: str, tool_index: int, turn: int, seq: int, status: str) -> JsonDict:
+    return {
+        "run": {
+            "episodeId": f"episode-{tool_index:02d}-{turn:03d}",
+            "sessionId": tool_id,
+            "agent": "default",
+            "status": status,
+            "turnCount": turn,
+            "lastActivityAt": iso_timestamp(seq * 1000),
+            "activity": ACTIVITIES[seq % len(ACTIVITIES)],
+            "activityLog": f"logs/{tool_id}.subagents.md",
+            "children": [],
+        }
+    }
+
+
+def final_result_text(tool_id: str, tool_index: int, turns: int) -> str:
+    return (
+        f"STORM-FINAL-RESULT {tool_id}\n"
+        f"Subagent finished after {turns} synthetic turns.\n"
+        f"Summary: investigated synthetic area {tool_index}; all checks passed."
+    )
+
+
+def run_scenario(config: JsonDict, log_file: Path | None) -> None:
+    """Emit the fill phase, then the storm phase, then end the turn."""
+    updates = int(config["updates"])
+    tools = storm_tool_ids(int(config["parallel_tools"]))
+    rng = random.Random(int(config["seed"]))
+    delays = gap_schedule(updates, float(config["gap_scale"]), rng)
+    emitted = {"tool_execution_start": 0, "tool_execution_update": 0,
+               "tool_execution_end": 0}
+
+    write_json({"type": "agent_start"})
+
+    for block_index, tool in enumerate(fill_plan(config)):
+        emit_fill_block(block_index, tool, int(config["fill_output_lines"]))
+        emitted["tool_execution_start"] += 1
+        emitted["tool_execution_end"] += 1
+        time.sleep(0.002)
+
+    # Storm: parallel subagent tool calls in one assistant message.
+    tool_calls = [
+        {
+            "type": "toolCall",
+            "id": tool_id,
+            "name": "subagent",
+            "arguments": {
+                "task": f"Investigate synthetic area {index} and report a summary."
+            },
+        }
+        for index, tool_id in enumerate(tools)
+    ]
+    message: JsonDict = {"role": "assistant", "content": tool_calls}
+    write_json({"type": "message_start", "message": message})
+    for index, call in enumerate(tool_calls):
+        write_json(
+            {
+                "type": "message_update",
+                "message": message,
+                "assistantMessageEvent": {"type": "toolcall_start", "contentIndex": index},
+            }
+        )
+        write_json(
+            {
+                "type": "message_update",
+                "message": message,
+                "assistantMessageEvent": {
+                    "type": "toolcall_delta",
+                    "contentIndex": index,
+                    "delta": json.dumps(call["arguments"]),
+                },
+            }
+        )
+        write_json(
+            {
+                "type": "tool_execution_start",
+                "toolCallId": call["id"],
+                "toolName": "subagent",
+                "args": call["arguments"],
+            }
+        )
+        emitted["tool_execution_start"] += 1
+
+    per_tool_updates = {tool_id: 0 for tool_id in tools}
+    for seq, delay in enumerate(delays):
+        time.sleep(delay)
+        tool_index = seq % len(tools)
+        tool_id = tools[tool_index]
+        per_tool_updates[tool_id] += 1
+        turn = per_tool_updates[tool_id] // 8 + 1
+        activity = ACTIVITIES[seq % len(ACTIVITIES)]
+        write_json(
+            {
+                "type": "tool_execution_update",
+                "toolCallId": tool_id,
+                "toolName": "subagent",
+                "args": {
+                    "task": f"Investigate synthetic area {tool_index} and report a summary."
+                },
+                "partialResult": {
+                    "content": [
+                        {"type": "text", "text": progress_text(seq, tool_id, turn, activity)}
+                    ],
+                    "details": run_details(tool_id, tool_index, turn, seq, "running"),
+                },
+            }
+        )
+        emitted["tool_execution_update"] += 1
+
+    for index, call in enumerate(tool_calls):
+        tool_id = call["id"]
+        turns = per_tool_updates[tool_id] // 8 + 1
+        write_json(
+            {
+                "type": "tool_execution_end",
+                "toolCallId": tool_id,
+                "toolName": "subagent",
+                "result": tool_result(
+                    final_result_text(tool_id, index, turns),
+                    details=run_details(tool_id, index, turns, updates, "done"),
+                ),
+                "isError": False,
+            }
+        )
+        emitted["tool_execution_end"] += 1
+    write_json({"type": "message_end", "message": message})
+    write_json({"type": "agent_end", "messages": [message]})
+    log_line(log_file, {"event": "storm-complete", "emitted": emitted})
+
+
+def parse_args(argv: list[str]) -> tuple[argparse.Namespace, Path | None]:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", default="rpc")
+    parser.add_argument("--approve", action="store_true")
+    parser.add_argument("--no-approve", action="store_true")
+    parser.add_argument("--size", choices=("full", "smoke"), default=None)
+    parser.add_argument("--log-file")
+    parser.add_argument("--fill-bash", type=int)
+    parser.add_argument("--fill-read", type=int)
+    parser.add_argument("--fill-write", type=int)
+    parser.add_argument("--fill-edit", type=int)
+    parser.add_argument("--fill-output-lines", type=int)
+    parser.add_argument("--updates", type=int)
+    parser.add_argument("--parallel-tools", type=int)
+    parser.add_argument("--gap-scale", type=float)
+    parser.add_argument("--seed", type=int)
+    args = parser.parse_args(argv)
+    log_file = Path(args.log_file) if args.log_file else None
+    return args, log_file
+
+
+def resolve_config(args: argparse.Namespace) -> JsonDict:
+    size = args.size or os_environ_get("PI_TU_BENCH_SIZE") or "full"
+    defaults = dict(SMOKE_DEFAULTS if size == "smoke" else FULL_DEFAULTS)
+    config: JsonDict = {
+        "fill_bash": env_int("PI_TU_BENCH_FILL_BASH", int(defaults["fill_bash"])),
+        "fill_read": env_int("PI_TU_BENCH_FILL_READ", int(defaults["fill_read"])),
+        "fill_write": env_int("PI_TU_BENCH_FILL_WRITE", int(defaults["fill_write"])),
+        "fill_edit": env_int("PI_TU_BENCH_FILL_EDIT", int(defaults["fill_edit"])),
+        "fill_output_lines": env_int(
+            "PI_TU_BENCH_FILL_OUTPUT_LINES", int(defaults["fill_output_lines"])
+        ),
+        "updates": env_int("PI_TU_BENCH_UPDATES", int(defaults["updates"])),
+        "parallel_tools": env_int(
+            "PI_TU_BENCH_PARALLEL_TOOLS", int(defaults["parallel_tools"])
+        ),
+        "gap_scale": env_float("PI_TU_BENCH_GAP_SCALE", float(defaults["gap_scale"])),
+        "seed": env_int("PI_TU_BENCH_SEED", int(defaults["seed"])),
+    }
+    overrides = {
+        "fill_bash": args.fill_bash,
+        "fill_read": args.fill_read,
+        "fill_write": args.fill_write,
+        "fill_edit": args.fill_edit,
+        "fill_output_lines": args.fill_output_lines,
+        "updates": args.updates,
+        "parallel_tools": args.parallel_tools,
+        "gap_scale": args.gap_scale,
+        "seed": args.seed,
+    }
+    for key, value in overrides.items():
+        if value is not None:
+            config[key] = value
+    return config
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    if raw_argv == ["--version"]:
+        print("0.79.1")
+        return 0
+
+    args, log_file = parse_args([a for a in raw_argv if a != "--version"])
+    config = resolve_config(args)
+    log_line(log_file, {"event": "fake-pi-start", "config": {k: v for k, v in config.items()}})
+
+    storm_thread: threading.Thread | None = None
+    for raw in sys.stdin.buffer:
+        line = raw.decode("utf-8", "replace").strip()
+        if not line:
+            continue
+        try:
+            command = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        command_type = command.get("type")
+        log_line(log_file, {"direction": "in", "command": command_type, "id": command.get("id")})
+        if command_type == "get_state":
+            respond(command, data=state_rpc())
+        elif command_type == "get_commands":
+            respond(command, data={"commands": []})
+        elif command_type == "get_session_stats":
+            respond(command, data=stats_rpc())
+        elif command_type == "get_fork_messages":
+            respond(command, data={"messages": []})
+        elif command_type == "get_last_assistant_text":
+            respond(command, data={"text": ""})
+        elif command_type == "prompt":
+            respond(command)
+            storm_thread = threading.Thread(
+                target=run_scenario, args=(config, log_file), daemon=True
+            )
+            storm_thread.start()
+        elif command_type in ("abort", "steer", "set_thinking_level"):
+            respond(command)
+        elif command_type == "new_session":
+            respond(command, data={"cancelled": False})
+        else:
+            response: JsonDict = {
+                "type": "response",
+                "command": command_type,
+                "success": False,
+                "error": f"unsupported: {command_type}",
+            }
+            if "id" in command:
+                response["id"] = command["id"]
+            write_json(response)
+    # stdin closed (session teardown): let an in-flight storm finish writing
+    # before the interpreter exits and flushes stdout.
+    if storm_thread is not None:
+        storm_thread.join()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/pi-coding-agent-tool-update-bench.el
+++ b/bench/pi-coding-agent-tool-update-bench.el
@@ -1,0 +1,901 @@
+;;; pi-coding-agent-tool-update-bench.el --- Tool-update storm benchmarks -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Daniel Nouri
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Deterministic tool_execution_update storm benchmarks for pi-coding-agent.
+;; A real session backed by `bench/fake-pi-tool-update-storm.py' renders a
+;; synthetic long-session fill phase and then a burst-patterned storm of
+;; subagent progress updates.  The harness measures how the stock frontend
+;; copes: per-event handling time via around-advice on
+;; `pi-coding-agent--handle-display-event', and user-perceived main-thread
+;; blocking via a 50 ms probe timer's lateness, and tool block re-render
+;; counts via advice on `pi-coding-agent--tool-block-replace-body' and
+;; `pi-coding-agent--display-tool-end' (the environment-independent
+;; coalescing metric).  All content is synthetic; no private session files
+;; are read.
+;;
+;; Run with:
+;;
+;;   make bench-tool-update            # GUI via xvfb, primary lane
+;;   make bench-tool-update-batch      # --batch, secondary lane
+;;   make bench-tool-update-smoke      # cheap correctness smoke
+;;
+;; or directly through `bench/run-tool-update-bench.sh'.
+;;
+;; The primary lane is GUI/xvfb because the measured cost is dominated by
+;; buffer mutation plus redisplay/fontification, which batch mode cannot
+;; reproduce.  Batch numbers are useful for CI trend artifacts.  The run
+;; fails on correctness violations (lost or duplicated tool blocks and
+;; events), not on timing thresholds.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'json)
+(require 'seq)
+(require 'subr-x)
+
+(defconst pi-coding-agent-tu-bench-repo-root
+  (file-name-as-directory
+   (expand-file-name ".."
+                     (file-name-directory
+                      (or load-file-name buffer-file-name default-directory))))
+  "Repository root containing the tool-update benchmark files.")
+
+(add-to-list 'load-path pi-coding-agent-tu-bench-repo-root)
+(require 'pi-coding-agent)
+
+(defun pi-coding-agent-tu-bench--env (name default)
+  "Return environment variable NAME, or DEFAULT when it is unset or empty."
+  (let ((value (getenv name)))
+    (if (and value (not (string-empty-p value))) value default)))
+
+(defun pi-coding-agent-tu-bench--env-int (name default)
+  "Return environment variable NAME as an integer, or DEFAULT."
+  (string-to-number (pi-coding-agent-tu-bench--env
+                     name (number-to-string default))))
+
+(defun pi-coding-agent-tu-bench--env-float (name default)
+  "Return environment variable NAME as a float, or DEFAULT."
+  (string-to-number (pi-coding-agent-tu-bench--env
+                     name (number-to-string default))))
+
+(defun pi-coding-agent-tu-bench--truthy-env-p (name default)
+  "Return non-nil when environment variable NAME is truthy.
+DEFAULT is used when NAME is unset."
+  (let ((value (downcase (pi-coding-agent-tu-bench--env name default))))
+    (and (member value '("1" "true" "yes" "on")) t)))
+
+(defun pi-coding-agent-tu-bench--json-bool (value)
+  "Return VALUE encoded as a JSON boolean sentinel."
+  (if value t :json-false))
+
+(defvar pi-coding-agent-tu-bench-scenario
+  (pi-coding-agent-tu-bench--env "PI_TU_BENCH_SCENARIO" "standalone")
+  "Scenario label written into tool-update benchmark artifacts.")
+
+(defvar pi-coding-agent-tu-bench-iteration
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_ITERATION" 1)
+  "Iteration number written into tool-update benchmark artifacts.")
+
+(defvar pi-coding-agent-tu-bench-fill-bash
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_FILL_BASH" 58)
+  "Number of completed bash tool executions in the synthetic fill phase.")
+
+(defvar pi-coding-agent-tu-bench-fill-read
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_FILL_READ" 5)
+  "Number of completed read tool executions in the synthetic fill phase.")
+
+(defvar pi-coding-agent-tu-bench-fill-write
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_FILL_WRITE" 2)
+  "Number of completed write tool executions in the synthetic fill phase.")
+
+(defvar pi-coding-agent-tu-bench-fill-edit
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_FILL_EDIT" 1)
+  "Number of completed edit tool executions in the synthetic fill phase.")
+
+(defvar pi-coding-agent-tu-bench-fill-output-lines
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_FILL_OUTPUT_LINES" 20)
+  "Number of synthetic output lines per fill phase tool result.")
+
+(defvar pi-coding-agent-tu-bench-updates
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_UPDATES" 400)
+  "Number of storm phase tool_execution_update events.")
+
+(defvar pi-coding-agent-tu-bench-parallel-tools
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_PARALLEL_TOOLS" 3)
+  "Number of parallel subagent tool executions in the storm phase.")
+
+(defvar pi-coding-agent-tu-bench-gap-scale
+  (pi-coding-agent-tu-bench--env-float "PI_TU_BENCH_GAP_SCALE" 1.0)
+  "Gap scale factor applied to storm pauses; recorded for artifacts only.
+The fake backend applies the scale when scheduling events.")
+
+(defvar pi-coding-agent-tu-bench-seed
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_SEED" 20240817)
+  "PRNG seed for the fake backend's gap pattern; recorded for artifacts.")
+
+(defvar pi-coding-agent-tu-bench-timeout-seconds
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_TIMEOUT_SECONDS" 240)
+  "Timeout in seconds for waiting on the storm to settle.")
+
+(defvar pi-coding-agent-tu-bench-display-buffers
+  (pi-coding-agent-tu-bench--truthy-env-p "PI_TU_BENCH_DISPLAY" "0")
+  "Whether GUI benchmark runs should display chat and input windows.")
+
+(defvar pi-coding-agent-tu-bench-probe-interval
+  0.05
+  "Probe timer interval in seconds for measuring main thread blocking.")
+
+(defvar pi-coding-agent-tu-bench-out-dir
+  (file-name-as-directory
+   (expand-file-name (pi-coding-agent-tu-bench--env
+                      "PI_TU_BENCH_OUT_DIR"
+                      "tmp/tool-update-bench/standalone")
+                     pi-coding-agent-tu-bench-repo-root))
+  "Output directory for one tool-update benchmark iteration.")
+
+(defvar pi-coding-agent-tu-bench-runner-out-dir
+  (file-name-as-directory
+   (expand-file-name (pi-coding-agent-tu-bench--env
+                      "PI_TU_BENCH_RUNNER_OUT_DIR"
+                      pi-coding-agent-tu-bench-out-dir)
+                     pi-coding-agent-tu-bench-repo-root))
+  "Top-level runner output directory for reproduction commands.")
+
+(defvar pi-coding-agent-tu-bench-fake-pi
+  (expand-file-name "bench/fake-pi-tool-update-storm.py"
+                    pi-coding-agent-tu-bench-repo-root)
+  "Fake pi RPC executable used by tool-update benchmark runs.")
+
+(defvar pi-coding-agent-tu-bench-fake-log
+  (expand-file-name "fake-pi.jsonl" pi-coding-agent-tu-bench-out-dir)
+  "Content-free fake RPC log path for one benchmark run.")
+
+(defvar pi-coding-agent-tu-bench-result-file
+  (expand-file-name "result.json" pi-coding-agent-tu-bench-out-dir)
+  "JSON result artifact path for one benchmark run.")
+
+(defvar pi-coding-agent-tu-bench-report-file
+  (expand-file-name "report.md" pi-coding-agent-tu-bench-out-dir)
+  "Markdown report artifact path for one benchmark run.")
+
+(defvar pi-coding-agent-tu-bench-times-file
+  (expand-file-name "times.tsv" pi-coding-agent-tu-bench-out-dir)
+  "Per-event-type timing artifact path for one benchmark run.")
+
+(defvar pi-coding-agent-tu-bench--event-log nil
+  "List of (TYPE . ELAPSED-MS) entries for handled display events.")
+
+(defvar pi-coding-agent-tu-bench--prompt-time nil
+  "Float time when the storm prompt was sent.")
+
+(defvar pi-coding-agent-tu-bench--agent-end-time nil
+  "Float time when the agent_end event finished handling, or nil.")
+
+(defvar pi-coding-agent-tu-bench--probe-expected nil
+  "Float time the next probe firing was expected, or nil.")
+
+(defvar pi-coding-agent-tu-bench--probe-lateness nil
+  "List of probe firing lateness values in seconds.")
+
+(defvar pi-coding-agent-tu-bench--probe-timer nil
+  "The probe timer object, or nil.")
+
+(defvar pi-coding-agent-tu-bench--render-log nil
+  "Hash table of render operation metrics.
+Keys are \"operation\\ttool-call-id\" strings; values are (COUNT TOTAL-MS
+MAX-MS) lists.  This is the environment-independent coalescing metric: it
+counts how often the frontend re-renders tool block bodies, independent of
+how expensive each render is on the host.")
+
+(defun pi-coding-agent-tu-bench--around-handle-event (orig event)
+  "Around advice recording handling time for display EVENT.
+Calls ORIG with EVENT and appends to the benchmark event log."
+  (let ((start (float-time)))
+    (prog1 (funcall orig event)
+      (let ((type (or (plist-get event :type) "unknown")))
+        (push (cons type (* 1000.0 (- (float-time) start)))
+              pi-coding-agent-tu-bench--event-log)
+        (when (equal type "agent_end")
+          (setq pi-coding-agent-tu-bench--agent-end-time (float-time)))))))
+
+(defun pi-coding-agent-tu-bench--install-advice ()
+  "Install the per-event timing and render counting advice."
+  (advice-add 'pi-coding-agent--handle-display-event
+              :around #'pi-coding-agent-tu-bench--around-handle-event)
+  (advice-add 'pi-coding-agent--tool-block-replace-body
+              :around #'pi-coding-agent-tu-bench--around-replace-body)
+  (advice-add 'pi-coding-agent--display-tool-end
+              :around #'pi-coding-agent-tu-bench--around-display-tool-end))
+
+(defun pi-coding-agent-tu-bench--remove-advice ()
+  "Remove all benchmark advice."
+  (advice-remove 'pi-coding-agent--handle-display-event
+                 #'pi-coding-agent-tu-bench--around-handle-event)
+  (advice-remove 'pi-coding-agent--tool-block-replace-body
+                 #'pi-coding-agent-tu-bench--around-replace-body)
+  (advice-remove 'pi-coding-agent--display-tool-end
+                 #'pi-coding-agent-tu-bench--around-display-tool-end))
+
+(defun pi-coding-agent-tu-bench--record-render (operation tool-call-id
+                                                          elapsed-ms)
+  "Record one OPERATION render for TOOL-CALL-ID taking ELAPSED-MS."
+  (unless (hash-table-p pi-coding-agent-tu-bench--render-log)
+    (setq pi-coding-agent-tu-bench--render-log (make-hash-table :test 'equal)))
+  (let* ((key (format "%s\t%s" operation (or tool-call-id "(unkeyed)")))
+         (row (gethash key pi-coding-agent-tu-bench--render-log)))
+    (if row
+        (progn
+          (cl-incf (car row))
+          (cl-incf (cadr row) elapsed-ms)
+          (setf (caddr row) (max (caddr row) elapsed-ms)))
+      (puthash key (list 1 elapsed-ms elapsed-ms)
+               pi-coding-agent-tu-bench--render-log))))
+
+(defun pi-coding-agent-tu-bench--around-replace-body (orig block &rest args)
+  "Around advice counting and timing a body replacement for BLOCK.
+Calls ORIG with BLOCK and ARGS."
+  (let ((start (float-time)))
+    (prog1 (apply orig block args)
+      (pi-coding-agent-tu-bench--record-render
+       "replace-body"
+       (and block (pi-coding-agent--tool-block-tool-call-id block))
+       (* 1000.0 (- (float-time) start))))))
+
+(defun pi-coding-agent-tu-bench--around-display-tool-end (orig &rest args)
+  "Around advice counting and timing one tool end display.
+Calls ORIG with ARGS; the block comes from ARGS or the current block."
+  (let ((start (float-time))
+        (block (or (nth 5 args) (pi-coding-agent--current-tool-block))))
+    (prog1 (apply orig args)
+      (pi-coding-agent-tu-bench--record-render
+       "display-tool-end"
+       (and block (pi-coding-agent--tool-block-tool-call-id block))
+       (* 1000.0 (- (float-time) start))))))
+
+(defun pi-coding-agent-tu-bench--render-rows ()
+  "Return render metric rows sorted by operation, then descending count.
+Each row is a plist with :operation :toolCallId :count :totalMs :meanMs
+and :maxMs."
+  (let (rows)
+    (maphash
+     (lambda (key cell)
+       (let ((parts (split-string key "\t")))
+         (push (list :operation (car parts)
+                     :toolCallId (cadr parts)
+                     :count (car cell)
+                     :totalMs (cadr cell)
+                     :meanMs (/ (cadr cell) (car cell))
+                     :maxMs (caddr cell))
+               rows)))
+     pi-coding-agent-tu-bench--render-log)
+    (sort rows (lambda (a b)
+                 (if (equal (plist-get a :operation) (plist-get b :operation))
+                     (> (plist-get a :count) (plist-get b :count))
+                   (string< (plist-get a :operation)
+                            (plist-get b :operation)))))))
+
+(defun pi-coding-agent-tu-bench--render-count (operation tool-call-id)
+  "Return how often OPERATION was recorded for TOOL-CALL-ID."
+  (let ((row (and (hash-table-p pi-coding-agent-tu-bench--render-log)
+                  (gethash (format "%s\t%s" operation tool-call-id)
+                           pi-coding-agent-tu-bench--render-log))))
+    (if row (car row) 0)))
+
+(defun pi-coding-agent-tu-bench--render-total (operation)
+  "Return the total number of recorded OPERATION renders."
+  (cl-loop for row in (pi-coding-agent-tu-bench--render-rows)
+           when (equal (plist-get row :operation) operation)
+           sum (plist-get row :count)))
+
+(defun pi-coding-agent-tu-bench--render-operation-json (operation)
+  "Return aggregate and per-tool-call-id metrics for OPERATION as a plist."
+  (let ((rows (seq-filter (lambda (row)
+                            (equal (plist-get row :operation) operation))
+                          (pi-coding-agent-tu-bench--render-rows))))
+    (list :total (cl-loop for row in rows sum (plist-get row :count))
+          :totalMs (cl-loop for row in rows sum (plist-get row :totalMs))
+          :maxMs (if rows
+                     (apply #'max (mapcar (lambda (row)
+                                            (plist-get row :maxMs))
+                                          rows))
+                   0.0)
+          :perToolCallId (mapcar (lambda (row)
+                                   (cons (plist-get row :toolCallId)
+                                         (plist-get row :count)))
+                                 rows))))
+
+(defun pi-coding-agent-tu-bench--probe-tick ()
+  "Record how late this probe firing is relative to its expected time."
+  (let ((now (float-time)))
+    (when pi-coding-agent-tu-bench--probe-expected
+      (push (max 0.0 (- now pi-coding-agent-tu-bench--probe-expected))
+            pi-coding-agent-tu-bench--probe-lateness))
+    (setq pi-coding-agent-tu-bench--probe-expected
+          (+ now pi-coding-agent-tu-bench-probe-interval))))
+
+(defun pi-coding-agent-tu-bench--start-probe ()
+  "Start the probe timer and reset its state."
+  (setq pi-coding-agent-tu-bench--probe-expected nil
+        pi-coding-agent-tu-bench--probe-lateness nil)
+  (setq pi-coding-agent-tu-bench--probe-timer
+        (run-with-timer 0 pi-coding-agent-tu-bench-probe-interval
+                        #'pi-coding-agent-tu-bench--probe-tick)))
+
+(defun pi-coding-agent-tu-bench--stop-probe ()
+  "Cancel the probe timer when it is running."
+  (when pi-coding-agent-tu-bench--probe-timer
+    (cancel-timer pi-coding-agent-tu-bench--probe-timer)
+    (setq pi-coding-agent-tu-bench--probe-timer nil)))
+
+(defun pi-coding-agent-tu-bench--event-count (type)
+  "Return the number of handled display events of TYPE."
+  (cl-count type pi-coding-agent-tu-bench--event-log
+            :key #'car :test #'equal))
+
+(defun pi-coding-agent-tu-bench--event-stats ()
+  "Return per-event-type handling stats sorted by descending total ms.
+Each row is a plist with :type :count :totalMs :meanMs and :maxMs."
+  (let ((table (make-hash-table :test 'equal))
+        (rows nil))
+    (dolist (entry pi-coding-agent-tu-bench--event-log)
+      (let ((cell (gethash (car entry) table)))
+        (if cell
+            (progn
+              (cl-incf (car cell))
+              (cl-incf (cadr cell) (cdr entry))
+              (setf (caddr cell) (max (caddr cell) (cdr entry))))
+          (puthash (car entry) (list 1 (cdr entry) (cdr entry)) table))))
+    (maphash (lambda (type cell)
+               (push (list :type type
+                           :count (car cell)
+                           :totalMs (cadr cell)
+                           :meanMs (/ (cadr cell) (car cell))
+                           :maxMs (caddr cell))
+                     rows))
+             table)
+    (sort rows (lambda (a b) (> (plist-get a :totalMs)
+                                (plist-get b :totalMs))))))
+
+(defun pi-coding-agent-tu-bench--percentile (samples p)
+  "Return the P percentile of SAMPLES as a fraction between 0 and 1."
+  (let* ((sorted (sort (copy-sequence samples) #'<))
+         (n (length sorted)))
+    (if (zerop n)
+        0.0
+      (nth (min (1- n) (floor (* p n))) sorted))))
+
+(defun pi-coding-agent-tu-bench--probe-stats ()
+  "Return probe timer statistics as a plist of millisecond values."
+  (let ((lateness pi-coding-agent-tu-bench--probe-lateness))
+    (list :intervalMs (* 1000.0 pi-coding-agent-tu-bench-probe-interval)
+          :fires (length lateness)
+          :p50Ms (* 1000.0 (pi-coding-agent-tu-bench--percentile lateness 0.50))
+          :p95Ms (* 1000.0 (pi-coding-agent-tu-bench--percentile lateness 0.95))
+          :maxMs (if lateness
+                     (* 1000.0 (cl-reduce #'max lateness))
+                   0.0)
+          :over100Ms (cl-count-if (lambda (x) (> x 0.1)) lateness)
+          :over250Ms (cl-count-if (lambda (x) (> x 0.25)) lateness))))
+
+(defun pi-coding-agent-tu-bench--storm-tool-ids ()
+  "Return the expected storm phase subagent tool call IDs."
+  (cl-loop for index below pi-coding-agent-tu-bench-parallel-tools
+           collect (format "call-storm-%02d" index)))
+
+(defun pi-coding-agent-tu-bench--fill-tool-count ()
+  "Return the total number of fill phase tool executions."
+  (+ pi-coding-agent-tu-bench-fill-bash
+     pi-coding-agent-tu-bench-fill-read
+     pi-coding-agent-tu-bench-fill-write
+     pi-coding-agent-tu-bench-fill-edit))
+
+(defun pi-coding-agent-tu-bench--wait-until (predicate timeout)
+  "Wait for PREDICATE to become non-nil, or TIMEOUT seconds to elapse."
+  (let ((start (float-time))
+        result)
+    (while (and (not (setq result (funcall predicate)))
+                (< (- (float-time) start) timeout))
+      (accept-process-output nil 0.01)
+      (when (and pi-coding-agent-tu-bench-display-buffers (not noninteractive))
+        (redisplay t)))
+    result))
+
+(defun pi-coding-agent-tu-bench--pending-requests-count (proc)
+  "Return the number of pending RPC requests for PROC."
+  (let ((pending (and (processp proc)
+                      (process-get proc 'pi-coding-agent-pending-requests))))
+    (if (hash-table-p pending) (hash-table-count pending) 0)))
+
+(defun pi-coding-agent-tu-bench--count-occurrences (buffer text)
+  "Return the number of times TEXT occurs in BUFFER."
+  (if (not (buffer-live-p buffer))
+      0
+    (with-current-buffer buffer
+      (save-excursion
+        (goto-char (point-min))
+        (let ((count 0))
+          (while (search-forward text nil t)
+            (setq count (1+ count)))
+          count)))))
+
+(defun pi-coding-agent-tu-bench--tool-block-overlay-count (buffer tool-call-id)
+  "Return the number of tool block overlays in BUFFER for TOOL-CALL-ID."
+  (if (not (buffer-live-p buffer))
+      0
+    (with-current-buffer buffer
+      (cl-count-if
+       (lambda (ov)
+         (when-let* ((record (and (overlay-get ov 'pi-coding-agent-tool-block)
+                                  (overlay-get
+                                   ov 'pi-coding-agent-tool-block-record))))
+           (equal (pi-coding-agent--tool-block-tool-call-id record)
+                  tool-call-id)))
+       (overlays-in (point-min) (point-max))))))
+
+(defun pi-coding-agent-tu-bench--live-tool-block-count (buffer)
+  "Return the number of entries in BUFFER's live tool block registry."
+  (if (not (buffer-live-p buffer))
+      -1
+    (with-current-buffer buffer
+      (if (hash-table-p pi-coding-agent--live-tool-blocks)
+          (hash-table-count pi-coding-agent--live-tool-blocks)
+        0))))
+
+(defun pi-coding-agent-tu-bench--check (name ok detail)
+  "Return a correctness check entry for NAME with OK flag and DETAIL text."
+  (list :name name
+        :ok (pi-coding-agent-tu-bench--json-bool ok)
+        :detail detail))
+
+(defun pi-coding-agent-tu-bench--collect-checks (chat-buf)
+  "Return correctness check entries for the settled run in CHAT-BUF.
+Every entry must have a true :ok for the benchmark run to pass."
+  (let* ((storm-ids (pi-coding-agent-tu-bench--storm-tool-ids))
+         (expected-executions (+ (pi-coding-agent-tu-bench--fill-tool-count)
+                                 pi-coding-agent-tu-bench-parallel-tools))
+         (start-count (pi-coding-agent-tu-bench--event-count
+                       "tool_execution_start"))
+         (end-count (pi-coding-agent-tu-bench--event-count "tool_execution_end"))
+         (update-count (pi-coding-agent-tu-bench--event-count
+                        "tool_execution_update"))
+         (checks nil))
+    (push (pi-coding-agent-tu-bench--check
+           "agent-end-received"
+           (and pi-coding-agent-tu-bench--agent-end-time t)
+           (if pi-coding-agent-tu-bench--agent-end-time
+               "agent_end handled"
+             "agent_end never handled"))
+          checks)
+    (push (pi-coding-agent-tu-bench--check
+           "tool-execution-start-count"
+           (= start-count expected-executions)
+           (format "expected %d, handled %d" expected-executions start-count))
+          checks)
+    (push (pi-coding-agent-tu-bench--check
+           "tool-execution-end-count"
+           (= end-count expected-executions)
+           (format "expected %d, handled %d" expected-executions end-count))
+          checks)
+    (push (pi-coding-agent-tu-bench--check
+           "tool-execution-update-count"
+           (= update-count pi-coding-agent-tu-bench-updates)
+           (format "expected %d, handled %d"
+                   pi-coding-agent-tu-bench-updates update-count))
+          checks)
+    (let ((bad-blocks
+           (seq-filter
+            (lambda (tool-call-id)
+              (/= 1 (pi-coding-agent-tu-bench--tool-block-overlay-count
+                     chat-buf tool-call-id)))
+            storm-ids)))
+      (push (pi-coding-agent-tu-bench--check
+             "subagent-blocks-present-once"
+             (null bad-blocks)
+             (if bad-blocks
+                 (format "ids without exactly one finalized block: %s"
+                         (string-join bad-blocks ", "))
+               (format "each of %d subagent blocks present exactly once"
+                       (length storm-ids))))
+            checks))
+    (let ((bad-texts
+           (seq-filter
+            (lambda (tool-call-id)
+              (/= 1 (pi-coding-agent-tu-bench--count-occurrences
+                     chat-buf (format "STORM-FINAL-RESULT %s" tool-call-id))))
+            storm-ids)))
+      (push (pi-coding-agent-tu-bench--check
+             "subagent-final-text-exactly-once"
+             (null bad-texts)
+             (if bad-texts
+                 (format "ids whose final text is not exactly once: %s"
+                         (string-join bad-texts ", "))
+               "every subagent final result text appears exactly once"))
+            checks))
+    (let ((live-count (pi-coding-agent-tu-bench--live-tool-block-count
+                       chat-buf)))
+      (push (pi-coding-agent-tu-bench--check
+             "no-live-tool-blocks-remain"
+             (= live-count 0)
+             (format "%d live tool block registry entries remain" live-count))
+            checks))
+    (nreverse checks)))
+
+(defun pi-coding-agent-tu-bench--cleanup-session (chat-buf)
+  "Kill CHAT-BUF, its input buffer, and their fake pi process."
+  (when (buffer-live-p chat-buf)
+    (let ((input-buf (buffer-local-value 'pi-coding-agent--input-buffer
+                                         chat-buf)))
+      (with-current-buffer chat-buf
+        (when (and (boundp 'pi-coding-agent--process)
+                   (processp pi-coding-agent--process)
+                   (process-live-p pi-coding-agent--process))
+          (set-process-query-on-exit-flag pi-coding-agent--process nil)
+          (delete-process pi-coding-agent--process)))
+      (kill-buffer chat-buf)
+      (when (buffer-live-p input-buf)
+        (kill-buffer input-buf)))))
+
+(defun pi-coding-agent-tu-bench--run-session ()
+  "Run one storm session and return a metrics plist.
+Sets up a fake-backed session in a temporary directory, sends one prompt,
+waits for agent_end, then collects buffer metrics and correctness checks."
+  (let* ((session-dir (make-temp-file
+                       (expand-file-name "session-"
+                                         pi-coding-agent-tu-bench-out-dir)
+                       t))
+         (chat-buf nil)
+         (ok nil)
+         (error-text nil)
+         (gc-before nil)
+         (gc-time-before nil)
+         (start nil))
+    (setq pi-coding-agent-executable
+          (list (or (executable-find "python3") (error "Python3 not found"))
+                pi-coding-agent-tu-bench-fake-pi))
+    (setq pi-coding-agent-extra-args
+          (list "--log-file" pi-coding-agent-tu-bench-fake-log))
+    ;; Never prompt about grammars or versions from a benchmark run.
+    (setq pi-coding-agent-essential-grammar-action 'warn)
+    (unwind-protect
+        (condition-case err
+            (progn
+              ;; Keep the asynchronous `pi --version' probe out of the run;
+              ;; it would spawn an extra fake process in the GUI lane.
+              (let ((pi-coding-agent--version-probe-delay 3600))
+                (setq chat-buf (pi-coding-agent--setup-session session-dir)))
+              (when (and pi-coding-agent-tu-bench-display-buffers
+                         (not noninteractive))
+                (pi-coding-agent--show-session-buffers
+                 chat-buf
+                 (buffer-local-value 'pi-coding-agent--input-buffer chat-buf))
+                (redisplay t))
+              (garbage-collect)
+              (setq gc-before gcs-done
+                    gc-time-before gc-elapsed
+                    start (float-time))
+              (pi-coding-agent-tu-bench--start-probe)
+              (setq pi-coding-agent-tu-bench--prompt-time (float-time))
+              (with-current-buffer chat-buf
+                (pi-coding-agent--prepare-and-send
+                 "run the synthetic tool update storm"))
+              (setq ok
+                    (pi-coding-agent-tu-bench--wait-until
+                     (lambda ()
+                       (let ((proc (and (buffer-live-p chat-buf)
+                                        (with-current-buffer chat-buf
+                                          pi-coding-agent--process))))
+                         (unless (and (processp proc) (process-live-p proc))
+                           (error "Fake pi process exited before the storm settled"))
+                         (and pi-coding-agent-tu-bench--agent-end-time
+                              (= 0 (pi-coding-agent-tu-bench--pending-requests-count
+                                    proc)))))
+                     pi-coding-agent-tu-bench-timeout-seconds))
+              (unless ok
+                (error "Timed out waiting for agent_end after %d seconds"
+                       pi-coding-agent-tu-bench-timeout-seconds)))
+          (error (setq error-text (error-message-string err))))
+      (pi-coding-agent-tu-bench--stop-probe))
+    (prog1
+        (list :ok (pi-coding-agent-tu-bench--json-bool ok)
+              :error error-text
+              :wallMs (when pi-coding-agent-tu-bench--agent-end-time
+                        (* 1000.0 (- pi-coding-agent-tu-bench--agent-end-time
+                                     pi-coding-agent-tu-bench--prompt-time)))
+              :seconds (and start (- (float-time) start))
+              :gcs (and gc-before (- gcs-done gc-before))
+              :gcSeconds (and gc-time-before (- gc-elapsed gc-time-before))
+              :bufferBytes (and (buffer-live-p chat-buf)
+                                (with-current-buffer chat-buf (buffer-size)))
+              :bufferLines (and (buffer-live-p chat-buf)
+                                (with-current-buffer chat-buf
+                                  (count-lines (point-min) (point-max))))
+              :overlays (and (buffer-live-p chat-buf)
+                             (with-current-buffer chat-buf
+                               (length (overlays-in (point-min) (point-max)))))
+              :checks (pi-coding-agent-tu-bench--collect-checks chat-buf))
+      (pi-coding-agent-tu-bench--cleanup-session chat-buf))))
+
+(defun pi-coding-agent-tu-bench--git-string (&rest args)
+  "Run git with ARGS in the repository root and return trimmed output."
+  (string-trim
+   (with-temp-buffer
+     (let ((default-directory pi-coding-agent-tu-bench-repo-root))
+       (if (zerop (apply #'process-file "git" nil t nil args))
+           (buffer-string)
+         "")))))
+
+(defun pi-coding-agent-tu-bench--workload-json ()
+  "Return the configured workload as a JSON-encodable plist."
+  (list :fillBash pi-coding-agent-tu-bench-fill-bash
+        :fillRead pi-coding-agent-tu-bench-fill-read
+        :fillWrite pi-coding-agent-tu-bench-fill-write
+        :fillEdit pi-coding-agent-tu-bench-fill-edit
+        :fillOutputLines pi-coding-agent-tu-bench-fill-output-lines
+        :updates pi-coding-agent-tu-bench-updates
+        :parallelTools pi-coding-agent-tu-bench-parallel-tools
+        :gapScale pi-coding-agent-tu-bench-gap-scale
+        :seed pi-coding-agent-tu-bench-seed))
+
+(defun pi-coding-agent-tu-bench--write-times-tsv ()
+  "Write event timing and render rows to `pi-coding-agent-tu-bench-times-file'."
+  (with-temp-file pi-coding-agent-tu-bench-times-file
+    (insert "series\tname\tcount\ttotal_ms\tmean_ms\tmax_ms\n")
+    (dolist (row (pi-coding-agent-tu-bench--event-stats))
+      (insert (format "event\t%s\t%d\t%.3f\t%.3f\t%.3f\n"
+                      (plist-get row :type)
+                      (plist-get row :count)
+                      (plist-get row :totalMs)
+                      (plist-get row :meanMs)
+                      (plist-get row :maxMs))))
+    (dolist (row (pi-coding-agent-tu-bench--render-rows))
+      (insert (format "render\t%s:%s\t%d\t%.3f\t%.3f\t%.3f\n"
+                      (plist-get row :operation)
+                      (plist-get row :toolCallId)
+                      (plist-get row :count)
+                      (plist-get row :totalMs)
+                      (plist-get row :meanMs)
+                      (plist-get row :maxMs))))))
+
+(defun pi-coding-agent-tu-bench--checks-json (entries)
+  "Encode correctness check ENTRIES as a JSON vector."
+  (vconcat
+   (mapcar (lambda (check)
+             (list :name (plist-get check :name)
+                   :ok (plist-get check :ok)
+                   :detail (plist-get check :detail)))
+           entries)))
+
+(defun pi-coding-agent-tu-bench--write-result-json (metrics)
+  "Write run METRICS to `pi-coding-agent-tu-bench-result-file'."
+  (let* ((dirty (not (string-empty-p
+                      (pi-coding-agent-tu-bench--git-string
+                       "status" "--porcelain" "--untracked-files=no"))))
+         (probe (pi-coding-agent-tu-bench--probe-stats))
+         (object
+          (list :scenario pi-coding-agent-tu-bench-scenario
+                :iteration pi-coding-agent-tu-bench-iteration
+                :commit (pi-coding-agent-tu-bench--git-string
+                         "rev-parse" "--short" "HEAD")
+                :dirty (pi-coding-agent-tu-bench--json-bool dirty)
+                :display (pi-coding-agent-tu-bench--json-bool
+                          pi-coding-agent-tu-bench-display-buffers)
+                :emacsVersion emacs-version
+                :markdownGrammar
+                (pi-coding-agent-tu-bench--json-bool
+                 (treesit-language-available-p 'markdown))
+                :workload (pi-coding-agent-tu-bench--workload-json)
+                :ok (plist-get metrics :ok)
+                :error (or (plist-get metrics :error) :json-null)
+                :wallMs (or (plist-get metrics :wallMs) :json-null)
+                :seconds (plist-get metrics :seconds)
+                :gcs (plist-get metrics :gcs)
+                :gcSeconds (plist-get metrics :gcSeconds)
+                :bufferBytes (plist-get metrics :bufferBytes)
+                :bufferLines (plist-get metrics :bufferLines)
+                :overlays (plist-get metrics :overlays)
+                :eventStats
+                (vconcat
+                 (mapcar (lambda (row)
+                           (list :type (plist-get row :type)
+                                 :count (plist-get row :count)
+                                 :totalMs (plist-get row :totalMs)
+                                 :meanMs (plist-get row :meanMs)
+                                 :maxMs (plist-get row :maxMs)))
+                         (pi-coding-agent-tu-bench--event-stats)))
+                :probe (list :intervalMs (plist-get probe :intervalMs)
+                             :fires (plist-get probe :fires)
+                             :p50Ms (plist-get probe :p50Ms)
+                             :p95Ms (plist-get probe :p95Ms)
+                             :maxMs (plist-get probe :maxMs)
+                             :over100Ms (plist-get probe :over100Ms)
+                             :over250Ms (plist-get probe :over250Ms)
+                             :latenessMs
+                             (vconcat
+                              (mapcar (lambda (x) (* 1000.0 x))
+                                      (nreverse
+                                       (copy-sequence
+                                        pi-coding-agent-tu-bench--probe-lateness)))))
+                :renders (list :replaceBody
+                               (pi-coding-agent-tu-bench--render-operation-json
+                                "replace-body")
+                               :displayToolEnd
+                               (pi-coding-agent-tu-bench--render-operation-json
+                                "display-tool-end"))
+                :checks (pi-coding-agent-tu-bench--checks-json
+                         (plist-get metrics :checks)))))
+    (with-temp-file pi-coding-agent-tu-bench-result-file
+      (insert (json-encode object) "\n"))))
+
+(defun pi-coding-agent-tu-bench--write-report (metrics run-ok)
+  "Write a Markdown report for METRICS; RUN-OK is the overall verdict."
+  (let ((dirty (not (string-empty-p
+                     (pi-coding-agent-tu-bench--git-string
+                      "status" "--porcelain" "--untracked-files=no"))))
+        (probe (pi-coding-agent-tu-bench--probe-stats)))
+    (with-temp-file pi-coding-agent-tu-bench-report-file
+      (insert "# Tool-update storm benchmark\n\n")
+      (insert "Synthetic deterministic workload only; no private session content is read or stored.\n\n")
+      (insert (format "- Verdict: `%s`\n" (if run-ok "pass" "FAIL")))
+      (insert (format "- Scenario: `%s`\n" pi-coding-agent-tu-bench-scenario))
+      (insert (format "- Iteration: `%d`\n" pi-coding-agent-tu-bench-iteration))
+      (insert (format "- Commit: `%s`%s\n"
+                      (pi-coding-agent-tu-bench--git-string
+                       "rev-parse" "--short" "HEAD")
+                      (if dirty " (dirty)" "")))
+      (insert (format "- Emacs: `%s`\n" emacs-version))
+      (insert (format "- Visible GUI buffers: `%s`\n"
+                      (if pi-coding-agent-tu-bench-display-buffers
+                          "yes" "no")))
+      (insert (format "- Markdown tree-sitter grammar: `%s`\n\n"
+                      (if (treesit-language-available-p 'markdown)
+                          "available" "MISSING")))
+      (insert "## Reproduction command shape\n\n")
+      (insert "```sh\n")
+      (insert (format "./bench/run-tool-update-bench.sh %s --scenario %s -c 1 --out-dir %s\n"
+                      (if pi-coding-agent-tu-bench-display-buffers
+                          "" "--batch")
+                      pi-coding-agent-tu-bench-scenario
+                      pi-coding-agent-tu-bench-runner-out-dir))
+      (insert "```\n\n")
+      (insert "## Workload\n\n")
+      (insert (format "- Fill: `%d` bash, `%d` read, `%d` write, `%d` edit completed tool executions x `%d` output lines\n"
+                      pi-coding-agent-tu-bench-fill-bash
+                      pi-coding-agent-tu-bench-fill-read
+                      pi-coding-agent-tu-bench-fill-write
+                      pi-coding-agent-tu-bench-fill-edit
+                      pi-coding-agent-tu-bench-fill-output-lines))
+      (insert (format "- Storm: `%d` updates across `%d` parallel subagent tools, gap scale `%.2f`, seed `%d`\n\n"
+                      pi-coding-agent-tu-bench-updates
+                      pi-coding-agent-tu-bench-parallel-tools
+                      pi-coding-agent-tu-bench-gap-scale
+                      pi-coding-agent-tu-bench-seed))
+      (insert "## Wall-clock and buffer metrics\n\n")
+      (insert (format "- Prompt to agent_end: `%s` ms\n"
+                      (if-let* ((wall (plist-get metrics :wallMs)))
+                          (format "%.0f" wall) "n/a")))
+      (insert (format "- Total run seconds: `%.3f`; GCs: `%s`; GC seconds: `%s`\n"
+                      (or (plist-get metrics :seconds) 0.0)
+                      (or (plist-get metrics :gcs) "n/a")
+                      (if-let* ((gcs (plist-get metrics :gcSeconds)))
+                          (format "%.3f" gcs) "n/a")))
+      (insert (format "- Chat buffer: `%s` chars, `%s` lines, `%s` overlays\n\n"
+                      (or (plist-get metrics :bufferBytes) "n/a")
+                      (or (plist-get metrics :bufferLines) "n/a")
+                      (or (plist-get metrics :overlays) "n/a")))
+      (insert "## Probe timer (main-thread blocking)\n\n")
+      (insert (format "- Interval: `%.0f` ms; fires: `%d`\n"
+                      (plist-get probe :intervalMs) (plist-get probe :fires)))
+      (insert (format "- Lateness p50: `%.1f` ms; p95: `%.1f` ms; max: `%.1f` ms\n"
+                      (plist-get probe :p50Ms)
+                      (plist-get probe :p95Ms)
+                      (plist-get probe :maxMs)))
+      (insert (format "- Fires >100 ms late: `%d`; >250 ms late: `%d`\n\n"
+                      (plist-get probe :over100Ms)
+                      (plist-get probe :over250Ms)))
+      (insert "## Per-event-type handling\n\n")
+      (insert "| event type | count | total ms | mean ms | max ms |\n")
+      (insert "|---|---:|---:|---:|---:|\n")
+      (dolist (row (pi-coding-agent-tu-bench--event-stats))
+        (insert (format "| `%s` | %d | %.1f | %.2f | %.1f |\n"
+                        (plist-get row :type)
+                        (plist-get row :count)
+                        (plist-get row :totalMs)
+                        (plist-get row :meanMs)
+                        (plist-get row :maxMs))))
+      (insert "\n## Tool block render counts\n\n")
+      (insert "Environment-independent coalescing metric: how often the frontend re-renders tool block bodies.  ")
+      (insert "The WP2 coalescing renderer should drop `replace-body` calls towards (storm seconds / 0.25) x parallel tools.\n\n")
+      (insert "| operation | total calls | total ms | mean ms | max ms |\n")
+      (insert "|---|---:|---:|---:|---:|\n")
+      (dolist (operation '("replace-body" "display-tool-end"))
+        (let ((aggregate (pi-coding-agent-tu-bench--render-operation-json
+                          operation))
+              (rows (seq-filter
+                     (lambda (row)
+                       (equal (plist-get row :operation) operation))
+                     (pi-coding-agent-tu-bench--render-rows))))
+          (insert (format "| `%s` | %d | %.1f | %.2f | %.1f |\n"
+                          operation
+                          (plist-get aggregate :total)
+                          (plist-get aggregate :totalMs)
+                          (if rows
+                              (/ (plist-get aggregate :totalMs)
+                                 (plist-get aggregate :total))
+                            0.0)
+                          (plist-get aggregate :maxMs)))))
+      (insert "\nPer storm tool call ID:\n\n")
+      (insert "| tool call id | replace-body calls | display-tool-end calls |\n")
+      (insert "|---|---:|---:|\n")
+      (dolist (tool-call-id (pi-coding-agent-tu-bench--storm-tool-ids))
+        (insert (format "| `%s` | %d | %d |\n"
+                        tool-call-id
+                        (pi-coding-agent-tu-bench--render-count
+                         "replace-body" tool-call-id)
+                        (pi-coding-agent-tu-bench--render-count
+                         "display-tool-end" tool-call-id))))
+      (insert "\nThe full per-tool-call-id breakdown (including fill phase ids) is in `result.json` and `times.tsv`.\n")
+      (insert "\n## Correctness checks\n\n")
+      (insert "| check | ok | detail |\n")
+      (insert "|---|---|---|\n")
+      (dolist (check (plist-get metrics :checks))
+        (insert (format "| `%s` | %s | %s |\n"
+                        (plist-get check :name)
+                        (if (eq (plist-get check :ok) t) "yes" "NO")
+                        (plist-get check :detail))))
+      (insert "\n## Raw artifacts\n\n")
+      (insert (format "- Result JSON: `%s`\n"
+                      pi-coding-agent-tu-bench-result-file))
+      (insert (format "- Timing TSV: `%s`\n"
+                      pi-coding-agent-tu-bench-times-file))
+      (insert (format "- Fake RPC log without content: `%s`\n"
+                      pi-coding-agent-tu-bench-fake-log)))))
+
+(defun pi-coding-agent-tu-bench--metrics-ok-p (metrics)
+  "Return non-nil when METRICS report a settled run with every check green."
+  (and (eq (plist-get metrics :ok) t)
+       (seq-every-p (lambda (check) (eq (plist-get check :ok) t))
+                    (plist-get metrics :checks))))
+
+;;;###autoload
+(defun pi-coding-agent-tu-bench-run ()
+  "Run one tool-update benchmark iteration and write artifacts.
+Return non-nil when the storm settled and all correctness checks passed.
+Timing thresholds are not enforced."
+  (when (and pi-coding-agent-tu-bench-display-buffers
+             (not noninteractive)
+             (not (display-graphic-p)))
+    (error "GUI benchmark lane requires a graphic display; use xvfb-run"))
+  (make-directory pi-coding-agent-tu-bench-out-dir t)
+  (ignore-errors (delete-file pi-coding-agent-tu-bench-fake-log))
+  (setq pi-coding-agent-tu-bench--event-log nil
+        pi-coding-agent-tu-bench--prompt-time nil
+        pi-coding-agent-tu-bench--agent-end-time nil
+        pi-coding-agent-tu-bench--probe-expected nil
+        pi-coding-agent-tu-bench--probe-lateness nil
+        pi-coding-agent-tu-bench--render-log (make-hash-table :test 'equal))
+  (pi-coding-agent-tu-bench--install-advice)
+  (unwind-protect
+      (let* ((metrics (pi-coding-agent-tu-bench--run-session))
+             (run-ok (pi-coding-agent-tu-bench--metrics-ok-p metrics)))
+        (pi-coding-agent-tu-bench--write-times-tsv)
+        (pi-coding-agent-tu-bench--write-result-json metrics)
+        (pi-coding-agent-tu-bench--write-report metrics run-ok)
+        (princ (format "Wrote %s\n" pi-coding-agent-tu-bench-result-file))
+        (princ (format "Wrote %s\n" pi-coding-agent-tu-bench-times-file))
+        (princ (format "Wrote %s\n" pi-coding-agent-tu-bench-report-file))
+        run-ok)
+    (pi-coding-agent-tu-bench--remove-advice)))
+
+(defun pi-coding-agent-tu-bench-run-batch ()
+  "Run one tool-update benchmark iteration in batch mode and exit."
+  (let ((standard-output #'external-debugging-output))
+    (kill-emacs (if (pi-coding-agent-tu-bench-run) 0 1))))
+
+(provide 'pi-coding-agent-tool-update-bench)
+;;; pi-coding-agent-tool-update-bench.el ends here

--- a/bench/run-tool-update-bench.sh
+++ b/bench/run-tool-update-bench.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# run-tool-update-bench.sh - Run pi-coding-agent tool-update storm benchmarks
+#
+# Usage:
+#   ./bench/run-tool-update-bench.sh                         # GUI via xvfb (primary lane)
+#   ./bench/run-tool-update-bench.sh --batch                 # batch mode (secondary lane)
+#   ./bench/run-tool-update-bench.sh -c 3                    # 3 repetitions per scenario
+#   ./bench/run-tool-update-bench.sh --scenario smoke -c 1   # cheap correctness smoke
+#   ./bench/run-tool-update-bench.sh --scenarios storm,smoke # comma-separated scenarios
+#   ./bench/run-tool-update-bench.sh --out-dir tmp/tu-bench  # write artifacts elsewhere
+#
+# The primary lane uses xvfb-run for GUI Emacs: the measured cost is buffer
+# mutation plus redisplay/fontification, which batch mode cannot reproduce.
+# Batch numbers are a faster secondary lane and CI artifact generator.
+# The script fails on correctness failures, not on timing thresholds.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BATCH=0
+REPS=3
+OUT_DIR="$PROJECT_DIR/tmp/tool-update-bench"
+SCENARIOS=()
+
+usage() {
+    sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_arg() {
+    local opt="$1"
+    if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: $opt requires an argument" >&2
+        usage >&2
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --batch) BATCH=1; shift ;;
+        -c|--count)
+            require_arg "$1" "${2:-}"
+            REPS="$2"
+            shift 2
+            ;;
+        --out-dir)
+            require_arg "$1" "${2:-}"
+            OUT_DIR="$2"
+            shift 2
+            ;;
+        --scenario)
+            require_arg "$1" "${2:-}"
+            SCENARIOS+=("$2")
+            shift 2
+            ;;
+        --scenarios)
+            require_arg "$1" "${2:-}"
+            IFS=',' read -r -a SCENARIOS <<< "$2"
+            shift 2
+            ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if ! [[ "$REPS" =~ ^[0-9]+$ ]] || [[ "$REPS" -lt 1 ]]; then
+    echo "ERROR: repetition count must be a positive integer: $REPS" >&2
+    exit 1
+fi
+
+if [[ ${#SCENARIOS[@]} -eq 0 ]]; then
+    SCENARIOS=(storm)
+fi
+
+case "$OUT_DIR" in
+    /*) ;;
+    *) OUT_DIR="$PWD/$OUT_DIR" ;;
+esac
+while [[ "$OUT_DIR" != "/" && "$OUT_DIR" == */ ]]; do
+    OUT_DIR="${OUT_DIR%/}"
+done
+if [[ -z "$OUT_DIR" || "$OUT_DIR" == "/" ]]; then
+    echo "ERROR: refusing unsafe output directory: $OUT_DIR" >&2
+    exit 1
+fi
+
+BENCH_MARKER="$OUT_DIR/.pi-coding-agent-tool-update-bench"
+if [[ -L "$OUT_DIR" ]]; then
+    echo "ERROR: refusing symlink output directory: $OUT_DIR" >&2
+    exit 1
+fi
+if [[ -e "$OUT_DIR" && ! -d "$OUT_DIR" ]]; then
+    echo "ERROR: refusing to replace non-directory output path: $OUT_DIR" >&2
+    exit 1
+fi
+if [[ -d "$OUT_DIR" && ! -f "$BENCH_MARKER" ]] && find "$OUT_DIR" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    echo "ERROR: refusing to remove non-empty output directory without benchmark marker: $OUT_DIR" >&2
+    exit 1
+fi
+
+scenario_env() {
+    case "$1" in
+        smoke)
+            cat <<'EOF'
+PI_TU_BENCH_FILL_BASH=6
+PI_TU_BENCH_FILL_READ=2
+PI_TU_BENCH_FILL_WRITE=1
+PI_TU_BENCH_FILL_EDIT=1
+PI_TU_BENCH_FILL_OUTPUT_LINES=8
+PI_TU_BENCH_UPDATES=30
+PI_TU_BENCH_PARALLEL_TOOLS=2
+PI_TU_BENCH_GAP_SCALE=0.2
+PI_TU_BENCH_SEED=20240817
+PI_TU_BENCH_TIMEOUT_SECONDS=60
+EOF
+            ;;
+        storm)
+            cat <<'EOF'
+PI_TU_BENCH_FILL_BASH=58
+PI_TU_BENCH_FILL_READ=5
+PI_TU_BENCH_FILL_WRITE=2
+PI_TU_BENCH_FILL_EDIT=1
+PI_TU_BENCH_FILL_OUTPUT_LINES=20
+PI_TU_BENCH_UPDATES=400
+PI_TU_BENCH_PARALLEL_TOOLS=3
+PI_TU_BENCH_GAP_SCALE=1.0
+PI_TU_BENCH_SEED=20240817
+PI_TU_BENCH_TIMEOUT_SECONDS=240
+EOF
+            ;;
+        *) echo "Unknown scenario: $1" >&2; exit 1 ;;
+    esac
+}
+
+for scenario in "${SCENARIOS[@]}"; do
+    scenario_env "$scenario" >/dev/null
+done
+
+EMACS_INIT=(
+    -Q -L "$PROJECT_DIR"
+    --eval "(setq inhibit-startup-screen t)"
+    --eval "(require 'package)"
+    --eval "(package-initialize)"
+    --eval "(setq load-path (cons (expand-file-name \"$PROJECT_DIR\") load-path))"
+    -l "$SCRIPT_DIR/pi-coding-agent-tool-update-bench.el"
+)
+
+printf '=== pi-coding-agent Tool-Update Storm Benchmarks ===\n'
+printf 'Project: %s\n' "$PROJECT_DIR"
+if [[ "$BATCH" = "1" ]]; then
+    MODE="batch"
+    printf 'Mode: batch (secondary lane), %s reps\n' "$REPS"
+else
+    MODE="gui-xvfb"
+    printf 'Mode: GUI via xvfb (primary lane), %s reps\n' "$REPS"
+    if ! command -v xvfb-run >/dev/null 2>&1; then
+        echo "ERROR: xvfb-run not found. Install xvfb or use --batch." >&2
+        exit 1
+    fi
+fi
+printf 'Scenarios: %s\n\n' "${SCENARIOS[*]}"
+
+rm -rf -- "$OUT_DIR"
+mkdir -p -- "$OUT_DIR"
+touch -- "$BENCH_MARKER"
+
+for scenario in "${SCENARIOS[@]}"; do
+    for ((iter = 1; iter <= REPS; iter++)); do
+        run_dir="$OUT_DIR/$scenario/iter-$(printf '%02d' "$iter")"
+        mkdir -p "$run_dir"
+        env_file="$run_dir/env"
+        scenario_env "$scenario" > "$env_file"
+        set -a
+        # shellcheck disable=SC1090
+        source "$env_file"
+        set +a
+        export PI_TU_BENCH_SCENARIO="$scenario"
+        export PI_TU_BENCH_ITERATION="$iter"
+        export PI_TU_BENCH_OUT_DIR="$run_dir"
+        export PI_TU_BENCH_RUNNER_OUT_DIR="$OUT_DIR"
+        export PI_TU_BENCH_DISPLAY=$([[ "$BATCH" = "1" ]] && echo 0 || echo 1)
+
+        printf '[%s/%s] running\n' "$scenario" "$iter"
+        if [[ "$BATCH" = "1" ]]; then
+            if ! emacs --batch "${EMACS_INIT[@]}" \
+                -f pi-coding-agent-tu-bench-run-batch \
+                > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
+                cat "$run_dir/stdout.log"
+                cat "$run_dir/stderr.log" >&2
+                exit 1
+            fi
+        else
+            if ! xvfb-run -a env GDK_BACKEND=x11 PATH="$PATH" \
+                emacs --geometry 120x40 "${EMACS_INIT[@]}" \
+                --eval "(let ((standard-output #'external-debugging-output)) (kill-emacs (if (pi-coding-agent-tu-bench-run) 0 1)))" \
+                </dev/null > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
+                cat "$run_dir/stdout.log"
+                cat "$run_dir/stderr.log" >&2
+                exit 1
+            fi
+        fi
+    done
+done
+
+python3 - "$OUT_DIR" "$MODE" "$REPS" "${SCENARIOS[*]}" <<'PY'
+from __future__ import annotations
+
+import csv
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+out = Path(sys.argv[1])
+mode = sys.argv[2]
+reps = sys.argv[3]
+scenarios_arg = sys.argv[4]
+rows: list[dict[str, Any]] = []
+
+for result_path in sorted(out.glob("*/iter-*/result.json")):
+    with result_path.open(encoding="utf-8") as handle:
+        result = json.load(handle)
+    probe = result.get("probe", {})
+    renders = result.get("renders", {})
+    update_stats = next(
+        (row for row in result.get("eventStats", [])
+         if row.get("type") == "tool_execution_update"),
+        {},
+    )
+    failed_checks = [
+        check.get("name")
+        for check in result.get("checks", [])
+        if check.get("ok") is not True
+    ]
+    rows.append({
+        "scenario": result.get("scenario"),
+        "iteration": result.get("iteration"),
+        "ok": result.get("ok") is True and not failed_checks,
+        "wallMs": result.get("wallMs"),
+        "updateMeanMs": update_stats.get("meanMs"),
+        "updateMaxMs": update_stats.get("maxMs"),
+        "replaceBodyCalls": renders.get("replaceBody", {}).get("total"),
+        "displayToolEndCalls": renders.get("displayToolEnd", {}).get("total"),
+        "probeP95Ms": probe.get("p95Ms"),
+        "probeMaxMs": probe.get("maxMs"),
+        "probeOver100Ms": probe.get("over100Ms"),
+        "probeOver250Ms": probe.get("over250Ms"),
+        "bufferBytes": result.get("bufferBytes"),
+        "overlays": result.get("overlays"),
+        "seconds": result.get("seconds"),
+        "failedChecks": ";".join(failed_checks),
+        "error": result.get("error") or "",
+        "resultPath": str(result_path),
+    })
+
+csv_path = out / "summary.csv"
+if rows:
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+summary_lines: list[str] = []
+summary_lines.append("# pi-coding-agent tool-update storm benchmark summary")
+summary_lines.append("")
+summary_lines.append("Synthetic deterministic workload only; no private session content is used.")
+summary_lines.append("")
+summary_lines.append(f"- Mode: `{mode}`")
+summary_lines.append(f"- Repetitions per scenario: `{reps}`")
+summary_lines.append(f"- Scenarios: `{scenarios_arg}`")
+summary_lines.append("- Timing thresholds: `none` (correctness failures still fail the run)")
+summary_lines.append("")
+summary_lines.append("| scenario | wall ms (median) | update mean ms | update max ms | replace-body calls | tool-end renders | probe p95 ms | probe max ms | >100 ms late | >250 ms late | successful runs |")
+summary_lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+
+print("\nsummary")
+print("scenario    wall-med  upd-mean  upd-max  replace-body  tool-end  probe-p95  probe-max  >100ms  >250ms  ok")
+print("--------    --------  --------  -------  ------------  --------  ---------  ---------  ------  ------  --")
+
+failed = [row for row in rows if not row["ok"]]
+for scenario in sorted({str(row["scenario"]) for row in rows}):
+    subset_all = [row for row in rows if str(row["scenario"]) == scenario]
+    subset = [row for row in subset_all if row["ok"]]
+    if not subset:
+        print(f"{scenario:<11} no successful runs")
+        summary_lines.append(f"| {scenario} | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0/{len(subset_all)} |")
+        continue
+    walls = sorted(float(row["wallMs"]) for row in subset)
+    upd_mean = statistics.median(float(row["updateMeanMs"]) for row in subset)
+    upd_max = max(float(row["updateMaxMs"]) for row in subset)
+    replace_body = max(int(row["replaceBodyCalls"]) for row in subset)
+    tool_end = max(int(row["displayToolEndCalls"]) for row in subset)
+    p95 = statistics.median(float(row["probeP95Ms"]) for row in subset)
+    pmax = max(float(row["probeMaxMs"]) for row in subset)
+    over100 = max(int(row["probeOver100Ms"]) for row in subset)
+    over250 = max(int(row["probeOver250Ms"]) for row in subset)
+    ok_count = f"{len(subset)}/{len(subset_all)}"
+    print(
+        f"{scenario:<11} {walls[len(walls)//2]:8.0f}  {upd_mean:8.2f}  {upd_max:7.1f}  "
+        f"{replace_body:12d}  {tool_end:8d}  {p95:9.1f}  {pmax:9.1f}  {over100:6d}  {over250:6d}  {ok_count}"
+    )
+    summary_lines.append(
+        f"| {scenario} | {statistics.median(walls):.0f} | {upd_mean:.2f} | {upd_max:.1f} | "
+        f"{replace_body} | {tool_end} | {p95:.1f} | {pmax:.1f} | {over100} | {over250} | {ok_count} |"
+    )
+
+summary_lines.append("")
+summary_lines.append("## Artifacts")
+summary_lines.append("")
+summary_lines.append(f"- CSV: `{csv_path}`")
+summary_lines.append("- Per-run reports: `SCENARIO/iter-NN/report.md`")
+summary_lines.append("- Per-run JSON: `SCENARIO/iter-NN/result.json`")
+summary_lines.append("- Per-run timing TSV: `SCENARIO/iter-NN/times.tsv`")
+
+if failed:
+    summary_lines.append("")
+    summary_lines.append("## Correctness failures")
+    summary_lines.append("")
+    for row in failed:
+        detail = row["error"] or f"failed checks: {row['failedChecks']}"
+        summary_lines.append(
+            f"- {row['scenario']} iter {row['iteration']}: {detail} ({row['resultPath']})"
+        )
+
+summary_path = out / "summary.md"
+summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+
+print(f"\nWrote {csv_path}")
+print(f"Wrote {summary_path}")
+
+if not rows:
+    print("ERROR: no benchmark result rows found", file=sys.stderr)
+    raise SystemExit(1)
+if failed:
+    print("ERROR: one or more tool-update correctness checks failed", file=sys.stderr)
+    raise SystemExit(1)
+PY

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1088,6 +1088,7 @@ decision is made.  For proper cancellation support, use `pi-coding-agent-quit'
 which asks upfront before any buffers are touched."
   (when (derived-mode-p 'pi-coding-agent-chat-mode)
     (pi-coding-agent--cancel-followup-drain-timer)
+    (pi-coding-agent--cancel-tool-update-flush)
     (pi-coding-agent--invalidate-prompt-start-wait)
     (pi-coding-agent--set-activity-phase "idle" 'teardown t)
     (dolist (proc (delete-dups (delq nil (list pi-coding-agent--process
@@ -1298,6 +1299,9 @@ Updates buffer-local state and renders display updates."
             (args (when (and tool-call-id pi-coding-agent--tool-args-cache)
                     (prog1 (gethash tool-call-id pi-coding-agent--tool-args-cache)
                       (remhash tool-call-id pi-coding-agent--tool-args-cache)))))
+       ;; The authoritative result supersedes any pending preview; discard
+       ;; it first so completion renders exactly once.
+       (pi-coding-agent--discard-pending-tool-update tool-call-id)
        (pi-coding-agent--display-tool-end (plist-get event :toolName)
                                           args
                                           (plist-get result :content)
@@ -1305,9 +1309,14 @@ Updates buffer-local state and renders display updates."
                                           (plist-get event :isError)
                                           block)))
     ("tool_execution_update"
-     (pi-coding-agent--display-tool-update
-      (plist-get event :partialResult)
-      (pi-coding-agent--tool-block-get (plist-get event :toolCallId))))
+     (let ((tool-call-id (plist-get event :toolCallId))
+           (partial-result (plist-get event :partialResult)))
+       (if tool-call-id
+           ;; Coalesce: keep only the latest preview per tool call and
+           ;; render at the flush cadence, not once per event.
+           (pi-coding-agent--queue-tool-update tool-call-id partial-result)
+         ;; No toolCallId: render through the legacy compatibility block.
+         (pi-coding-agent--display-tool-update partial-result nil))))
     ("compaction_start"
      (pi-coding-agent--cancel-followup-drain-timer)
      (pi-coding-agent--set-activity-phase "compact")
@@ -1318,6 +1327,9 @@ Updates buffer-local state and renders display updates."
      (pi-coding-agent--cancel-followup-drain-timer)
      (pi-coding-agent--handle-compaction-end-event event))
     ("agent_end"
+     ;; Defensively drop pending previews and cancel the flush timer; any
+     ;; tool still running here is aborted and its block is finalized below.
+     (pi-coding-agent--cancel-tool-update-flush)
      (pi-coding-agent--set-canonical-messages
       (plist-get pi-coding-agent--state :messages))
      (pi-coding-agent--display-agent-end)
@@ -1419,9 +1431,10 @@ Returns a plist with:
   "Delete pi-owned render artifacts in the current chat buffer.
 This removes completed/pending tool overlays, diff overlays, and lightweight
 cold-tool metadata before buffer reset or history rebuild, then clears keyed
-live-tool state, cached execution args, and the compatibility pending overlay
-slot so buffer and render state stay consistent.  Tree-sitter overlays are
-left alone."
+live-tool state, cached execution args, pending coalesced tool updates, and
+the compatibility pending overlay slot so buffer and render state stay
+consistent.  Tree-sitter overlays are left alone."
+  (pi-coding-agent--cancel-tool-update-flush)
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-tool-block t)
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-diff-overlay t)
   (let ((inhibit-read-only t))
@@ -2147,6 +2160,97 @@ shows complete lines only)."
           (pi-coding-agent--tool-block-replace-body
            block display-content show-hidden-indicator lang)
           (pi-coding-agent--tool-block-set-last-tail block cache-key))))))
+
+;;;; Coalesced tool update rendering
+
+;; Pi emits one `tool_execution_update' per extension onUpdate call, with a
+;; cumulative `:partialResult' (replace semantics).  Rendering every event
+;; synchronously multiplied an expensive fenced body replacement by
+;; machine-gun update bursts (median inter-update gap ~1 ms, peaks above
+;; 40 updates/s in real subagent sessions).  Instead, each event only
+;; records the latest partial result for its tool call, and one buffer-local
+;; one-shot timer renders the pending previews at a humane cadence.  Typing
+;; always wins: the flush re-arms instead of rendering while input is pending.
+
+(defconst pi-coding-agent--tool-update-render-interval 0.25
+  "Seconds between coalesced renders of streaming tool output previews.
+The pattern mirrors pi's TUI, which coalesces repaints latest-wins behind
+a minimum render interval; 250 ms is this frontend's humane cadence for
+previews that an authoritative tool_execution_end always supersedes.
+Internal constant, not a user option.")
+
+(defvar-local pi-coding-agent--pending-tool-updates nil
+  "Alist of (TOOL-CALL-ID . PARTIAL-RESULT) awaiting coalesced rendering.
+Only the latest partial result per tool call is kept; superseded snapshots
+are dropped.  New entries are pushed, so flushing iterates the reversed
+alist to render first-queued-first.")
+
+(defvar-local pi-coding-agent--tool-update-flush-timer nil
+  "The one pending one-shot flush timer for tool updates, or nil.
+At most one timer exists per chat buffer; updates never cancel or rearm
+it.  Only the flush itself schedules a further attempt (typing-wins).")
+
+(defun pi-coding-agent--schedule-tool-update-flush ()
+  "Arm the one-shot tool-update flush timer for the current buffer."
+  (setq pi-coding-agent--tool-update-flush-timer
+        (run-at-time pi-coding-agent--tool-update-render-interval nil
+                     #'pi-coding-agent--flush-tool-updates
+                     (current-buffer))))
+
+(defun pi-coding-agent--queue-tool-update (tool-call-id partial-result)
+  "Record PARTIAL-RESULT as the pending preview for TOOL-CALL-ID.
+Latest-wins per tool call; the shared flush timer is armed only when none
+is pending, and an armed timer keeps its deadline.  No chat text changes."
+  (when (and tool-call-id partial-result)
+    (if-let* ((entry (assoc tool-call-id pi-coding-agent--pending-tool-updates)))
+        (setcdr entry partial-result)
+      (push (cons tool-call-id partial-result)
+            pi-coding-agent--pending-tool-updates))
+    (unless pi-coding-agent--tool-update-flush-timer
+      (pi-coding-agent--schedule-tool-update-flush))))
+
+(defun pi-coding-agent--flush-tool-updates (buffer)
+  "Render pending tool update previews in BUFFER, then leave clean state.
+Timer callback for `pi-coding-agent--tool-update-flush-timer'.  Clears the
+timer slot first so updates arriving during the flush can schedule a fresh
+pass.  While user input is pending, renders nothing and schedules one
+retry; typing wins over preview refresh.  Errors during rendering cannot
+wedge the scheduler: the timer slot and pending map are already cleared
+before any preview is painted."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq pi-coding-agent--tool-update-flush-timer nil)
+      (if (input-pending-p)
+          (when pi-coding-agent--pending-tool-updates
+            (pi-coding-agent--schedule-tool-update-flush))
+        (let ((pending (nreverse pi-coding-agent--pending-tool-updates)))
+          (setq pi-coding-agent--pending-tool-updates nil)
+          (dolist (entry pending)
+            (pi-coding-agent--display-tool-update
+             (cdr entry)
+             ;; Falls back to the compatibility block when the tool call
+             ;; has no keyed live block.
+             (pi-coding-agent--tool-block-get (car entry)))))))))
+
+(defun pi-coding-agent--discard-pending-tool-update (tool-call-id)
+  "Drop any pending preview for TOOL-CALL-ID.
+Called on tool_execution_end before the authoritative final render.  A
+still-armed flush timer is left alone: it fires into the remaining (or
+empty) pending map, and flushing nothing is a no-op."
+  (when (and tool-call-id pi-coding-agent--pending-tool-updates)
+    (setq pi-coding-agent--pending-tool-updates
+          (assoc-delete-all tool-call-id
+                            pi-coding-agent--pending-tool-updates))))
+
+(defun pi-coding-agent--cancel-tool-update-flush ()
+  "Cancel any armed tool-update flush timer and discard pending previews.
+Idempotent.  Runs on agent_end and wherever live tool state is torn
+down -- buffer kill, session reset, history rebuild -- so no stale
+timer or preview survives a session transition."
+  (when (timerp pi-coding-agent--tool-update-flush-timer)
+    (cancel-timer pi-coding-agent--tool-update-flush-timer))
+  (setq pi-coding-agent--tool-update-flush-timer nil
+        pi-coding-agent--pending-tool-updates nil))
 
 (defun pi-coding-agent--display-tool-update (partial-result &optional block)
   "Display PARTIAL-RESULT as streaming output in BLOCK.

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -10691,6 +10691,8 @@ Regression test: single lines should respect byte limit even with no newlines."
      '(:type "tool_execution_update"
        :toolCallId "test-id"
        :partialResult (:content [(:type "text" :text "streaming output line 1")])))
+    ;; Updates are coalesced; flush renders the latest pending preview
+    (pi-coding-agent-test--flush-tool-updates)
     ;; Should show partial content
     (should (string-match-p "streaming output" (buffer-string)))))
 
@@ -10712,7 +10714,8 @@ Regression test: single lines should respect byte limit even with no newlines."
         (pi-coding-agent--handle-display-event
          `(:type "tool_execution_update"
            :toolCallId "test-id"
-           :partialResult (:content [(:type "text" :text ,many-lines)])))))
+           :partialResult (:content [(:type "text" :text ,many-lines)])))
+        (pi-coding-agent-test--flush-tool-updates)))
     ;; Should show indicator that earlier output is hidden
     (should (string-match-p "earlier output" (buffer-string)))
     ;; Should show last few lines
@@ -10736,7 +10739,8 @@ Regression test: streaming output with no newlines should still be capped."
         (pi-coding-agent--handle-display-event
          `(:type "tool_execution_update"
            :toolCallId "test-id"
-           :partialResult (:content [(:type "text" :text ,long-line)])))))
+           :partialResult (:content [(:type "text" :text ,long-line)])))
+        (pi-coding-agent-test--flush-tool-updates)))
     ;; Output should be truncated - 5 visual lines * 80 chars = 400 chars max
     (let ((buffer-content (buffer-string)))
       ;; Should NOT contain all 1000 x's
@@ -10787,6 +10791,229 @@ Regression test: streaming output with no newlines should still be capped."
       (should (= 1 (pi-coding-agent-test--count-matches "\\$ echo one" content)))
       (should (= 1 (pi-coding-agent-test--count-matches "\\$ echo two" content))))
     (should (= 0 (hash-table-count pi-coding-agent--live-tool-blocks)))))
+
+;; ── Coalesced tool_execution_update rendering ──────────────────────
+
+(defun pi-coding-agent-test--send-tool-execution-update (tool-call-id text)
+  "Send a tool_execution_update event for TOOL-CALL-ID with TEXT output."
+  (pi-coding-agent--handle-display-event
+   `(:type "tool_execution_update"
+     :toolCallId ,tool-call-id
+     :partialResult (:content [(:type "text" :text ,text)]))))
+
+(defun pi-coding-agent-test--flush-tool-updates ()
+  "Run the coalesced tool-update flush in the current buffer."
+  (pi-coding-agent--flush-tool-updates (current-buffer)))
+
+(ert-deftest pi-coding-agent-test-tool-update-queues-without-immediate-render ()
+  "A tool update stores pending state and schedules a flush, but does
+not render synchronously."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash"
+       :toolCallId "call_1"
+       :args (:command "long-running")))
+    (pi-coding-agent-test--send-tool-execution-update "call_1" "line one\n")
+    ;; Nothing rendered yet
+    (should-not (string-match-p "line one" (buffer-string)))
+    ;; ...but the latest partial result is pending and one timer is armed
+    (should (assoc "call_1" pi-coding-agent--pending-tool-updates))
+    (should (timerp pi-coding-agent--tool-update-flush-timer))))
+
+(ert-deftest pi-coding-agent-test-tool-update-supersedes-without-rearm ()
+  "A second update for the same tool call replaces the pending preview
+without rearming the flush timer; one flush renders only the latest."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash"
+       :toolCallId "call_1"
+       :args (:command "long-running")))
+    (pi-coding-agent-test--send-tool-execution-update "call_1" "alpha-first\n")
+    (let ((first-timer pi-coding-agent--tool-update-flush-timer)
+          (replace-calls 0))
+      (pi-coding-agent-test--send-tool-execution-update "call_1" "bravo-second\n")
+      ;; The pending entry was replaced, the timer was not rearmed
+      (should (eq first-timer pi-coding-agent--tool-update-flush-timer))
+      (should (= 1 (length pi-coding-agent--pending-tool-updates)))
+      (let ((orig (symbol-function 'pi-coding-agent--tool-block-replace-body)))
+        (cl-letf (((symbol-function 'pi-coding-agent--tool-block-replace-body)
+                   (lambda (&rest args)
+                     (setq replace-calls (1+ replace-calls))
+                     (apply orig args))))
+          (pi-coding-agent-test--flush-tool-updates)))
+      ;; Only the latest snapshot was rendered, exactly once
+      (should (= 1 replace-calls))
+      (should (string-match-p "bravo-second" (buffer-string)))
+      (should-not (string-match-p "alpha-first" (buffer-string)))
+      ;; Flush leaves clean state
+      (should-not pi-coding-agent--pending-tool-updates)
+      (should-not pi-coding-agent--tool-update-flush-timer))))
+
+(ert-deftest pi-coding-agent-test-tool-update-flush-renders-parallel-tools-in-own-blocks ()
+  "One flush renders pending previews for parallel tool calls, each
+under its own header."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "c1" :args (:command "echo one")))
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "c2" :args (:command "echo two")))
+    (pi-coding-agent-test--send-tool-execution-update "c1" "alpha\n")
+    (pi-coding-agent-test--send-tool-execution-update "c2" "bravo\n")
+    (pi-coding-agent-test--flush-tool-updates)
+    (let ((body-c1 (pi-coding-agent-test--tool-stream-body-by-id "c1"))
+          (body-c2 (pi-coding-agent-test--tool-stream-body-by-id "c2")))
+      (should (string-match-p "alpha" body-c1))
+      (should-not (string-match-p "bravo" body-c1))
+      (should (string-match-p "bravo" body-c2))
+      (should-not (string-match-p "alpha" body-c2)))
+    ;; First-queued-first-rendered: c1's preview precedes c2's header
+    (let ((content (buffer-string)))
+      (should (< (string-match "alpha" content)
+                 (string-match "\$ echo two" content))))))
+
+(ert-deftest pi-coding-agent-test-tool-execution-end-discards-pending-preview ()
+  "tool_execution_end drops the pending preview without rendering it
+and renders only the authoritative final result."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "call_1" :args (:command "test")))
+    (pi-coding-agent-test--send-tool-execution-update "call_1" "preview text\n")
+    (should (assoc "call_1" pi-coding-agent--pending-tool-updates))
+    ;; End arrives before any flush: the preview must never be painted
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_end"
+       :toolName "bash"
+       :toolCallId "call_1"
+       :result (:content [(:type "text" :text "final text")])
+       :isError nil))
+    (should (string-match-p "final text" (buffer-string)))
+    (should-not (string-match-p "preview text" (buffer-string)))
+    (should-not pi-coding-agent--pending-tool-updates)))
+
+(ert-deftest pi-coding-agent-test-tool-execution-end-keeps-other-pending-updates ()
+  "Completing one tool call neither discards nor renders another
+tool's pending preview, and keeps the flush timer armed."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "c1" :args (:command "echo one")))
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "c2" :args (:command "echo two")))
+    (pi-coding-agent-test--send-tool-execution-update "c1" "alpha\n")
+    (pi-coding-agent-test--send-tool-execution-update "c2" "bravo\n")
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_end"
+       :toolName "bash" :toolCallId "c1"
+       :result (:content [(:type "text" :text "final alpha")])
+       :isError nil))
+    ;; c1's pending entry is gone; c2's survives with the timer armed
+    (should-not (assoc "c1" pi-coding-agent--pending-tool-updates))
+    (should (assoc "c2" pi-coding-agent--pending-tool-updates))
+    (should (timerp pi-coding-agent--tool-update-flush-timer))
+    (pi-coding-agent-test--flush-tool-updates)
+    (should (string-match-p "bravo"
+                            (pi-coding-agent-test--tool-stream-body-by-id "c2")))))
+
+(ert-deftest pi-coding-agent-test-tool-update-flush-defers-to-typing ()
+  "While input is pending, the flush renders nothing and re-arms once;
+when input clears, the next flush renders the pending preview."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "call_1" :args (:command "test")))
+    (pi-coding-agent-test--send-tool-execution-update "call_1" "deferred text\n")
+    (let ((armed-timer pi-coding-agent--tool-update-flush-timer))
+      (cl-letf (((symbol-function 'input-pending-p) (lambda (&rest _) t)))
+        (pi-coding-agent-test--flush-tool-updates))
+      ;; Typing won: no render, state kept, one fresh one-shot attempt armed
+      (should-not (string-match-p "deferred text" (buffer-string)))
+      (should (assoc "call_1" pi-coding-agent--pending-tool-updates))
+      (should (timerp pi-coding-agent--tool-update-flush-timer))
+      (should-not (eq armed-timer pi-coding-agent--tool-update-flush-timer)))
+    (pi-coding-agent-test--flush-tool-updates)
+    (should (string-match-p "deferred text" (buffer-string)))
+    (should-not pi-coding-agent--pending-tool-updates)
+    (should-not pi-coding-agent--tool-update-flush-timer)))
+
+(ert-deftest pi-coding-agent-test-agent-end-clears-pending-tool-updates ()
+  "agent_end discards pending previews and cancels the flush timer."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "call_1" :args (:command "test")))
+    (pi-coding-agent-test--send-tool-execution-update "call_1" "preview\n")
+    (should (timerp pi-coding-agent--tool-update-flush-timer))
+    (pi-coding-agent--handle-display-event '(:type "agent_end"))
+    (should-not pi-coding-agent--pending-tool-updates)
+    (should-not pi-coding-agent--tool-update-flush-timer)))
+
+(ert-deftest pi-coding-agent-test-tool-update-flush-error-leaves-clean-state ()
+  "A rendering error during flush cannot wedge the timer or the
+pending state; later updates flush normally again."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "call_1" :args (:command "test")))
+    (pi-coding-agent-test--send-tool-execution-update "call_1" "boom\n")
+    (cl-letf (((symbol-function 'pi-coding-agent--display-tool-update)
+               (lambda (&rest _) (signal 'error '("render failed")))))
+      (should-error (pi-coding-agent-test--flush-tool-updates)
+                    :type 'error))
+    (should-not pi-coding-agent--pending-tool-updates)
+    (should-not pi-coding-agent--tool-update-flush-timer)
+    ;; The queue still works afterwards
+    (pi-coding-agent-test--send-tool-execution-update "call_1" "recovered\n")
+    (pi-coding-agent-test--flush-tool-updates)
+    (should (string-match-p "recovered" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-clear-render-artifacts-discards-pending-tool-updates ()
+  "Session reset/history rebuild discards pending previews and the
+flush timer along with the other live tool state."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "call_1" :args (:command "test")))
+    (pi-coding-agent-test--send-tool-execution-update "call_1" "preview\n")
+    (should (timerp pi-coding-agent--tool-update-flush-timer))
+    (pi-coding-agent--clear-render-artifacts)
+    (should-not pi-coding-agent--pending-tool-updates)
+    (should-not pi-coding-agent--tool-update-flush-timer)))
+
+(ert-deftest pi-coding-agent-test-tool-update-timer-cancelled-on-kill ()
+  "Killing the chat buffer cancels a pending flush timer.
+Uses a non-temporary buffer because `with-temp-buffer' inhibits buffer
+hooks, including `kill-buffer-hook'."
+  (let ((buf (generate-new-buffer "*pi-coding-agent-test-update-kill*"))
+        (pi-coding-agent-quit-without-confirmation t)
+        timer)
+    (unwind-protect
+        (with-current-buffer buf
+          (pi-coding-agent-chat-mode)
+          (pi-coding-agent--handle-display-event
+           '(:type "tool_execution_start"
+             :toolName "bash" :toolCallId "call_1" :args (:command "test")))
+          (pi-coding-agent-test--send-tool-execution-update "call_1" "preview\n")
+          (setq timer pi-coding-agent--tool-update-flush-timer)
+          (should (timerp timer))
+          (kill-buffer buf)
+          (should-not (memq timer timer-list)))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
 
 ;; ── Toolcall streaming (during LLM generation) ─────────────────────
 
@@ -11216,6 +11443,7 @@ authoritative args, header and overlay path are updated."
      '(:type "tool_execution_update"
        :toolCallId "call_1"
        :partialResult (:content [(:type "text" :text "hi\n")])) )
+    (pi-coding-agent-test--flush-tool-updates)
     (should (string-match-p "\\$ echo hi\n```\nhi" (buffer-string)))))
 
 (ert-deftest pi-coding-agent-test-toolcall-delta-streams-multiple-write-previews-independently ()
@@ -11859,7 +12087,8 @@ a slot, so downstream consumers that skip blanks still get N content lines."
      '(:type "tool_execution_update"
        :toolCallId "test-id"
        :partialResult (:content [(:type "text" :text "partial streaming")])))
-    ;; Partial content should be present
+    ;; Partial content should be present once the coalesced flush runs
+    (pi-coding-agent-test--flush-tool-updates)
     (should (string-match-p "partial streaming" (buffer-string)))
     ;; Now end the tool
     (pi-coding-agent--handle-display-event
@@ -12569,6 +12798,7 @@ fence so tree-sitter does not parse it as markdown."
        :partialResult
        (:content [(:type "text"
                    :text "# Heading\necho \"**bold**\"\necho \"__init__.py\"\n")])))
+    (pi-coding-agent-test--flush-tool-updates)
     ;; Simulate jit-lock
     (font-lock-ensure (point-min) (point-max))
     (dolist (pattern '("# Heading" "**bold**" "__init__"))


### PR DESCRIPTION
## What users experienced

Sessions that delegate work to subagents left Emacs sluggish: moving the cursor or typing, in any window, lagged while the subagents ran.

## Why

Pi sends one `tool_execution_update` event each time a tool reports progress. Subagent sessions emit them in bursts — in one recorded session, 3128 events over 134 minutes, with a median interval of one millisecond and peaks above forty per second. The frontend rendered every event as it arrived: a full replacement of the tool block's body in the chat buffer, followed by refontification. At burst rates this left the main thread with no time to answer keystrokes.

The protocol makes this work unnecessary. Each update carries the complete output so far, so a superseded update can be discarded without loss; only the final `tool_execution_end` is authoritative.

## What changed

An update now records only the latest partial result for its tool call. A single one-shot timer per chat buffer, armed when clean state becomes dirty and never rearmed by further events, renders the pending previews at a 250 ms cadence. While user input is pending, the flush re-arms instead of rendering: typing takes precedence over progress display. When a tool call ends, its pending preview is discarded and the authoritative result renders immediately, exactly once, and no stale preview can overwrite it.

## Measurement

A new benchmark replays a deterministic synthetic storm of these events against a fake pi and counts how often the frontend re-renders tool block bodies. CI runs it as a smoke check on every pull request.

| | renders per storm | handling per update | stalls over 100 ms |
|---|---:|---:|---:|
| before | 402 | 19.5 ms | 25 |
| after | 154 | 0.03 ms | 2 |

Render counts come from the CI benchmark; responsiveness figures from a GUI Emacs session reproducing the reporter's configuration, replaying a recorded 416-event storm against a 50 ms probe timer.

Progress reports exist to serve the user; they ought not to make the editor less responsive to the person they report to.
