### PR TITLE
Support Pi 0.84 delta-only tool calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BATCH = $(EMACS) --batch -Q -L . \
 LOCAL_LOAD_PATH = --eval "(setq load-path (cons (expand-file-name \".\") load-path))"
 
 # Pi CLI version — single source of truth (workflows extract this automatically)
-PI_VERSION ?= 0.79.1
+PI_VERSION ?= 0.84.2
 PI_PACKAGE ?= @earendil-works/pi-coding-agent
 PI_BIN ?= .cache/pi/node_modules/.bin/pi
 PI_BIN_DIR = $(abspath $(dir $(PI_BIN)))

--- a/README.org
+++ b/README.org
@@ -49,11 +49,16 @@ is the shortest path to a usable session.
 
 - Emacs 29.1 or later, built with tree-sitter support
 - Node.js 22.19 or later for the pi CLI
-- [[https://pi.dev][pi coding agent]] =@earendil-works/pi-coding-agent@0.79.1= or later,
+- [[https://pi.dev][pi coding agent]] =@earendil-works/pi-coding-agent@0.84.2= or later,
   installed and in =PATH= on the host where Pi runs
 - Pi CLI authentication: a provider API key, or a one-time =/login= run
   in a terminal (see [[*Install pi and authenticate][Install pi and authenticate]])
 - A C compiler if Emacs needs to compile tree-sitter grammars
+
+The published Pi 0.84.2 CLI omits tool identity metadata from
+=toolcall_start=.  It remains supported: tool blocks appear when the
+corresponding =toolcall_end= arrives.  Newer Pi builds that include =id= and
+=toolName= on the start event also show supported arguments while they stream.
 
 ** Install pi and authenticate 🔐
 

--- a/bench/fake-pi-tool-update-storm.py
+++ b/bench/fake-pi-tool-update-storm.py
@@ -12,12 +12,13 @@ Fill phase
     "line 0042 of bash block 003"); no real paths or session text are used.
 
 Storm phase
-    ``--parallel-tools`` parallel ``subagent`` tool executions in one
-    assistant message, then ``--updates`` ``tool_execution_update`` events
-    distributed round-robin across them, then ``tool_execution_end`` for
-    each (with a final result text), then ``message_end`` and ``agent_end``.
-    Update payloads mimic pi-submarine progress text (150-300 characters,
-    changing every update) and carry a small ``details.run`` object.
+    ``--parallel-tools`` parallel ``subagent`` calls in one completed
+    assistant tool-use message, then ``--updates`` ``tool_execution_update``
+    events distributed round-robin across their executions.  Correlated tool
+    results and a final assistant message complete the run before
+    ``agent_end``.  Update payloads mimic pi-submarine progress text (150-300
+    characters, changing every update) and carry a small ``details.run``
+    object.
 
 Storm gap pattern (deterministic, seeded PRNG; stable for a fixed Python
 version):
@@ -144,6 +145,35 @@ def write_json(payload: JsonDict) -> None:
         sys.stdout.flush()
 
 
+def zero_usage() -> JsonDict:
+    """Return deterministic cumulative usage for a streaming update."""
+    return {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "totalTokens": 0,
+        "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "total": 0,
+        },
+    }
+
+
+def write_message_update(event: JsonDict) -> None:
+    """Emit one delta-only Pi 0.84 assistant message update."""
+    write_json(
+        {
+            "type": "message_update",
+            "usage": zero_usage(),
+            "assistantMessageEvent": event,
+        }
+    )
+
+
 def respond(command: JsonDict, data: JsonDict | None = None) -> None:
     response: JsonDict = {
         "type": "response",
@@ -192,6 +222,23 @@ def tool_result(text: str, details: JsonDict | None = None) -> JsonDict:
     if details is not None:
         result["details"] = details
     return result
+
+
+def emit_tool_result_message(
+    tool_call: JsonDict, result: JsonDict, timestamp_offset_ms: int
+) -> JsonDict:
+    """Emit and return one authoritative tool-result message."""
+    message: JsonDict = {
+        "role": "toolResult",
+        "toolCallId": tool_call["id"],
+        "toolName": tool_call["name"],
+        **result,
+        "isError": False,
+        "timestamp": TIMESTAMP_BASE_MS + timestamp_offset_ms,
+    }
+    write_json({"type": "message_start", "message": message})
+    write_json({"type": "message_end", "message": message})
+    return message
 
 
 def iso_timestamp(offset_ms: int) -> str:
@@ -259,66 +306,50 @@ def fill_plan(config: JsonDict) -> list[str]:
     return plan
 
 
-def emit_fill_block(block_index: int, tool: str, output_lines: int) -> None:
-    """Emit one completed fill tool execution with surrounding events."""
+def emit_fill_block(block_index: int, tool: str, output_lines: int) -> list[JsonDict]:
+    """Emit one completed fill tool exchange and return its messages."""
     tool_call_id = f"call-fill-{block_index:04d}"
     arguments, result_text = fill_tool_call(block_index, tool, output_lines)
     thinking = fill_thinking(block_index)
+    thinking_block = {"type": "thinking", "thinking": thinking}
     tool_call = {
         "type": "toolCall",
         "id": tool_call_id,
         "name": tool,
         "arguments": arguments,
     }
-    message: JsonDict = {"role": "assistant", "content": [tool_call]}
-    write_json({"type": "message_start", "message": message})
-    write_json(
+    message: JsonDict = {
+        "role": "assistant",
+        "content": [thinking_block, tool_call],
+        "timestamp": TIMESTAMP_BASE_MS + block_index * 10,
+        "stopReason": "toolUse",
+    }
+    message_start = {**message, "content": [], "stopReason": "pending"}
+    write_json({"type": "message_start", "message": message_start})
+    write_message_update({"type": "thinking_start", "contentIndex": 0})
+    write_message_update(
+        {"type": "thinking_delta", "contentIndex": 0, "delta": thinking}
+    )
+    write_message_update(
         {
-            "type": "message_update",
-            "message": message,
-            "assistantMessageEvent": {"type": "thinking_start", "contentIndex": 0},
+            "type": "thinking_end",
+            "contentIndex": 0,
+            "content": thinking,
         }
     )
-    write_json(
+    write_message_update({"type": "toolcall_start", "contentIndex": 1})
+    write_message_update(
         {
-            "type": "message_update",
-            "message": message,
-            "assistantMessageEvent": {
-                "type": "thinking_delta",
-                "contentIndex": 0,
-                "delta": thinking,
-            },
+            "type": "toolcall_delta",
+            "contentIndex": 1,
+            "delta": json.dumps(arguments, separators=(",", ":")),
         }
     )
-    write_json(
-        {
-            "type": "message_update",
-            "message": message,
-            "assistantMessageEvent": {
-                "type": "thinking_end",
-                "contentIndex": 0,
-                "content": thinking,
-            },
-        }
+    write_message_update(
+        {"type": "toolcall_end", "contentIndex": 1, "toolCall": tool_call}
     )
-    write_json(
-        {
-            "type": "message_update",
-            "message": message,
-            "assistantMessageEvent": {"type": "toolcall_start", "contentIndex": 0},
-        }
-    )
-    write_json(
-        {
-            "type": "message_update",
-            "message": message,
-            "assistantMessageEvent": {
-                "type": "toolcall_delta",
-                "contentIndex": 0,
-                "delta": json.dumps(arguments),
-            },
-        }
-    )
+    write_json({"type": "message_end", "message": message})
+
     write_json(
         {
             "type": "tool_execution_start",
@@ -327,16 +358,20 @@ def emit_fill_block(block_index: int, tool: str, output_lines: int) -> None:
             "args": arguments,
         }
     )
+    result = tool_result(result_text)
     write_json(
         {
             "type": "tool_execution_end",
             "toolCallId": tool_call_id,
             "toolName": tool,
-            "result": tool_result(result_text),
+            "result": result,
             "isError": False,
         }
     )
-    write_json({"type": "message_end", "message": message})
+    result_message = emit_tool_result_message(
+        tool_call, result, block_index * 10 + 1
+    )
+    return [message, result_message]
 
 
 def gap_schedule(updates: int, gap_scale: float, rng: random.Random) -> list[float]:
@@ -410,23 +445,29 @@ def final_result_text(tool_id: str, tool_index: int, turns: int) -> str:
 
 
 def run_scenario(config: JsonDict, log_file: Path | None) -> None:
-    """Emit the fill phase, then the storm phase, then end the turn."""
+    """Emit the fill phase, then the storm phase, then end the run."""
     updates = int(config["updates"])
     tools = storm_tool_ids(int(config["parallel_tools"]))
     rng = random.Random(int(config["seed"]))
     delays = gap_schedule(updates, float(config["gap_scale"]), rng)
-    emitted = {"tool_execution_start": 0, "tool_execution_update": 0,
-               "tool_execution_end": 0}
+    emitted = {
+        "tool_execution_start": 0,
+        "tool_execution_update": 0,
+        "tool_execution_end": 0,
+    }
+    messages: list[JsonDict] = []
 
     write_json({"type": "agent_start"})
 
     for block_index, tool in enumerate(fill_plan(config)):
-        emit_fill_block(block_index, tool, int(config["fill_output_lines"]))
+        messages.extend(
+            emit_fill_block(block_index, tool, int(config["fill_output_lines"]))
+        )
         emitted["tool_execution_start"] += 1
         emitted["tool_execution_end"] += 1
         time.sleep(0.002)
 
-    # Storm: parallel subagent tool calls in one assistant message.
+    # Storm: generate all parallel subagent calls in one assistant message.
     tool_calls = [
         {
             "type": "toolCall",
@@ -438,27 +479,34 @@ def run_scenario(config: JsonDict, log_file: Path | None) -> None:
         }
         for index, tool_id in enumerate(tools)
     ]
-    message: JsonDict = {"role": "assistant", "content": tool_calls}
-    write_json({"type": "message_start", "message": message})
+    message: JsonDict = {
+        "role": "assistant",
+        "content": tool_calls,
+        "timestamp": TIMESTAMP_BASE_MS + 100_000,
+        "stopReason": "toolUse",
+    }
+    message_start = {**message, "content": [], "stopReason": "pending"}
+    write_json({"type": "message_start", "message": message_start})
     for index, call in enumerate(tool_calls):
-        write_json(
+        write_message_update({"type": "toolcall_start", "contentIndex": index})
+        write_message_update(
             {
-                "type": "message_update",
-                "message": message,
-                "assistantMessageEvent": {"type": "toolcall_start", "contentIndex": index},
+                "type": "toolcall_delta",
+                "contentIndex": index,
+                "delta": json.dumps(call["arguments"], separators=(",", ":")),
             }
         )
-        write_json(
+        write_message_update(
             {
-                "type": "message_update",
-                "message": message,
-                "assistantMessageEvent": {
-                    "type": "toolcall_delta",
-                    "contentIndex": index,
-                    "delta": json.dumps(call["arguments"]),
-                },
+                "type": "toolcall_end",
+                "contentIndex": index,
+                "toolCall": call,
             }
         )
+    write_json({"type": "message_end", "message": message})
+    messages.append(message)
+
+    for call in tool_calls:
         write_json(
             {
                 "type": "tool_execution_start",
@@ -487,32 +535,62 @@ def run_scenario(config: JsonDict, log_file: Path | None) -> None:
                 },
                 "partialResult": {
                     "content": [
-                        {"type": "text", "text": progress_text(seq, tool_id, turn, activity)}
+                        {
+                            "type": "text",
+                            "text": progress_text(seq, tool_id, turn, activity),
+                        }
                     ],
-                    "details": run_details(tool_id, tool_index, turn, seq, "running"),
+                    "details": run_details(
+                        tool_id, tool_index, turn, seq, "running"
+                    ),
                 },
             }
         )
         emitted["tool_execution_update"] += 1
 
+    completed: list[tuple[JsonDict, JsonDict]] = []
     for index, call in enumerate(tool_calls):
         tool_id = call["id"]
         turns = per_tool_updates[tool_id] // 8 + 1
+        result = tool_result(
+            final_result_text(tool_id, index, turns),
+            details=run_details(tool_id, index, turns, updates, "done"),
+        )
         write_json(
             {
                 "type": "tool_execution_end",
                 "toolCallId": tool_id,
                 "toolName": "subagent",
-                "result": tool_result(
-                    final_result_text(tool_id, index, turns),
-                    details=run_details(tool_id, index, turns, updates, "done"),
-                ),
+                "result": result,
                 "isError": False,
             }
         )
+        completed.append((call, result))
         emitted["tool_execution_end"] += 1
-    write_json({"type": "message_end", "message": message})
-    write_json({"type": "agent_end", "messages": [message]})
+
+    for index, (call, result) in enumerate(completed):
+        messages.append(
+            emit_tool_result_message(call, result, 101_000 + index)
+        )
+
+    final_text = "Synthetic tool-update storm complete."
+    final_message: JsonDict = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": final_text}],
+        "timestamp": TIMESTAMP_BASE_MS + 102_000,
+        "stopReason": "stop",
+    }
+    final_start = {**final_message, "content": [], "stopReason": "pending"}
+    write_json({"type": "message_start", "message": final_start})
+    write_message_update(
+        {"type": "text_delta", "contentIndex": 0, "delta": final_text}
+    )
+    write_json({"type": "message_end", "message": final_message})
+    messages.append(final_message)
+
+    write_json(
+        {"type": "agent_end", "messages": messages, "willRetry": False}
+    )
     log_line(log_file, {"event": "storm-complete", "emitted": emitted})
 
 
@@ -575,7 +653,7 @@ def resolve_config(args: argparse.Namespace) -> JsonDict:
 def main(argv: list[str] | None = None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     if raw_argv == ["--version"]:
-        print("0.79.1")
+        print("0.84.2")
         return 0
 
     args, log_file = parse_args([a for a in raw_argv if a != "--version"])

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1479,6 +1479,7 @@ consistent.  Tree-sitter overlays are left alone."
   last-tail)
 
 (cl-defstruct (pi-coding-agent--toolcall-stream
+               (:conc-name pi-coding-agent--tool-stream-)
                (:constructor pi-coding-agent--make-toolcall-stream))
   "Incremental preview state for one streamed tool call."
   content-index
@@ -1545,7 +1546,7 @@ implicit insertions still sort after explicitly ordered preview blocks."
     (when pi-coding-agent--toolcall-streams
       (maphash
        (lambda (_content-index stream)
-         (when-let* ((block (pi-coding-agent--toolcall-stream-block stream))
+         (when-let* ((block (pi-coding-agent--tool-stream-block stream))
                      (overlay (pi-coding-agent--tool-block-overlay block))
                      ((overlay-buffer overlay)))
            (unless (memq block blocks)
@@ -2038,8 +2039,8 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
 
 (defun pi-coding-agent--toolcall-preview-property (stream)
   "Return STREAM's preview property for its current top-level JSON key."
-  (let ((key (pi-coding-agent--toolcall-stream-current-key stream)))
-    (pcase (pi-coding-agent--toolcall-stream-tool-name stream)
+  (let ((key (pi-coding-agent--tool-stream-current-key stream)))
+    (pcase (pi-coding-agent--tool-stream-tool-name stream)
       ("bash" (and (equal key "command") :command))
       ((or "read" "edit")
        (pcase key
@@ -2053,10 +2054,10 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
 
 (defun pi-coding-agent--toolcall-stream-append-string (stream text)
   "Append decoded TEXT to STREAM's bounded interesting JSON string."
-  (let ((role (pi-coding-agent--toolcall-stream-string-role stream)))
+  (let ((role (pi-coding-agent--tool-stream-string-role stream)))
     (when (memq role '(key value))
       (unless (string-empty-p text)
-        (setf (pi-coding-agent--toolcall-stream-high-surrogate stream) nil))
+        (setf (pi-coding-agent--tool-stream-high-surrogate stream) nil))
       (let* ((property (and (eq role 'value)
                             (pi-coding-agent--toolcall-preview-property
                              stream)))
@@ -2066,18 +2067,18 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
                       (max 1 pi-coding-agent-preview-max-bytes))
                      (t pi-coding-agent--toolcall-preview-metadata-limit)))
              (combined
-              (concat (pi-coding-agent--toolcall-stream-string-value stream)
+              (concat (pi-coding-agent--tool-stream-string-value stream)
                       text)))
         (when (and (eq property :content) (string-match-p "\n" text))
-          (setf (pi-coding-agent--toolcall-stream-content-render-p stream) t))
-        (setf (pi-coding-agent--toolcall-stream-string-value stream)
+          (setf (pi-coding-agent--tool-stream-content-render-p stream) t))
+        (setf (pi-coding-agent--tool-stream-string-value stream)
               (cond
                ((<= (length combined) limit) combined)
                ((eq property :content)
-                (unless (pi-coding-agent--toolcall-stream-content-truncated stream)
-                  (setf (pi-coding-agent--toolcall-stream-content-render-p stream)
+                (unless (pi-coding-agent--tool-stream-content-truncated stream)
+                  (setf (pi-coding-agent--tool-stream-content-render-p stream)
                         t))
-                (setf (pi-coding-agent--toolcall-stream-content-truncated stream)
+                (setf (pi-coding-agent--tool-stream-content-truncated stream)
                       t)
                 (substring combined (- (length combined) limit)))
                (t (substring combined 0 limit))))))))
@@ -2085,49 +2086,49 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
 (defun pi-coding-agent--toolcall-stream-clear-value (stream)
   "Clear STREAM's preview value before consuming a later JSON value."
   (when-let* ((property (pi-coding-agent--toolcall-preview-property stream)))
-    (setf (pi-coding-agent--toolcall-stream-arguments stream)
-          (plist-put (pi-coding-agent--toolcall-stream-arguments stream)
+    (setf (pi-coding-agent--tool-stream-arguments stream)
+          (plist-put (pi-coding-agent--tool-stream-arguments stream)
                      property nil))
     (when (eq property :content)
-      (setf (pi-coding-agent--toolcall-stream-content-render-p stream) t
-            (pi-coding-agent--toolcall-stream-content-truncated stream)
+      (setf (pi-coding-agent--tool-stream-content-render-p stream) t
+            (pi-coding-agent--tool-stream-content-truncated stream)
             nil))))
 
 (defun pi-coding-agent--toolcall-stream-publish-value (stream)
   "Publish STREAM's current top-level preview string into its arguments."
   (when-let* ((property (pi-coding-agent--toolcall-preview-property stream)))
-    (setf (pi-coding-agent--toolcall-stream-arguments stream)
-          (plist-put (pi-coding-agent--toolcall-stream-arguments stream)
+    (setf (pi-coding-agent--tool-stream-arguments stream)
+          (plist-put (pi-coding-agent--tool-stream-arguments stream)
                      property
-                     (pi-coding-agent--toolcall-stream-string-value stream)))))
+                     (pi-coding-agent--tool-stream-string-value stream)))))
 
 (defun pi-coding-agent--toolcall-stream-start-string (stream role)
   "Start a JSON string with ROLE in STREAM."
-  (setf (pi-coding-agent--toolcall-stream-string-role stream) role
-        (pi-coding-agent--toolcall-stream-string-value stream) ""
-        (pi-coding-agent--toolcall-stream-escape-state stream) nil
-        (pi-coding-agent--toolcall-stream-unicode-value stream) 0
-        (pi-coding-agent--toolcall-stream-unicode-digits stream) 0
-        (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+  (setf (pi-coding-agent--tool-stream-string-role stream) role
+        (pi-coding-agent--tool-stream-string-value stream) ""
+        (pi-coding-agent--tool-stream-escape-state stream) nil
+        (pi-coding-agent--tool-stream-unicode-value stream) 0
+        (pi-coding-agent--tool-stream-unicode-digits stream) 0
+        (pi-coding-agent--tool-stream-high-surrogate stream) nil)
   (when (eq role 'value)
     (pi-coding-agent--toolcall-stream-publish-value stream)))
 
 (defun pi-coding-agent--toolcall-stream-finish-string (stream)
   "Finish STREAM's current JSON string and advance its root parser."
-  (let ((role (pi-coding-agent--toolcall-stream-string-role stream))
-        (value (pi-coding-agent--toolcall-stream-string-value stream)))
+  (let ((role (pi-coding-agent--tool-stream-string-role stream))
+        (value (pi-coding-agent--tool-stream-string-value stream)))
     (when (eq role 'value)
       (pi-coding-agent--toolcall-stream-publish-value stream))
-    (setf (pi-coding-agent--toolcall-stream-string-role stream) nil
-          (pi-coding-agent--toolcall-stream-string-value stream) ""
-          (pi-coding-agent--toolcall-stream-escape-state stream) nil
-          (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+    (setf (pi-coding-agent--tool-stream-string-role stream) nil
+          (pi-coding-agent--tool-stream-string-value stream) ""
+          (pi-coding-agent--tool-stream-escape-state stream) nil
+          (pi-coding-agent--tool-stream-high-surrogate stream) nil)
     (pcase role
       ('key
-       (setf (pi-coding-agent--toolcall-stream-current-key stream) value
-             (pi-coding-agent--toolcall-stream-root-state stream) 'colon))
+       (setf (pi-coding-agent--tool-stream-current-key stream) value
+             (pi-coding-agent--tool-stream-root-state stream) 'colon))
       ((or 'value 'root-value)
-       (setf (pi-coding-agent--toolcall-stream-root-state stream)
+       (setf (pi-coding-agent--tool-stream-root-state stream)
              'after-value)))))
 
 (defun pi-coding-agent--json-hex-digit-value (char)
@@ -2139,10 +2140,10 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
 
 (defun pi-coding-agent--toolcall-stream-append-codepoint (stream codepoint)
   "Append decoded Unicode CODEPOINT to STREAM's current JSON string."
-  (let ((high (pi-coding-agent--toolcall-stream-high-surrogate stream)))
+  (let ((high (pi-coding-agent--tool-stream-high-surrogate stream)))
     (cond
      ((and high (>= codepoint #xdc00) (<= codepoint #xdfff))
-      (setf (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+      (setf (pi-coding-agent--tool-stream-high-surrogate stream) nil)
       (pi-coding-agent--toolcall-stream-append-string
        stream
        (char-to-string
@@ -2150,10 +2151,10 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
            (ash (- high #xd800) 10)
            (- codepoint #xdc00)))))
      (high
-      (setf (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+      (setf (pi-coding-agent--tool-stream-high-surrogate stream) nil)
       (pi-coding-agent--toolcall-stream-append-codepoint stream codepoint))
      ((and (>= codepoint #xd800) (<= codepoint #xdbff))
-      (setf (pi-coding-agent--toolcall-stream-high-surrogate stream)
+      (setf (pi-coding-agent--tool-stream-high-surrogate stream)
             codepoint))
      ((and (>= codepoint #xdc00) (<= codepoint #xdfff)))
      ((<= codepoint #x10ffff)
@@ -2162,46 +2163,46 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
 
 (defun pi-coding-agent--toolcall-stream-feed-string-char (stream char)
   "Consume one JSON string CHAR for STREAM."
-  (pcase (pi-coding-agent--toolcall-stream-escape-state stream)
+  (pcase (pi-coding-agent--tool-stream-escape-state stream)
     ('unicode
      (if-let* ((digit (pi-coding-agent--json-hex-digit-value char)))
-         (let ((count (1+ (pi-coding-agent--toolcall-stream-unicode-digits
+         (let ((count (1+ (pi-coding-agent--tool-stream-unicode-digits
                            stream)))
-               (value (+ (ash (pi-coding-agent--toolcall-stream-unicode-value
+               (value (+ (ash (pi-coding-agent--tool-stream-unicode-value
                                stream)
                               4)
                          digit)))
-           (setf (pi-coding-agent--toolcall-stream-unicode-digits stream)
+           (setf (pi-coding-agent--tool-stream-unicode-digits stream)
                  count
-                 (pi-coding-agent--toolcall-stream-unicode-value stream)
+                 (pi-coding-agent--tool-stream-unicode-value stream)
                  value)
            (when (= count 4)
-             (setf (pi-coding-agent--toolcall-stream-escape-state stream) nil
-                   (pi-coding-agent--toolcall-stream-unicode-digits stream) 0
-                   (pi-coding-agent--toolcall-stream-unicode-value stream) 0)
+             (setf (pi-coding-agent--tool-stream-escape-state stream) nil
+                   (pi-coding-agent--tool-stream-unicode-digits stream) 0
+                   (pi-coding-agent--tool-stream-unicode-value stream) 0)
              (pi-coding-agent--toolcall-stream-append-codepoint stream value)))
        ;; Pi repairs malformed provider escapes by preserving the backslash.
        ;; Publish the literal prefix and reprocess CHAR so a quote still closes
        ;; the string rather than corrupting all later top-level fields.
-       (let* ((count (pi-coding-agent--toolcall-stream-unicode-digits stream))
-              (value (pi-coding-agent--toolcall-stream-unicode-value stream))
+       (let* ((count (pi-coding-agent--tool-stream-unicode-digits stream))
+              (value (pi-coding-agent--tool-stream-unicode-value stream))
               (digits (if (= count 0)
                           ""
                         (format (format "%%0%dX" count) value))))
-         (setf (pi-coding-agent--toolcall-stream-escape-state stream) nil
-               (pi-coding-agent--toolcall-stream-unicode-digits stream) 0
-               (pi-coding-agent--toolcall-stream-unicode-value stream) 0
-               (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+         (setf (pi-coding-agent--tool-stream-escape-state stream) nil
+               (pi-coding-agent--tool-stream-unicode-digits stream) 0
+               (pi-coding-agent--tool-stream-unicode-value stream) 0
+               (pi-coding-agent--tool-stream-high-surrogate stream) nil)
          (pi-coding-agent--toolcall-stream-append-string
           stream (concat "\\u" digits))
          (pi-coding-agent--toolcall-stream-feed-string-char stream char))))
     ('escape
      (if (eq char ?u)
-         (setf (pi-coding-agent--toolcall-stream-escape-state stream) 'unicode
-               (pi-coding-agent--toolcall-stream-unicode-digits stream) 0
-               (pi-coding-agent--toolcall-stream-unicode-value stream) 0)
-       (setf (pi-coding-agent--toolcall-stream-escape-state stream) nil
-             (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+         (setf (pi-coding-agent--tool-stream-escape-state stream) 'unicode
+               (pi-coding-agent--tool-stream-unicode-digits stream) 0
+               (pi-coding-agent--tool-stream-unicode-value stream) 0)
+       (setf (pi-coding-agent--tool-stream-escape-state stream) nil
+             (pi-coding-agent--tool-stream-high-surrogate stream) nil)
        (pi-coding-agent--toolcall-stream-append-string
         stream
         (pcase char
@@ -2217,11 +2218,11 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
     (_
      (cond
       ((eq char ?\\)
-       (setf (pi-coding-agent--toolcall-stream-escape-state stream) 'escape))
+       (setf (pi-coding-agent--tool-stream-escape-state stream) 'escape))
       ((eq char ?\")
        (pi-coding-agent--toolcall-stream-finish-string stream))
       (t
-       (setf (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+       (setf (pi-coding-agent--tool-stream-high-surrogate stream) nil)
        (pi-coding-agent--toolcall-stream-append-string
         stream (char-to-string char)))))))
 
@@ -2231,36 +2232,36 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
 
 (defun pi-coding-agent--toolcall-stream-feed-structure-char (stream char)
   "Consume one non-string JSON CHAR for STREAM's top-level object parser."
-  (let ((depth (pi-coding-agent--toolcall-stream-depth stream)))
+  (let ((depth (pi-coding-agent--tool-stream-depth stream)))
     (cond
      ((= depth 0)
       (when (eq char ?{)
-        (setf (pi-coding-agent--toolcall-stream-depth stream) 1
-              (pi-coding-agent--toolcall-stream-root-state stream) 'key)))
+        (setf (pi-coding-agent--tool-stream-depth stream) 1
+              (pi-coding-agent--tool-stream-root-state stream) 'key)))
      ((> depth 1)
       (cond
        ((eq char ?\")
         (pi-coding-agent--toolcall-stream-start-string stream 'nested))
        ((or (eq char ?{) (eq char ?\[))
-        (setf (pi-coding-agent--toolcall-stream-depth stream) (1+ depth)))
+        (setf (pi-coding-agent--tool-stream-depth stream) (1+ depth)))
        ((or (eq char ?}) (eq char ?\]))
         (let ((new-depth (1- depth)))
-          (setf (pi-coding-agent--toolcall-stream-depth stream) new-depth)
+          (setf (pi-coding-agent--tool-stream-depth stream) new-depth)
           (when (= new-depth 1)
-            (setf (pi-coding-agent--toolcall-stream-root-state stream)
+            (setf (pi-coding-agent--tool-stream-root-state stream)
                   'after-value))))))
      (t
-      (pcase (pi-coding-agent--toolcall-stream-root-state stream)
+      (pcase (pi-coding-agent--tool-stream-root-state stream)
         ('key
          (cond
           ((eq char ?\")
            (pi-coding-agent--toolcall-stream-start-string stream 'key))
           ((eq char ?})
-           (setf (pi-coding-agent--toolcall-stream-depth stream) 0
-                 (pi-coding-agent--toolcall-stream-root-state stream) 'done))))
+           (setf (pi-coding-agent--tool-stream-depth stream) 0
+                 (pi-coding-agent--tool-stream-root-state stream) 'done))))
         ('colon
          (when (eq char ?:)
-           (setf (pi-coding-agent--toolcall-stream-root-state stream) 'value)))
+           (setf (pi-coding-agent--tool-stream-root-state stream) 'value)))
         ('value
          (unless (pi-coding-agent--json-whitespace-char-p char)
            ;; JSON's last occurrence wins.  Clear a prior preview before
@@ -2274,33 +2275,33 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
                   'value
                 'root-value)))
             ((or (eq char ?{) (eq char ?\[))
-             (setf (pi-coding-agent--toolcall-stream-depth stream) 2
-                   (pi-coding-agent--toolcall-stream-root-state stream) 'nested))
+             (setf (pi-coding-agent--tool-stream-depth stream) 2
+                   (pi-coding-agent--tool-stream-root-state stream) 'nested))
             ((eq char ?,)
-             (setf (pi-coding-agent--toolcall-stream-root-state stream) 'key
-                   (pi-coding-agent--toolcall-stream-current-key stream) nil))
+             (setf (pi-coding-agent--tool-stream-root-state stream) 'key
+                   (pi-coding-agent--tool-stream-current-key stream) nil))
             ((eq char ?})
-             (setf (pi-coding-agent--toolcall-stream-depth stream) 0
-                   (pi-coding-agent--toolcall-stream-root-state stream) 'done))
+             (setf (pi-coding-agent--tool-stream-depth stream) 0
+                   (pi-coding-agent--tool-stream-root-state stream) 'done))
             (t
-             (setf (pi-coding-agent--toolcall-stream-root-state stream)
+             (setf (pi-coding-agent--tool-stream-root-state stream)
                    'scalar)))))
         ('scalar
          (cond
           ((eq char ?,)
-           (setf (pi-coding-agent--toolcall-stream-root-state stream) 'key
-                 (pi-coding-agent--toolcall-stream-current-key stream) nil))
+           (setf (pi-coding-agent--tool-stream-root-state stream) 'key
+                 (pi-coding-agent--tool-stream-current-key stream) nil))
           ((eq char ?})
-           (setf (pi-coding-agent--toolcall-stream-depth stream) 0
-                 (pi-coding-agent--toolcall-stream-root-state stream) 'done))))
+           (setf (pi-coding-agent--tool-stream-depth stream) 0
+                 (pi-coding-agent--tool-stream-root-state stream) 'done))))
         ('after-value
          (cond
           ((eq char ?,)
-           (setf (pi-coding-agent--toolcall-stream-root-state stream) 'key
-                 (pi-coding-agent--toolcall-stream-current-key stream) nil))
+           (setf (pi-coding-agent--tool-stream-root-state stream) 'key
+                 (pi-coding-agent--tool-stream-current-key stream) nil))
           ((eq char ?})
-           (setf (pi-coding-agent--toolcall-stream-depth stream) 0
-                 (pi-coding-agent--toolcall-stream-root-state stream) 'done)))))))))
+           (setf (pi-coding-agent--tool-stream-depth stream) 0
+                 (pi-coding-agent--tool-stream-root-state stream) 'done)))))))))
 
 (defun pi-coding-agent--toolcall-stream-feed (stream delta)
   "Append raw argument JSON DELTA to STREAM's display-only preview state."
@@ -2308,8 +2309,8 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
     (let ((index 0)
           (length (length delta)))
       (while (< index length)
-        (if (and (pi-coding-agent--toolcall-stream-string-role stream)
-                 (null (pi-coding-agent--toolcall-stream-escape-state stream)))
+        (if (and (pi-coding-agent--tool-stream-string-role stream)
+                 (null (pi-coding-agent--tool-stream-escape-state stream)))
             ;; Plain string runs dominate write payloads.  Append each run once
             ;; rather than repeatedly copying the accumulated value per char.
             (let ((special (string-match "[\"\\\\]" delta index)))
@@ -2325,11 +2326,11 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
                  stream (substring delta index))
                 (setq index length)))
           (let ((char (aref delta index)))
-            (if (pi-coding-agent--toolcall-stream-string-role stream)
+            (if (pi-coding-agent--tool-stream-string-role stream)
                 (pi-coding-agent--toolcall-stream-feed-string-char stream char)
               (pi-coding-agent--toolcall-stream-feed-structure-char stream char)))
           (setq index (1+ index)))))
-    (when (eq (pi-coding-agent--toolcall-stream-string-role stream) 'value)
+    (when (eq (pi-coding-agent--tool-stream-string-role stream) 'value)
       (pi-coding-agent--toolcall-stream-publish-value stream)))
   stream)
 
@@ -2347,8 +2348,8 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
 
 (defun pi-coding-agent--toolcall-stream-header-key (stream)
   "Return STREAM metadata whose change requires a header repaint."
-  (let ((args (pi-coding-agent--toolcall-stream-arguments stream)))
-    (pcase (pi-coding-agent--toolcall-stream-tool-name stream)
+  (let ((args (pi-coding-agent--tool-stream-arguments stream)))
+    (pcase (pi-coding-agent--tool-stream-tool-name stream)
       ("bash" (pi-coding-agent--tool-arg-get args :command))
       ((or "read" "write" "edit")
        (pi-coding-agent--tool-arg-path args))
@@ -2357,40 +2358,40 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
 (defun pi-coding-agent--render-toolcall-stream (stream _event-type)
   "Render changed, visible parts of generation STREAM."
   (when (pi-coding-agent--tool-name-p
-         (pi-coding-agent--toolcall-stream-tool-name stream))
-    (let* ((tool-name (pi-coding-agent--toolcall-stream-tool-name stream))
-           (args (pi-coding-agent--toolcall-stream-arguments stream))
+         (pi-coding-agent--tool-stream-tool-name stream))
+    (let* ((tool-name (pi-coding-agent--tool-stream-tool-name stream))
+           (args (pi-coding-agent--tool-stream-arguments stream))
            (header-key (pi-coding-agent--toolcall-stream-header-key stream))
-           (block (pi-coding-agent--toolcall-stream-block stream)))
+           (block (pi-coding-agent--tool-stream-block stream)))
       (unless block
         ;; Generation identity is contentIndex, not a provider ID that may be
         ;; empty, duplicated, or corrected at either authoritative end event.
         (setq block
               (pi-coding-agent--display-tool-start
                tool-name args nil
-               (pi-coding-agent--toolcall-stream-content-index stream)
+               (pi-coding-agent--tool-stream-content-index stream)
                'streaming 'defer))
-        (setf (pi-coding-agent--toolcall-stream-block stream) block
-              (pi-coding-agent--toolcall-stream-rendered-header-key stream)
+        (setf (pi-coding-agent--tool-stream-block stream) block
+              (pi-coding-agent--tool-stream-rendered-header-key stream)
               header-key))
       (setq pi-coding-agent--pending-tool-overlay
             (pi-coding-agent--tool-block-overlay block))
       (unless (equal header-key
-                     (pi-coding-agent--toolcall-stream-rendered-header-key
+                     (pi-coding-agent--tool-stream-rendered-header-key
                       stream))
         (pi-coding-agent--display-tool-update-header
          tool-name args block 'streaming)
-        (setf (pi-coding-agent--toolcall-stream-rendered-header-key stream)
+        (setf (pi-coding-agent--tool-stream-rendered-header-key stream)
               header-key)
         (when (and (equal tool-name "write")
                    (pi-coding-agent--tool-arg-member args :content))
-          (setf (pi-coding-agent--toolcall-stream-content-render-p stream)
+          (setf (pi-coding-agent--tool-stream-content-render-p stream)
                 t)))
       ;; The write preview displays complete lines only.  Avoid rewriting its
       ;; fenced body for every token that merely extends a partial line.
       (when (and (equal tool-name "write")
                  (pi-coding-agent--tool-arg-member args :content)
-                 (pi-coding-agent--toolcall-stream-content-render-p stream))
+                 (pi-coding-agent--tool-stream-content-render-p stream))
         (let* ((content (pi-coding-agent--tool-arg-get args :content))
                (complete-content
                 (pi-coding-agent--toolcall-complete-content content)))
@@ -2402,9 +2403,9 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
                 (pi-coding-agent--tool-path-string
                  (pi-coding-agent--tool-arg-path args)))
                block
-               (pi-coding-agent--toolcall-stream-content-truncated stream))
+               (pi-coding-agent--tool-stream-content-truncated stream))
             (pi-coding-agent--clear-toolcall-preview-body block))
-          (setf (pi-coding-agent--toolcall-stream-content-render-p stream)
+          (setf (pi-coding-agent--tool-stream-content-render-p stream)
                 nil))))))
 
 (defun pi-coding-agent--tool-block-rekey (block tool-call-id)
@@ -2432,7 +2433,7 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
          ;; rendered yet (as in tagged Pi 0.84.2), create its block rather than
          ;; adopting another stream's colliding authoritative ID.
          (block (if stream
-                    (or (pi-coding-agent--toolcall-stream-block stream)
+                    (or (pi-coding-agent--tool-stream-block stream)
                         (pi-coding-agent--display-tool-start
                          tool-name args nil content-index nil 'defer))
                   (pi-coding-agent--tool-block-get tool-call-id))))
@@ -2442,12 +2443,12 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
           (pi-coding-agent--reconcile-toolcall-preview-block
            content-index tool-call "toolcall_end" block))
     (when stream
-      (setf (pi-coding-agent--toolcall-stream-tool-call-id stream) tool-call-id
-            (pi-coding-agent--toolcall-stream-tool-name stream)
+      (setf (pi-coding-agent--tool-stream-tool-call-id stream) tool-call-id
+            (pi-coding-agent--tool-stream-tool-name stream)
             (plist-get tool-call :name)
-            (pi-coding-agent--toolcall-stream-arguments stream)
+            (pi-coding-agent--tool-stream-arguments stream)
             (plist-get tool-call :arguments)
-            (pi-coding-agent--toolcall-stream-block stream) block))
+            (pi-coding-agent--tool-stream-block stream) block))
     block))
 
 (defun pi-coding-agent--handle-toolcall-message-event (event)
@@ -2458,7 +2459,7 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
     (pcase event-type
       ("toolcall_start"
        (when-let* ((old-stream (gethash content-index streams))
-                   (old-block (pi-coding-agent--toolcall-stream-block
+                   (old-block (pi-coding-agent--tool-stream-block
                                old-stream)))
          (pi-coding-agent--tool-block-delete old-block))
        (let ((stream (pi-coding-agent--make-toolcall-stream
@@ -2476,7 +2477,7 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
                            new-stream))))
          ;; Generic tool arguments are hidden while streaming.  Scan only the
          ;; built-ins whose command/path/content drives a live preview.
-         (when (member (pi-coding-agent--toolcall-stream-tool-name stream)
+         (when (member (pi-coding-agent--tool-stream-tool-name stream)
                        '("bash" "read" "edit" "write"))
            (pi-coding-agent--toolcall-stream-feed
             stream (plist-get event :delta)))
@@ -2578,7 +2579,7 @@ nil, reuse a keyed block or create one."
        (lambda (_content-index stream)
          (when (and (not (memq stream excluded))
                     (equal tool-call-id
-                           (pi-coding-agent--toolcall-stream-tool-call-id
+                           (pi-coding-agent--tool-stream-tool-call-id
                             stream)))
            (throw 'found stream)))
        pi-coding-agent--toolcall-streams)
@@ -2596,7 +2597,7 @@ nil, reuse a keyed block or create one."
         (if first
             (unless (eq block (plist-get first :block))
               (when-let* ((stream (plist-get item :stream)))
-                (setf (pi-coding-agent--toolcall-stream-block stream) nil))
+                (setf (pi-coding-agent--tool-stream-block stream) nil))
               (pi-coding-agent--tool-block-delete block)
               (puthash tool-call-id
                        (plist-get first :block)
@@ -2643,7 +2644,7 @@ nil, reuse a keyed block or create one."
           ;; generation-only block now rather than leaving an orphan behind.
           (when block
             (when stream
-              (setf (pi-coding-agent--toolcall-stream-block stream) nil))
+              (setf (pi-coding-agent--tool-stream-block stream) nil))
             (pi-coding-agent--tool-block-delete block)))))
     (setq matched-items
           (pi-coding-agent--dedupe-final-toolcall-items
@@ -2656,9 +2657,9 @@ nil, reuse a keyed block or create one."
     (when streams
       (maphash
        (lambda (_content-index stream)
-         (when-let* ((block (pi-coding-agent--toolcall-stream-block stream)))
+         (when-let* ((block (pi-coding-agent--tool-stream-block stream)))
            (unless (memq block matched-blocks)
-             (setf (pi-coding-agent--toolcall-stream-block stream) nil)
+             (setf (pi-coding-agent--tool-stream-block stream) nil)
              (pi-coding-agent--tool-block-delete block))))
        streams))
     (pi-coding-agent--prune-stale-toolcall-previews tool-call-ids)))

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -86,6 +86,13 @@ current message with tree-sitter.  Most assistant text is not table content, so
 we track whether a pipe has appeared since the last decoration attempt and skip
 the query when no table can be present.")
 
+(defvar-local pi-coding-agent--toolcall-streams nil
+  "Tool-call generation state keyed by assistant content index.
+Pi's RPC protocol streams raw argument JSON deltas without a cumulative
+assistant message.  This table exists only while the current assistant message
+is being generated; completed tool execution remains keyed separately by tool
+call ID in `pi-coding-agent--live-tool-blocks'.")
+
 (defun pi-coding-agent--history-postprocessing-deferred-p ()
   "Return non-nil when history display post-processing is currently deferred."
   pi-coding-agent--defer-history-postprocessing)
@@ -125,6 +132,7 @@ Note: status is set to `streaming' by the event handler."
   (setq pi-coding-agent--in-code-block nil)
   (setq pi-coding-agent--in-thinking-block nil)
   (setq pi-coding-agent--streaming-table-candidate nil)
+  (pi-coding-agent--reset-toolcall-streams)
   (pi-coding-agent--set-activity-phase "thinking"))
 
 (defun pi-coding-agent--process-streaming-char (char state in-block)
@@ -651,6 +659,7 @@ follow-up as a fresh prompt.")
   (let ((was-aborted pi-coding-agent--aborted))
     (let ((inhibit-read-only t))
       (pi-coding-agent--finalize-live-tool-blocks 'pi-coding-agent-tool-block-error)
+      (pi-coding-agent--reset-toolcall-streams)
       (when pi-coding-agent--tool-args-cache
         (clrhash pi-coding-agent--tool-args-cache))
       ;; Abort means "stop everything" — discard queued follow-ups too
@@ -1163,6 +1172,12 @@ which asks upfront before any buffers are touched."
              (plist-get response :stderr)
              (plist-get response :exitCode))
             (process-put process 'pi-coding-agent-exit-error-rendered t))
+        (pi-coding-agent--cancel-tool-update-flush)
+        (pi-coding-agent--finalize-live-tool-blocks
+         'pi-coding-agent-tool-block-error)
+        (pi-coding-agent--reset-toolcall-streams)
+        (when pi-coding-agent--tool-args-cache
+          (clrhash pi-coding-agent--tool-args-cache))
         (pi-coding-agent--set-process nil)
         (pi-coding-agent--set-activity-phase "idle")
         (setq pi-coding-agent--local-user-message nil)
@@ -1199,6 +1214,8 @@ Updates buffer-local state and renders display updates."
        ;; A new message starts a fresh rendering context.
        (setq pi-coding-agent--in-thinking-block nil)
        (pi-coding-agent--reset-thinking-state)
+       (when (equal role "assistant")
+         (pi-coding-agent--reset-toolcall-streams))
        (pcase role
          ("user"
           ;; User message from pi - check if we displayed it locally
@@ -1250,14 +1267,8 @@ Updates buffer-local state and renders display updates."
          ("thinking_end"
           (pi-coding-agent--display-thinking-end (plist-get msg-event :content)))
          ((or "toolcall_start" "toolcall_delta" "toolcall_end")
-          ;; Preview reconciliation follows the authoritative assistant
-          ;; message content.  The current contentIndex decides which
-          ;; generic tool header is still streaming or complete.
           (pi-coding-agent--set-activity-phase "running")
-          (pi-coding-agent--reconcile-toolcall-previews
-           (plist-get event :message)
-           event-type
-           (plist-get msg-event :contentIndex)))
+          (pi-coding-agent--handle-toolcall-message-event msg-event))
          ("error"
           ;; Error during streaming (e.g., API error)
           (pi-coding-agent--display-error (plist-get msg-event :reason))))))
@@ -1267,8 +1278,12 @@ Updates buffer-local state and renders display updates."
        ;; Display error if message ended with error (e.g., API error)
        (when (equal (plist-get message :stopReason) "error")
          (pi-coding-agent--display-error (plist-get message :errorMessage)))
-       ;; Refresh header so cost and context % update promptly.
+       ;; The completed assistant message is authoritative over streamed
+       ;; preview identities, arguments, and membership.
        (when assistant-p
+         (when (plist-member message :content)
+           (pi-coding-agent--reconcile-toolcall-previews message))
+         (pi-coding-agent--reset-toolcall-streams)
          (pi-coding-agent--refresh-header)))
      (pi-coding-agent--render-complete-message))
     ("tool_execution_start"
@@ -1446,7 +1461,8 @@ consistent.  Tree-sitter overlays are left alone."
   (when pi-coding-agent--tool-args-cache
     (clrhash pi-coding-agent--tool-args-cache))
   (when pi-coding-agent--live-tool-blocks
-    (clrhash pi-coding-agent--live-tool-blocks)))
+    (clrhash pi-coding-agent--live-tool-blocks))
+  (pi-coding-agent--reset-toolcall-streams))
 
 (cl-defstruct (pi-coding-agent--tool-block
                (:constructor pi-coding-agent--make-tool-block))
@@ -1461,6 +1477,27 @@ consistent.  Tree-sitter overlays are left alone."
   offset
   line-map
   last-tail)
+
+(cl-defstruct (pi-coding-agent--toolcall-stream
+               (:constructor pi-coding-agent--make-toolcall-stream))
+  "Incremental preview state for one streamed tool call."
+  content-index
+  tool-call-id
+  tool-name
+  block
+  arguments
+  rendered-header-key
+  content-render-p
+  content-truncated
+  (depth 0)
+  (root-state 'root)
+  string-role
+  (string-value "")
+  current-key
+  escape-state
+  (unicode-value 0)
+  (unicode-digits 0)
+  high-surrogate)
 
 (defun pi-coding-agent--ensure-live-tool-blocks ()
   "Return the live tool block registry for the current buffer."
@@ -1486,18 +1523,34 @@ implicit insertions still sort after explicitly ordered preview blocks."
         order)
     (pi-coding-agent--next-tool-block-order)))
 
+(defun pi-coding-agent--tool-call-id-p (tool-call-id)
+  "Return non-nil when TOOL-CALL-ID is usable for event correlation."
+  (and (stringp tool-call-id) (not (string-empty-p tool-call-id))))
+
 (defun pi-coding-agent--tool-block-get (tool-call-id)
   "Return the live tool block for TOOL-CALL-ID, or nil."
-  (when (and tool-call-id pi-coding-agent--live-tool-blocks)
+  (when (and (pi-coding-agent--tool-call-id-p tool-call-id)
+             pi-coding-agent--live-tool-blocks)
     (gethash tool-call-id pi-coding-agent--live-tool-blocks)))
 
 (defun pi-coding-agent--live-tool-blocks-in-order ()
-  "Return all live tool blocks sorted by their recorded order."
+  "Return all keyed and generation-owned tool blocks in display order."
   (let (blocks)
     (when pi-coding-agent--live-tool-blocks
-      (maphash (lambda (_tool-call-id block)
-                 (push block blocks))
-               pi-coding-agent--live-tool-blocks))
+      (maphash
+       (lambda (_tool-call-id block)
+         (when (overlay-buffer (pi-coding-agent--tool-block-overlay block))
+           (push block blocks)))
+       pi-coding-agent--live-tool-blocks))
+    (when pi-coding-agent--toolcall-streams
+      (maphash
+       (lambda (_content-index stream)
+         (when-let* ((block (pi-coding-agent--toolcall-stream-block stream))
+                     (overlay (pi-coding-agent--tool-block-overlay block))
+                     ((overlay-buffer overlay)))
+           (unless (memq block blocks)
+             (push block blocks))))
+       pi-coding-agent--toolcall-streams))
     (sort blocks
           (lambda (left right)
             (< (pi-coding-agent--tool-block-order left)
@@ -1510,8 +1563,9 @@ implicit insertions still sort after explicitly ordered preview blocks."
             (pi-coding-agent--live-tool-blocks-in-order)))
 
 (defun pi-coding-agent--tool-block-register (block)
-  "Register BLOCK in the keyed live registry when it has a tool call ID."
-  (when-let* ((tool-call-id (pi-coding-agent--tool-block-tool-call-id block)))
+  "Register BLOCK when it has a nonempty authoritative tool call ID."
+  (when-let* ((tool-call-id (pi-coding-agent--tool-block-tool-call-id block))
+              ((pi-coding-agent--tool-call-id-p tool-call-id)))
     (puthash tool-call-id block (pi-coding-agent--ensure-live-tool-blocks)))
   block)
 
@@ -1519,7 +1573,8 @@ implicit insertions still sort after explicitly ordered preview blocks."
   "Remove BLOCK from the keyed live registry."
   (when-let* ((tool-call-id (pi-coding-agent--tool-block-tool-call-id block))
               (live-blocks pi-coding-agent--live-tool-blocks))
-    (remhash tool-call-id live-blocks))
+    (when (eq (gethash tool-call-id live-blocks) block)
+      (remhash tool-call-id live-blocks)))
   block)
 
 (defun pi-coding-agent--tool-block-from-overlay (overlay)
@@ -1756,13 +1811,15 @@ until an authoritative tool execution/history event supplies it."
          (next-block (and order
                           (pi-coding-agent--tool-block-next-after-order
                            block-order)))
+         (next-overlay (and next-block
+                            (pi-coding-agent--tool-block-overlay next-block)))
          (header-display (pi-coding-agent--tool-header tool-name args preview-state))
          (block nil)
          (inhibit-read-only t))
     (pi-coding-agent--with-scroll-preservation
       (save-excursion
-        (goto-char (if next-block
-                       (overlay-start (pi-coding-agent--tool-block-overlay next-block))
+        (goto-char (if next-overlay
+                       (overlay-start next-overlay)
                      (point-max)))
         (pi-coding-agent--ensure-blank-line-before-block)
         (let ((start (point)))
@@ -1774,8 +1831,12 @@ until an authoritative tool execution/history event supplies it."
             ;; When inserting before an already-live later block, keep one
             ;; blank separator after the new block without making it part of
             ;; the tool block overlay itself.
-            (when next-block
-              (insert "\n"))
+            (when next-overlay
+              (insert "\n")
+              ;; Insertion at an overlay's front boundary normally makes the
+              ;; new text part of that overlay.  Restore the later block's
+              ;; start to its shifted header so the two blocks stay disjoint.
+              (move-overlay next-overlay (point) (overlay-end next-overlay)))
             (let ((ov (make-overlay start (marker-position end-marker) nil nil nil)))
               (overlay-put ov 'pi-coding-agent-tool-block t)
               (overlay-put ov 'pi-coding-agent-tool-name tool-name)
@@ -1961,6 +2022,478 @@ When PREVIEW-STATE is `streaming', generic tool headers omit ARGS."
                   ;; the header.
                   (pi-coding-agent--tool-block-refresh-overlay block))))))))))
 
+(defun pi-coding-agent--ensure-toolcall-streams ()
+  "Return the current message's tool-call stream registry."
+  (or pi-coding-agent--toolcall-streams
+      (setq pi-coding-agent--toolcall-streams
+            (make-hash-table :test 'eql))))
+
+(defun pi-coding-agent--reset-toolcall-streams ()
+  "Discard raw tool-call generation state for the current message."
+  (when pi-coding-agent--toolcall-streams
+    (clrhash pi-coding-agent--toolcall-streams)))
+
+(defconst pi-coding-agent--toolcall-preview-metadata-limit 4096
+  "Maximum characters retained for a streamed command or path preview.")
+
+(defun pi-coding-agent--toolcall-preview-property (stream)
+  "Return STREAM's preview property for its current top-level JSON key."
+  (let ((key (pi-coding-agent--toolcall-stream-current-key stream)))
+    (pcase (pi-coding-agent--toolcall-stream-tool-name stream)
+      ("bash" (and (equal key "command") :command))
+      ((or "read" "edit")
+       (pcase key
+         ("path" :path)
+         ("file_path" :file_path)))
+      ("write"
+       (pcase key
+         ("path" :path)
+         ("file_path" :file_path)
+         ("content" :content))))))
+
+(defun pi-coding-agent--toolcall-stream-append-string (stream text)
+  "Append decoded TEXT to STREAM's bounded interesting JSON string."
+  (let ((role (pi-coding-agent--toolcall-stream-string-role stream)))
+    (when (memq role '(key value))
+      (unless (string-empty-p text)
+        (setf (pi-coding-agent--toolcall-stream-high-surrogate stream) nil))
+      (let* ((property (and (eq role 'value)
+                            (pi-coding-agent--toolcall-preview-property
+                             stream)))
+             (limit (cond
+                     ((eq role 'key) 64)
+                     ((eq property :content)
+                      (max 1 pi-coding-agent-preview-max-bytes))
+                     (t pi-coding-agent--toolcall-preview-metadata-limit)))
+             (combined
+              (concat (pi-coding-agent--toolcall-stream-string-value stream)
+                      text)))
+        (when (and (eq property :content) (string-match-p "\n" text))
+          (setf (pi-coding-agent--toolcall-stream-content-render-p stream) t))
+        (setf (pi-coding-agent--toolcall-stream-string-value stream)
+              (cond
+               ((<= (length combined) limit) combined)
+               ((eq property :content)
+                (unless (pi-coding-agent--toolcall-stream-content-truncated stream)
+                  (setf (pi-coding-agent--toolcall-stream-content-render-p stream)
+                        t))
+                (setf (pi-coding-agent--toolcall-stream-content-truncated stream)
+                      t)
+                (substring combined (- (length combined) limit)))
+               (t (substring combined 0 limit))))))))
+
+(defun pi-coding-agent--toolcall-stream-clear-value (stream)
+  "Clear STREAM's preview value before consuming a later JSON value."
+  (when-let* ((property (pi-coding-agent--toolcall-preview-property stream)))
+    (setf (pi-coding-agent--toolcall-stream-arguments stream)
+          (plist-put (pi-coding-agent--toolcall-stream-arguments stream)
+                     property nil))
+    (when (eq property :content)
+      (setf (pi-coding-agent--toolcall-stream-content-render-p stream) t
+            (pi-coding-agent--toolcall-stream-content-truncated stream)
+            nil))))
+
+(defun pi-coding-agent--toolcall-stream-publish-value (stream)
+  "Publish STREAM's current top-level preview string into its arguments."
+  (when-let* ((property (pi-coding-agent--toolcall-preview-property stream)))
+    (setf (pi-coding-agent--toolcall-stream-arguments stream)
+          (plist-put (pi-coding-agent--toolcall-stream-arguments stream)
+                     property
+                     (pi-coding-agent--toolcall-stream-string-value stream)))))
+
+(defun pi-coding-agent--toolcall-stream-start-string (stream role)
+  "Start a JSON string with ROLE in STREAM."
+  (setf (pi-coding-agent--toolcall-stream-string-role stream) role
+        (pi-coding-agent--toolcall-stream-string-value stream) ""
+        (pi-coding-agent--toolcall-stream-escape-state stream) nil
+        (pi-coding-agent--toolcall-stream-unicode-value stream) 0
+        (pi-coding-agent--toolcall-stream-unicode-digits stream) 0
+        (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+  (when (eq role 'value)
+    (pi-coding-agent--toolcall-stream-publish-value stream)))
+
+(defun pi-coding-agent--toolcall-stream-finish-string (stream)
+  "Finish STREAM's current JSON string and advance its root parser."
+  (let ((role (pi-coding-agent--toolcall-stream-string-role stream))
+        (value (pi-coding-agent--toolcall-stream-string-value stream)))
+    (when (eq role 'value)
+      (pi-coding-agent--toolcall-stream-publish-value stream))
+    (setf (pi-coding-agent--toolcall-stream-string-role stream) nil
+          (pi-coding-agent--toolcall-stream-string-value stream) ""
+          (pi-coding-agent--toolcall-stream-escape-state stream) nil
+          (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+    (pcase role
+      ('key
+       (setf (pi-coding-agent--toolcall-stream-current-key stream) value
+             (pi-coding-agent--toolcall-stream-root-state stream) 'colon))
+      ((or 'value 'root-value)
+       (setf (pi-coding-agent--toolcall-stream-root-state stream)
+             'after-value)))))
+
+(defun pi-coding-agent--json-hex-digit-value (char)
+  "Return CHAR's hexadecimal value, or nil when CHAR is not hexadecimal."
+  (cond
+   ((and (>= char ?0) (<= char ?9)) (- char ?0))
+   ((and (>= char ?a) (<= char ?f)) (+ 10 (- char ?a)))
+   ((and (>= char ?A) (<= char ?F)) (+ 10 (- char ?A)))))
+
+(defun pi-coding-agent--toolcall-stream-append-codepoint (stream codepoint)
+  "Append decoded Unicode CODEPOINT to STREAM's current JSON string."
+  (let ((high (pi-coding-agent--toolcall-stream-high-surrogate stream)))
+    (cond
+     ((and high (>= codepoint #xdc00) (<= codepoint #xdfff))
+      (setf (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+      (pi-coding-agent--toolcall-stream-append-string
+       stream
+       (char-to-string
+        (+ #x10000
+           (ash (- high #xd800) 10)
+           (- codepoint #xdc00)))))
+     (high
+      (setf (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+      (pi-coding-agent--toolcall-stream-append-codepoint stream codepoint))
+     ((and (>= codepoint #xd800) (<= codepoint #xdbff))
+      (setf (pi-coding-agent--toolcall-stream-high-surrogate stream)
+            codepoint))
+     ((and (>= codepoint #xdc00) (<= codepoint #xdfff)))
+     ((<= codepoint #x10ffff)
+      (pi-coding-agent--toolcall-stream-append-string
+       stream (char-to-string codepoint))))))
+
+(defun pi-coding-agent--toolcall-stream-feed-string-char (stream char)
+  "Consume one JSON string CHAR for STREAM."
+  (pcase (pi-coding-agent--toolcall-stream-escape-state stream)
+    ('unicode
+     (if-let* ((digit (pi-coding-agent--json-hex-digit-value char)))
+         (let ((count (1+ (pi-coding-agent--toolcall-stream-unicode-digits
+                           stream)))
+               (value (+ (ash (pi-coding-agent--toolcall-stream-unicode-value
+                               stream)
+                              4)
+                         digit)))
+           (setf (pi-coding-agent--toolcall-stream-unicode-digits stream)
+                 count
+                 (pi-coding-agent--toolcall-stream-unicode-value stream)
+                 value)
+           (when (= count 4)
+             (setf (pi-coding-agent--toolcall-stream-escape-state stream) nil
+                   (pi-coding-agent--toolcall-stream-unicode-digits stream) 0
+                   (pi-coding-agent--toolcall-stream-unicode-value stream) 0)
+             (pi-coding-agent--toolcall-stream-append-codepoint stream value)))
+       ;; Pi repairs malformed provider escapes by preserving the backslash.
+       ;; Publish the literal prefix and reprocess CHAR so a quote still closes
+       ;; the string rather than corrupting all later top-level fields.
+       (let* ((count (pi-coding-agent--toolcall-stream-unicode-digits stream))
+              (value (pi-coding-agent--toolcall-stream-unicode-value stream))
+              (digits (if (= count 0)
+                          ""
+                        (format (format "%%0%dX" count) value))))
+         (setf (pi-coding-agent--toolcall-stream-escape-state stream) nil
+               (pi-coding-agent--toolcall-stream-unicode-digits stream) 0
+               (pi-coding-agent--toolcall-stream-unicode-value stream) 0
+               (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+         (pi-coding-agent--toolcall-stream-append-string
+          stream (concat "\\u" digits))
+         (pi-coding-agent--toolcall-stream-feed-string-char stream char))))
+    ('escape
+     (if (eq char ?u)
+         (setf (pi-coding-agent--toolcall-stream-escape-state stream) 'unicode
+               (pi-coding-agent--toolcall-stream-unicode-digits stream) 0
+               (pi-coding-agent--toolcall-stream-unicode-value stream) 0)
+       (setf (pi-coding-agent--toolcall-stream-escape-state stream) nil
+             (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+       (pi-coding-agent--toolcall-stream-append-string
+        stream
+        (pcase char
+          (?\" "\"")
+          (?\\ "\\")
+          (?/ "/")
+          (?b "\b")
+          (?f "\f")
+          (?n "\n")
+          (?r "\r")
+          (?t "\t")
+          (_ (concat "\\" (char-to-string char)))))))
+    (_
+     (cond
+      ((eq char ?\\)
+       (setf (pi-coding-agent--toolcall-stream-escape-state stream) 'escape))
+      ((eq char ?\")
+       (pi-coding-agent--toolcall-stream-finish-string stream))
+      (t
+       (setf (pi-coding-agent--toolcall-stream-high-surrogate stream) nil)
+       (pi-coding-agent--toolcall-stream-append-string
+        stream (char-to-string char)))))))
+
+(defun pi-coding-agent--json-whitespace-char-p (char)
+  "Return non-nil when CHAR is JSON whitespace."
+  (memq char '(32 9 10 13)))
+
+(defun pi-coding-agent--toolcall-stream-feed-structure-char (stream char)
+  "Consume one non-string JSON CHAR for STREAM's top-level object parser."
+  (let ((depth (pi-coding-agent--toolcall-stream-depth stream)))
+    (cond
+     ((= depth 0)
+      (when (eq char ?{)
+        (setf (pi-coding-agent--toolcall-stream-depth stream) 1
+              (pi-coding-agent--toolcall-stream-root-state stream) 'key)))
+     ((> depth 1)
+      (cond
+       ((eq char ?\")
+        (pi-coding-agent--toolcall-stream-start-string stream 'nested))
+       ((or (eq char ?{) (eq char ?\[))
+        (setf (pi-coding-agent--toolcall-stream-depth stream) (1+ depth)))
+       ((or (eq char ?}) (eq char ?\]))
+        (let ((new-depth (1- depth)))
+          (setf (pi-coding-agent--toolcall-stream-depth stream) new-depth)
+          (when (= new-depth 1)
+            (setf (pi-coding-agent--toolcall-stream-root-state stream)
+                  'after-value))))))
+     (t
+      (pcase (pi-coding-agent--toolcall-stream-root-state stream)
+        ('key
+         (cond
+          ((eq char ?\")
+           (pi-coding-agent--toolcall-stream-start-string stream 'key))
+          ((eq char ?})
+           (setf (pi-coding-agent--toolcall-stream-depth stream) 0
+                 (pi-coding-agent--toolcall-stream-root-state stream) 'done))))
+        ('colon
+         (when (eq char ?:)
+           (setf (pi-coding-agent--toolcall-stream-root-state stream) 'value)))
+        ('value
+         (unless (pi-coding-agent--json-whitespace-char-p char)
+           ;; JSON's last occurrence wins.  Clear a prior preview before
+           ;; learning whether this later value is a string we can display.
+           (pi-coding-agent--toolcall-stream-clear-value stream)
+           (cond
+            ((eq char ?\")
+             (pi-coding-agent--toolcall-stream-start-string
+              stream
+              (if (pi-coding-agent--toolcall-preview-property stream)
+                  'value
+                'root-value)))
+            ((or (eq char ?{) (eq char ?\[))
+             (setf (pi-coding-agent--toolcall-stream-depth stream) 2
+                   (pi-coding-agent--toolcall-stream-root-state stream) 'nested))
+            ((eq char ?,)
+             (setf (pi-coding-agent--toolcall-stream-root-state stream) 'key
+                   (pi-coding-agent--toolcall-stream-current-key stream) nil))
+            ((eq char ?})
+             (setf (pi-coding-agent--toolcall-stream-depth stream) 0
+                   (pi-coding-agent--toolcall-stream-root-state stream) 'done))
+            (t
+             (setf (pi-coding-agent--toolcall-stream-root-state stream)
+                   'scalar)))))
+        ('scalar
+         (cond
+          ((eq char ?,)
+           (setf (pi-coding-agent--toolcall-stream-root-state stream) 'key
+                 (pi-coding-agent--toolcall-stream-current-key stream) nil))
+          ((eq char ?})
+           (setf (pi-coding-agent--toolcall-stream-depth stream) 0
+                 (pi-coding-agent--toolcall-stream-root-state stream) 'done))))
+        ('after-value
+         (cond
+          ((eq char ?,)
+           (setf (pi-coding-agent--toolcall-stream-root-state stream) 'key
+                 (pi-coding-agent--toolcall-stream-current-key stream) nil))
+          ((eq char ?})
+           (setf (pi-coding-agent--toolcall-stream-depth stream) 0
+                 (pi-coding-agent--toolcall-stream-root-state stream) 'done)))))))))
+
+(defun pi-coding-agent--toolcall-stream-feed (stream delta)
+  "Append raw argument JSON DELTA to STREAM's display-only preview state."
+  (when (stringp delta)
+    (let ((index 0)
+          (length (length delta)))
+      (while (< index length)
+        (if (and (pi-coding-agent--toolcall-stream-string-role stream)
+                 (null (pi-coding-agent--toolcall-stream-escape-state stream)))
+            ;; Plain string runs dominate write payloads.  Append each run once
+            ;; rather than repeatedly copying the accumulated value per char.
+            (let ((special (string-match "[\"\\\\]" delta index)))
+              (if special
+                  (progn
+                    (when (> special index)
+                      (pi-coding-agent--toolcall-stream-append-string
+                       stream (substring delta index special)))
+                    (pi-coding-agent--toolcall-stream-feed-string-char
+                     stream (aref delta special))
+                    (setq index (1+ special)))
+                (pi-coding-agent--toolcall-stream-append-string
+                 stream (substring delta index))
+                (setq index length)))
+          (let ((char (aref delta index)))
+            (if (pi-coding-agent--toolcall-stream-string-role stream)
+                (pi-coding-agent--toolcall-stream-feed-string-char stream char)
+              (pi-coding-agent--toolcall-stream-feed-structure-char stream char)))
+          (setq index (1+ index)))))
+    (when (eq (pi-coding-agent--toolcall-stream-string-role stream) 'value)
+      (pi-coding-agent--toolcall-stream-publish-value stream)))
+  stream)
+
+(defun pi-coding-agent--tool-name-p (tool-name)
+  "Return non-nil when TOOL-NAME can identify a streamed preview."
+  (and (stringp tool-name) (not (string-empty-p tool-name))))
+
+(defun pi-coding-agent--toolcall-complete-content (content)
+  "Return the complete-line prefix of streamed write CONTENT."
+  (when (stringp content)
+    (if (string-suffix-p "\n" content)
+        content
+      (when-let* ((last-newline (cl-position ?\n content :from-end t)))
+        (substring content 0 (1+ last-newline))))))
+
+(defun pi-coding-agent--toolcall-stream-header-key (stream)
+  "Return STREAM metadata whose change requires a header repaint."
+  (let ((args (pi-coding-agent--toolcall-stream-arguments stream)))
+    (pcase (pi-coding-agent--toolcall-stream-tool-name stream)
+      ("bash" (pi-coding-agent--tool-arg-get args :command))
+      ((or "read" "write" "edit")
+       (pi-coding-agent--tool-arg-path args))
+      (_ nil))))
+
+(defun pi-coding-agent--render-toolcall-stream (stream _event-type)
+  "Render changed, visible parts of generation STREAM."
+  (when (pi-coding-agent--tool-name-p
+         (pi-coding-agent--toolcall-stream-tool-name stream))
+    (let* ((tool-name (pi-coding-agent--toolcall-stream-tool-name stream))
+           (args (pi-coding-agent--toolcall-stream-arguments stream))
+           (header-key (pi-coding-agent--toolcall-stream-header-key stream))
+           (block (pi-coding-agent--toolcall-stream-block stream)))
+      (unless block
+        ;; Generation identity is contentIndex, not a provider ID that may be
+        ;; empty, duplicated, or corrected at either authoritative end event.
+        (setq block
+              (pi-coding-agent--display-tool-start
+               tool-name args nil
+               (pi-coding-agent--toolcall-stream-content-index stream)
+               'streaming 'defer))
+        (setf (pi-coding-agent--toolcall-stream-block stream) block
+              (pi-coding-agent--toolcall-stream-rendered-header-key stream)
+              header-key))
+      (setq pi-coding-agent--pending-tool-overlay
+            (pi-coding-agent--tool-block-overlay block))
+      (unless (equal header-key
+                     (pi-coding-agent--toolcall-stream-rendered-header-key
+                      stream))
+        (pi-coding-agent--display-tool-update-header
+         tool-name args block 'streaming)
+        (setf (pi-coding-agent--toolcall-stream-rendered-header-key stream)
+              header-key)
+        (when (and (equal tool-name "write")
+                   (pi-coding-agent--tool-arg-member args :content))
+          (setf (pi-coding-agent--toolcall-stream-content-render-p stream)
+                t)))
+      ;; The write preview displays complete lines only.  Avoid rewriting its
+      ;; fenced body for every token that merely extends a partial line.
+      (when (and (equal tool-name "write")
+                 (pi-coding-agent--tool-arg-member args :content)
+                 (pi-coding-agent--toolcall-stream-content-render-p stream))
+        (let* ((content (pi-coding-agent--tool-arg-get args :content))
+               (complete-content
+                (pi-coding-agent--toolcall-complete-content content)))
+          (if (stringp content)
+              (pi-coding-agent--display-tool-streaming-text
+               (or complete-content "")
+               pi-coding-agent-tool-preview-lines
+               (pi-coding-agent--path-to-language
+                (pi-coding-agent--tool-path-string
+                 (pi-coding-agent--tool-arg-path args)))
+               block
+               (pi-coding-agent--toolcall-stream-content-truncated stream))
+            (pi-coding-agent--clear-toolcall-preview-body block))
+          (setf (pi-coding-agent--toolcall-stream-content-render-p stream)
+                nil))))))
+
+(defun pi-coding-agent--tool-block-rekey (block tool-call-id)
+  "Change live BLOCK's registry key to authoritative TOOL-CALL-ID."
+  (when (and block (pi-coding-agent--tool-call-id-p tool-call-id))
+    (let ((changed
+           (not (equal (pi-coding-agent--tool-block-tool-call-id block)
+                       tool-call-id))))
+      (when changed
+        (pi-coding-agent--tool-block-unregister block)
+        (setf (pi-coding-agent--tool-block-tool-call-id block) tool-call-id))
+      ;; Registration may have been displaced by a colliding provisional ID.
+      (pi-coding-agent--tool-block-register block)
+      (when changed
+        (pi-coding-agent--tool-block-refresh-overlay block))))
+  block)
+
+(defun pi-coding-agent--reconcile-final-toolcall
+    (content-index tool-call &optional stream)
+  "Reconcile authoritative TOOL-CALL at CONTENT-INDEX with STREAM preview."
+  (let* ((tool-call-id (plist-get tool-call :id))
+         (tool-name (plist-get tool-call :name))
+         (args (plist-get tool-call :arguments))
+         ;; Content index owns a generation stream.  If that stream has not
+         ;; rendered yet (as in tagged Pi 0.84.2), create its block rather than
+         ;; adopting another stream's colliding authoritative ID.
+         (block (if stream
+                    (or (pi-coding-agent--toolcall-stream-block stream)
+                        (pi-coding-agent--display-tool-start
+                         tool-name args nil content-index nil 'defer))
+                  (pi-coding-agent--tool-block-get tool-call-id))))
+    (when block
+      (pi-coding-agent--tool-block-rekey block tool-call-id))
+    (setq block
+          (pi-coding-agent--reconcile-toolcall-preview-block
+           content-index tool-call "toolcall_end" block))
+    (when stream
+      (setf (pi-coding-agent--toolcall-stream-tool-call-id stream) tool-call-id
+            (pi-coding-agent--toolcall-stream-tool-name stream)
+            (plist-get tool-call :name)
+            (pi-coding-agent--toolcall-stream-arguments stream)
+            (plist-get tool-call :arguments)
+            (pi-coding-agent--toolcall-stream-block stream) block))
+    block))
+
+(defun pi-coding-agent--handle-toolcall-message-event (event)
+  "Assemble and render one delta-only toolcall message EVENT."
+  (let* ((event-type (plist-get event :type))
+         (content-index (plist-get event :contentIndex))
+         (streams (pi-coding-agent--ensure-toolcall-streams)))
+    (pcase event-type
+      ("toolcall_start"
+       (when-let* ((old-stream (gethash content-index streams))
+                   (old-block (pi-coding-agent--toolcall-stream-block
+                               old-stream)))
+         (pi-coding-agent--tool-block-delete old-block))
+       (let ((stream (pi-coding-agent--make-toolcall-stream
+                      :content-index content-index
+                      :tool-call-id (plist-get event :id)
+                      :tool-name (plist-get event :toolName))))
+         (puthash content-index stream streams)
+         (pi-coding-agent--render-toolcall-stream stream event-type)))
+      ("toolcall_delta"
+       (let ((stream (or (gethash content-index streams)
+                         (let ((new-stream
+                                (pi-coding-agent--make-toolcall-stream
+                                 :content-index content-index)))
+                           (puthash content-index new-stream streams)
+                           new-stream))))
+         ;; Generic tool arguments are hidden while streaming.  Scan only the
+         ;; built-ins whose command/path/content drives a live preview.
+         (when (member (pi-coding-agent--toolcall-stream-tool-name stream)
+                       '("bash" "read" "edit" "write"))
+           (pi-coding-agent--toolcall-stream-feed
+            stream (plist-get event :delta)))
+         (pi-coding-agent--render-toolcall-stream stream event-type)))
+      ("toolcall_end"
+       (when-let* ((tool-call (plist-get event :toolCall)))
+         (let ((stream (or (gethash content-index streams)
+                           (let ((new-stream
+                                  (pi-coding-agent--make-toolcall-stream
+                                   :content-index content-index)))
+                             (puthash content-index new-stream streams)
+                             new-stream))))
+           ;; Keep compact content-index/block identity until message_end,
+           ;; which may apply an extension-replaced final call.
+           (pi-coding-agent--reconcile-final-toolcall
+            content-index tool-call stream)))))))
+
 (defun pi-coding-agent--message-tool-calls (message)
   "Return MESSAGE toolCall content blocks in assistant source order.
 Each element is a plist `(:content-index N :tool-call TOOL-CALL)'."
@@ -1975,63 +2508,160 @@ Each element is a plist `(:content-index N :tool-call TOOL-CALL)'."
                   tool-calls)))))
     (nreverse tool-calls)))
 
+(defun pi-coding-agent--clear-toolcall-preview-body (block)
+  "Clear stale streamed body state from tool preview BLOCK."
+  (pi-coding-agent--tool-block-set-last-tail block nil)
+  (pi-coding-agent--tool-block-replace-body block "" nil nil))
+
 (defun pi-coding-agent--reconcile-toolcall-preview-block
-    (content-index tool-call &optional event-type event-content-index)
-  "Create or update the preview block for TOOL-CALL at CONTENT-INDEX.
-EVENT-TYPE and EVENT-CONTENT-INDEX identify the content block whose
-streaming state changed."
+    (content-index tool-call &optional event-type block)
+  "Create or update BLOCK for TOOL-CALL at CONTENT-INDEX.
+EVENT-TYPE selects streaming or authoritative presentation.  When BLOCK is
+nil, reuse a keyed block or create one."
   (let* ((tool-call-id (plist-get tool-call :id))
          (tool-name (plist-get tool-call :name))
          (args (plist-get tool-call :arguments))
-         (event-entry-p (or (null event-content-index)
-                            (equal event-content-index content-index)))
          (streaming-p (member event-type '("toolcall_start" "toolcall_delta")))
          (preview-state (and streaming-p 'streaming))
-         (existing-block (pi-coding-agent--tool-block-get tool-call-id))
+         (existing-block (or block
+                             (pi-coding-agent--tool-block-get tool-call-id)))
          (block (or existing-block
                     (pi-coding-agent--display-tool-start
                      tool-name args tool-call-id content-index preview-state
                      'defer))))
     (setq pi-coding-agent--pending-tool-overlay
           (pi-coding-agent--tool-block-overlay block))
-    (when (and existing-block event-entry-p)
+    (overlay-put (pi-coding-agent--tool-block-overlay block)
+                 'pi-coding-agent-tool-name tool-name)
+    (when existing-block
       (pi-coding-agent--display-tool-update-header
        tool-name args block preview-state))
-    (when (and event-entry-p (equal tool-name "write"))
-      (let ((content-entry (pi-coding-agent--tool-arg-member args :content)))
-        (when content-entry
-          (pi-coding-agent--display-tool-streaming-text
-           (or (pi-coding-agent--tool-arg-get args :content) "")
-           pi-coding-agent-tool-preview-lines
-           (pi-coding-agent--path-to-language
-            (pi-coding-agent--tool-path-string
-             (pi-coding-agent--tool-arg-path args)))
-           block))))
+    (let ((content (pi-coding-agent--tool-arg-get args :content)))
+      (cond
+       ((equal event-type "toolcall_end")
+        (if (and (equal tool-name "write") (stringp content))
+            (pi-coding-agent--display-tool-streaming-text
+             content
+             pi-coding-agent-tool-preview-lines
+             (pi-coding-agent--path-to-language
+              (pi-coding-agent--tool-path-string
+               (pi-coding-agent--tool-arg-path args)))
+             block)
+          (pi-coding-agent--clear-toolcall-preview-body block)))
+       ((and (equal tool-name "write")
+             (pi-coding-agent--tool-arg-member args :content))
+        (if (stringp content)
+            (pi-coding-agent--display-tool-streaming-text
+             content
+             pi-coding-agent-tool-preview-lines
+             (pi-coding-agent--path-to-language
+              (pi-coding-agent--tool-path-string
+               (pi-coding-agent--tool-arg-path args)))
+             block)
+          (pi-coding-agent--clear-toolcall-preview-body block)))))
     block))
 
 (defun pi-coding-agent--prune-stale-toolcall-previews (tool-call-ids)
   "Drop keyed live preview blocks whose IDs are absent from TOOL-CALL-IDS."
   (dolist (block (pi-coding-agent--live-tool-blocks-in-order))
-    (when-let* ((tool-call-id (pi-coding-agent--tool-block-tool-call-id block)))
+    (when-let* ((tool-call-id (pi-coding-agent--tool-block-tool-call-id block))
+                ((pi-coding-agent--tool-call-id-p tool-call-id)))
       (unless (member tool-call-id tool-call-ids)
         (pi-coding-agent--tool-block-delete block)))))
 
-(defun pi-coding-agent--reconcile-toolcall-previews
-    (message &optional event-type event-content-index)
-  "Reconcile live preview blocks from assistant MESSAGE content.
-EVENT-TYPE and EVENT-CONTENT-INDEX identify the toolcall block whose
-streaming state changed."
-  (let* ((entries (pi-coding-agent--message-tool-calls message))
-         (tool-call-ids (delq nil (mapcar (lambda (entry)
-                                            (plist-get (plist-get entry :tool-call) :id))
-                                          entries))))
-    (pi-coding-agent--prune-stale-toolcall-previews tool-call-ids)
+(defun pi-coding-agent--toolcall-stream-by-id (tool-call-id excluded)
+  "Return a stream for TOOL-CALL-ID that is not in EXCLUDED."
+  (when (and (pi-coding-agent--tool-call-id-p tool-call-id)
+             pi-coding-agent--toolcall-streams)
+    (catch 'found
+      (maphash
+       (lambda (_content-index stream)
+         (when (and (not (memq stream excluded))
+                    (equal tool-call-id
+                           (pi-coding-agent--toolcall-stream-tool-call-id
+                            stream)))
+           (throw 'found stream)))
+       pi-coding-agent--toolcall-streams)
+      nil)))
+
+(defun pi-coding-agent--dedupe-final-toolcall-items (items)
+  "In ITEMS, keep the first authoritative ID and delete ambiguous duplicates."
+  (let ((seen (make-hash-table :test 'equal))
+        unique)
+    (dolist (item items)
+      (let* ((tool-call (plist-get item :tool-call))
+             (tool-call-id (plist-get tool-call :id))
+             (first (gethash tool-call-id seen))
+             (block (plist-get item :block)))
+        (if first
+            (unless (eq block (plist-get first :block))
+              (when-let* ((stream (plist-get item :stream)))
+                (setf (pi-coding-agent--toolcall-stream-block stream) nil))
+              (pi-coding-agent--tool-block-delete block)
+              (puthash tool-call-id
+                       (plist-get first :block)
+                       (pi-coding-agent--ensure-live-tool-blocks)))
+          (puthash tool-call-id item seen)
+          (push item unique))))
+    (nreverse unique)))
+
+(defun pi-coding-agent--reconcile-toolcall-previews (message)
+  "Reconcile live preview blocks from authoritative assistant MESSAGE."
+  (let ((entries (pi-coding-agent--message-tool-calls message))
+        (streams pi-coding-agent--toolcall-streams)
+        matched-streams
+        matched-blocks
+        matched-items
+        tool-call-ids)
+    ;; Content index owns generation; a stable ID is only the fallback for a
+    ;; final message that no longer has a matching stream index.
     (dolist (entry entries)
-      (pi-coding-agent--reconcile-toolcall-preview-block
-       (plist-get entry :content-index)
-       (plist-get entry :tool-call)
-       event-type
-       event-content-index))))
+      (let* ((content-index (plist-get entry :content-index))
+             (tool-call (plist-get entry :tool-call))
+             (tool-call-id (plist-get tool-call :id))
+             (indexed-stream (and streams (gethash content-index streams)))
+             (stream (or (and indexed-stream
+                              (not (memq indexed-stream matched-streams))
+                              indexed-stream)
+                         (pi-coding-agent--toolcall-stream-by-id
+                          tool-call-id matched-streams)))
+             (block (pi-coding-agent--reconcile-final-toolcall
+                     content-index tool-call stream)))
+        (when stream
+          (push stream matched-streams))
+        (if (pi-coding-agent--tool-call-id-p tool-call-id)
+            (progn
+              (when block
+                (push block matched-blocks)
+                (push (list :content-index content-index
+                            :tool-call tool-call
+                            :stream stream
+                            :block block)
+                      matched-items))
+              (push tool-call-id tool-call-ids))
+          ;; Invalid final IDs cannot correlate execution.  Remove their
+          ;; generation-only block now rather than leaving an orphan behind.
+          (when block
+            (when stream
+              (setf (pi-coding-agent--toolcall-stream-block stream) nil))
+            (pi-coding-agent--tool-block-delete block)))))
+    (setq matched-items
+          (pi-coding-agent--dedupe-final-toolcall-items
+           (nreverse matched-items))
+          matched-blocks
+          (mapcar (lambda (item) (plist-get item :block)) matched-items)
+          tool-call-ids (delete-dups tool-call-ids))
+    ;; Empty/provisional IDs are owned only by their stream records and cannot
+    ;; be pruned through the execution-ID registry.
+    (when streams
+      (maphash
+       (lambda (_content-index stream)
+         (when-let* ((block (pi-coding-agent--toolcall-stream-block stream)))
+           (unless (memq block matched-blocks)
+             (setf (pi-coding-agent--toolcall-stream-block stream) nil)
+             (pi-coding-agent--tool-block-delete block))))
+       streams))
+    (pi-coding-agent--prune-stale-toolcall-previews tool-call-ids)))
 
 (defun pi-coding-agent--extract-text-from-content (content-blocks)
   "Extract text from CONTENT-BLOCKS vector efficiently.
@@ -2120,10 +2750,11 @@ LANG is passed to `pi-coding-agent--wrap-in-src-block' for fence construction."
           (pi-coding-agent--tool-block-refresh-overlay block))))))
 
 (defun pi-coding-agent--display-tool-streaming-text
-    (raw-text max-lines &optional lang block)
+    (raw-text max-lines &optional lang block source-truncated)
   "Display RAW-TEXT as streaming content in BLOCK.
 Shows a rolling tail truncated to MAX-LINES visual lines.
 When BLOCK is nil, fall back to the current compatibility tool block.
+SOURCE-TRUNCATED means the argument assembler already dropped an older prefix.
 
 When LANG is non-nil, wrap the tail in a markdown fenced code block so
 that `md-ts-mode' language injection handles syntax highlighting.
@@ -2150,11 +2781,10 @@ shows complete lines only)."
                (or (plist-get truncation :content) "")
                "\n+"))
              (show-hidden-indicator
-              (or has-hidden
+              (or source-truncated
+                  has-hidden
                   (> (plist-get truncation :hidden-lines) 0)))
-             (cache-key (if show-hidden-indicator
-                            (concat "H:" display-content)
-                          display-content))
+             (cache-key (list lang show-hidden-indicator display-content))
              (last-tail (pi-coding-agent--tool-block-last-tail block)))
         (unless (equal cache-key last-tail)
           (pi-coding-agent--tool-block-replace-body

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -1924,7 +1924,7 @@ Returns nil if MS is nil."
 (defconst pi-coding-agent--pi-package "@earendil-works/pi-coding-agent"
   "Npm package name for the pi CLI supported by pi-coding-agent.")
 
-(defconst pi-coding-agent--minimum-pi-version "0.81.0"
+(defconst pi-coding-agent--minimum-pi-version "0.84.2"
   "Minimum supported pi CLI version.")
 
 (defun pi-coding-agent--pi-install-command ()

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -34,7 +34,7 @@
 ;;
 ;; Requirements:
 ;;   - Emacs 29.1 or later (tree-sitter support required)
-;;   - pi coding agent @earendil-works/pi-coding-agent 0.81.0 or later,
+;;   - pi coding agent @earendil-works/pi-coding-agent 0.84.2 or later,
 ;;     installed and in PATH on the host where Pi runs
 ;;   - tree-sitter grammars for markdown and markdown-inline
 ;;

--- a/test/fixtures/fake-pi/README.md
+++ b/test/fixtures/fake-pi/README.md
@@ -79,9 +79,10 @@ Example:
 
 ## `tool_stream`
 
-Emits `toolcall_start`, `toolcall_delta`, `tool_execution_start`,
-`tool_execution_update`, and `tool_execution_end`, then completes the assistant
-turn.
+Emits the current delta-only lifecycle: `toolcall_start`, argument
+`toolcall_delta` events, authoritative `toolcall_end` and assistant
+`message_end`, tool execution events, a correlated tool-result message, and the
+final streamed assistant message before `agent_end`.
 
 Example:
 

--- a/test/fixtures/fake-pi/tool-abort.json
+++ b/test/fixtures/fake-pi/tool-abort.json
@@ -1,0 +1,16 @@
+{
+  "description": "Slow tool generation for deterministic mid-stream abort tests.",
+  "commands": [],
+  "prompt": {
+    "type": "tool_stream",
+    "tool_name": "read",
+    "tool_args": {
+      "path": "/tmp/fake-tool-abort.txt"
+    },
+    "partial_result_text": "must not execute\n",
+    "result_text": "must not complete\n",
+    "assistant_text": "Must not finish",
+    "delay_ms": 1000,
+    "echo_user": true
+  }
+}

--- a/test/pi-coding-agent-fake-pi-test.el
+++ b/test/pi-coding-agent-fake-pi-test.el
@@ -116,6 +116,26 @@ SPEC is (PROC SCENARIO &rest EXTRA-ARGS)."
   "Return the :type fields from OBJECTS."
   (mapcar (lambda (obj) (plist-get obj :type)) objects))
 
+(defun pi-coding-agent-fake-pi-test--events-of-type (objects type)
+  "Return events from OBJECTS whose top-level type is TYPE."
+  (seq-filter (lambda (obj) (equal (plist-get obj :type) type)) objects))
+
+(defun pi-coding-agent-fake-pi-test--message-events (objects type role)
+  "Return TYPE message events from OBJECTS whose message has ROLE."
+  (seq-filter
+   (lambda (obj)
+     (and (equal (plist-get obj :type) type)
+          (equal (plist-get (plist-get obj :message) :role) role)))
+   objects))
+
+(defun pi-coding-agent-fake-pi-test--message-updates (objects type)
+  "Return message updates from OBJECTS whose nested event has TYPE."
+  (seq-filter
+   (lambda (obj)
+     (and (equal (plist-get obj :type) "message_update")
+          (equal (plist-get (plist-get obj :assistantMessageEvent) :type) type)))
+   objects))
+
 (defun pi-coding-agent-fake-pi-test--run-cli (&rest args)
   "Run fake-pi with ARGS and return `(:exit-code N :output STRING)'."
   (let ((command
@@ -352,23 +372,26 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                                     (equal (plist-get (plist-get obj :message) :role)
                                            "assistant")))
                              events))
-           (text-deltas (seq-filter
-                         (lambda (obj)
-                           (and (equal (plist-get obj :type) "message_update")
-                                (equal (plist-get (plist-get obj :assistantMessageEvent) :type)
-                                       "text_delta")))
-                         events)))
+           (message-updates
+            (pi-coding-agent-fake-pi-test--events-of-type events "message_update"))
+           (text-deltas
+            (pi-coding-agent-fake-pi-test--message-updates events "text_delta")))
       (should (equal (plist-get response :type) "response"))
       (should (eq (plist-get response :success) t))
       (should (equal (plist-get response :command) "prompt"))
       (should (equal (car (pi-coding-agent-fake-pi-test--event-types events)) "agent_start"))
       (should assistant-start)
       (should (> (length text-deltas) 0))
+      (dolist (update message-updates)
+        (should (plist-member update :usage))
+        (should-not (plist-member update :message))
+        (should-not (plist-member (plist-get update :assistantMessageEvent)
+                                  :partial)))
       (should (equal (car (last (pi-coding-agent-fake-pi-test--event-types events)))
                      "agent_end")))))
 
 (ert-deftest pi-coding-agent-fake-pi-test-tool-stream-emits-tool-events ()
-  "tool_stream scenarios emit the toolcall and tool_execution event surface." 
+  "tool_stream emits an ordered, correlated, delta-only RPC lifecycle."
   (pi-coding-agent-fake-pi-test-with-process (proc "tool-read")
     (pi-coding-agent-fake-pi-test--send proc '(:type "prompt" :message "use the tool"))
     (should (equal (plist-get (pi-coding-agent-fake-pi-test--pop-object proc) :command)
@@ -376,38 +399,156 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
     (let* ((events (pi-coding-agent-fake-pi-test--collect-until
                     proc
                     (lambda (obj) (equal (plist-get obj :type) "agent_end"))))
-           (toolcall-start (seq-find
-                            (lambda (obj)
-                              (and (equal (plist-get obj :type) "message_update")
-                                   (equal (plist-get (plist-get obj :assistantMessageEvent) :type)
-                                          "toolcall_start")))
-                            events))
-           (tool-execution-start (seq-find
-                                  (lambda (obj)
-                                    (equal (plist-get obj :type) "tool_execution_start"))
-                                  events))
-           (tool-execution-update (seq-find
-                                   (lambda (obj)
-                                     (equal (plist-get obj :type) "tool_execution_update"))
-                                   events))
-           (tool-execution-end (seq-find
-                                (lambda (obj)
-                                  (equal (plist-get obj :type) "tool_execution_end"))
-                                events)))
-      (should toolcall-start)
-      (should tool-execution-start)
-      (should tool-execution-update)
-      (should tool-execution-end)
-      (should (equal (plist-get tool-execution-start :toolName) "read"))
-      (should (equal (plist-get (plist-get tool-execution-start :args) :path)
-                     "/tmp/fake-tool.txt"))
-      (should (string-match-p "fake tool output"
-                              (plist-get (aref (plist-get (plist-get tool-execution-update
-                                                                    :partialResult)
-                                                          :content)
-                                                 0)
-                                         :text)))
-      (should (equal (plist-get tool-execution-end :isError) :false)))))
+           (assistant-starts
+            (pi-coding-agent-fake-pi-test--message-events
+             events "message_start" "assistant"))
+           (assistant-ends
+            (pi-coding-agent-fake-pi-test--message-events
+             events "message_end" "assistant"))
+           (tool-result-start
+            (car (pi-coding-agent-fake-pi-test--message-events
+                  events "message_start" "toolResult")))
+           (tool-result-end
+            (car (pi-coding-agent-fake-pi-test--message-events
+                  events "message_end" "toolResult")))
+           (message-updates
+            (pi-coding-agent-fake-pi-test--events-of-type events "message_update"))
+           (toolcall-start-update
+            (car (pi-coding-agent-fake-pi-test--message-updates
+                  events "toolcall_start")))
+           (toolcall-delta-updates
+            (pi-coding-agent-fake-pi-test--message-updates events "toolcall_delta"))
+           (toolcall-end-update
+            (car (pi-coding-agent-fake-pi-test--message-updates
+                  events "toolcall_end")))
+           (text-delta-updates
+            (pi-coding-agent-fake-pi-test--message-updates events "text_delta"))
+           (tool-execution-start
+            (car (pi-coding-agent-fake-pi-test--events-of-type
+                  events "tool_execution_start")))
+           (tool-execution-update
+            (car (pi-coding-agent-fake-pi-test--events-of-type
+                  events "tool_execution_update")))
+           (tool-execution-end
+            (car (pi-coding-agent-fake-pi-test--events-of-type
+                  events "tool_execution_end")))
+           (agent-end (car (last events)))
+           (lifecycle
+            (mapcar
+             (lambda (obj)
+               (pcase (plist-get obj :type)
+                 ((or "message_start" "message_end")
+                  (format "%s:%s"
+                          (plist-get obj :type)
+                          (plist-get (plist-get obj :message) :role)))
+                 ("message_update"
+                  (plist-get (plist-get obj :assistantMessageEvent) :type))
+                 (type type)))
+             events)))
+      (should
+       (equal lifecycle
+              '("agent_start"
+                "message_start:user" "message_end:user"
+                "message_start:assistant"
+                "toolcall_start"
+                "toolcall_delta" "toolcall_delta" "toolcall_delta"
+                "toolcall_end"
+                "message_end:assistant"
+                "tool_execution_start" "tool_execution_update"
+                "tool_execution_end"
+                "message_start:toolResult" "message_end:toolResult"
+                "message_start:assistant"
+                "text_delta" "text_delta"
+                "message_end:assistant"
+                "agent_end")))
+      (should (> (length toolcall-delta-updates) 1))
+      (should (> (length text-delta-updates) 0))
+      (dolist (update message-updates)
+        (should (plist-member update :usage))
+        (should-not (plist-member update :message))
+        (should-not (plist-member (plist-get update :assistantMessageEvent)
+                                  :partial)))
+      (let* ((first-assistant-end (car assistant-ends))
+             (second-assistant-end (cadr assistant-ends))
+             (toolcall-start-event
+              (plist-get toolcall-start-update :assistantMessageEvent))
+             (toolcall-end-event
+              (plist-get toolcall-end-update :assistantMessageEvent))
+             (call-id (plist-get toolcall-start-event :id))
+             (streamed-arguments
+              (mapconcat
+               (lambda (update)
+                 (plist-get (plist-get update :assistantMessageEvent) :delta))
+               toolcall-delta-updates
+               ""))
+             (tool-call (plist-get toolcall-end-event :toolCall))
+             (tool-assistant-message (plist-get first-assistant-end :message))
+             (tool-call-from-message
+              (aref (plist-get tool-assistant-message :content) 0))
+             (tool-result-message (plist-get tool-result-start :message))
+             (final-message (plist-get second-assistant-end :message))
+             (agent-messages (plist-get agent-end :messages)))
+        (dolist (start assistant-starts)
+          (should (= (length (plist-get (plist-get start :message) :content)) 0))
+          (should (equal (plist-get (plist-get start :message) :stopReason)
+                         "pending")))
+        (should (and (stringp call-id) (> (length call-id) 0)))
+        (should (= (plist-get toolcall-start-event :contentIndex) 0))
+        (should (equal (plist-get toolcall-start-event :toolName) "read"))
+        (should (= (plist-get toolcall-end-event :contentIndex) 0))
+        (dolist (update toolcall-delta-updates)
+          (should (= (plist-get (plist-get update :assistantMessageEvent)
+                                :contentIndex)
+                     0)))
+        (should (equal (pi-coding-agent--parse-json-line streamed-arguments)
+                       '(:path "/tmp/fake-tool.txt")))
+        (should (equal tool-call tool-call-from-message))
+        (should (equal (plist-get tool-assistant-message :stopReason) "toolUse"))
+        (should (equal (plist-get tool-call :id) call-id))
+        (should (equal (plist-get tool-call :name) "read"))
+        (should (equal (plist-get (plist-get tool-call :arguments) :path)
+                       "/tmp/fake-tool.txt"))
+        (dolist (event (list tool-execution-start
+                             tool-execution-update
+                             tool-execution-end))
+          (should (equal (plist-get event :toolCallId) call-id))
+          (should (equal (plist-get event :toolName) "read")))
+        (should (equal (plist-get (plist-get tool-execution-start :args) :path)
+                       "/tmp/fake-tool.txt"))
+        (should (equal (plist-get (aref (plist-get (plist-get tool-execution-update
+                                                               :partialResult)
+                                                   :content)
+                                          0)
+                                  :text)
+                       "fake tool output\n"))
+        (should (equal (plist-get tool-execution-end :isError) :false))
+        (should (equal (plist-get tool-result-end :message) tool-result-message))
+        (should (equal (plist-get tool-result-message :toolCallId) call-id))
+        (should (equal (plist-get tool-result-message :toolName) "read"))
+        (should (equal (plist-get tool-result-message :isError) :false))
+        (should (equal (plist-get tool-result-message :content)
+                       (plist-get (plist-get tool-execution-end :result) :content)))
+        (should (equal (plist-get tool-result-message :details)
+                       (plist-get (plist-get tool-execution-end :result) :details)))
+        (should (equal (plist-get (aref (plist-get tool-result-message :content) 0)
+                                  :text)
+                       "fake tool output\nmore output\n"))
+        (should (equal (mapconcat
+                        (lambda (update)
+                          (plist-get (plist-get update :assistantMessageEvent) :delta))
+                        text-delta-updates
+                        "")
+                       "Tool finished"))
+        (should (equal (plist-get final-message :stopReason) "stop"))
+        (should (equal (plist-get (aref (plist-get final-message :content) 0) :text)
+                       "Tool finished"))
+        (should (equal (mapcar (lambda (message) (plist-get message :role))
+                               agent-messages)
+                       '("user" "assistant" "toolResult" "assistant")))
+        (should (equal (plist-get (aref agent-messages 1) :content)
+                       (plist-get tool-assistant-message :content)))
+        (should (equal (plist-get (aref agent-messages 2) :toolCallId) call-id))
+        (should (equal (plist-get agent-end :willRetry) :false))))))
 
 (ert-deftest pi-coding-agent-fake-pi-test-abort-stops-streaming ()
   "abort stops an in-flight prompt and leaves the fake idle."
@@ -416,7 +557,8 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
     (should (equal (plist-get (pi-coding-agent-fake-pi-test--pop-object proc) :command)
                    "prompt"))
     (let ((seen-first-delta nil)
-          (seen-agent-end nil)
+          (agent-end nil)
+          (aborted-message nil)
           (saw-stop-message-end nil)
           (saw-abort-response nil))
       (while (not seen-first-delta)
@@ -427,24 +569,92 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                      (equal (plist-get msg-event :type) "text_delta"))
             (setq seen-first-delta t))))
       (pi-coding-agent-fake-pi-test--send proc '(:type "abort"))
-      (while (not (and saw-abort-response seen-agent-end))
+      (while (not (and saw-abort-response agent-end))
         (let ((obj (pi-coding-agent-fake-pi-test--pop-object proc)))
           (pcase (plist-get obj :type)
             ("response"
              (when (equal (plist-get obj :command) "abort")
                (setq saw-abort-response (eq (plist-get obj :success) t))))
             ("message_end"
-             (when (equal (plist-get (plist-get obj :message) :stopReason) "stop")
-               (setq saw-stop-message-end t)))
+             (pcase (plist-get (plist-get obj :message) :stopReason)
+               ("aborted" (setq aborted-message (plist-get obj :message)))
+               ("stop" (setq saw-stop-message-end t))))
             ("agent_end"
-             (setq seen-agent-end t)))))
+             (setq agent-end obj)))))
       (should saw-abort-response)
-      (should seen-agent-end)
+      (should aborted-message)
+      (should (equal (plist-get aborted-message :errorMessage)
+                     "Request was aborted"))
       (should-not saw-stop-message-end)
+      (let ((messages (plist-get agent-end :messages)))
+        (should (equal (aref messages (1- (length messages)))
+                       aborted-message)))
       (pi-coding-agent-fake-pi-test--send proc '(:type "get_state"))
       (let* ((state (pi-coding-agent-fake-pi-test--pop-object proc))
              (data (plist-get state :data)))
         (should (eq (plist-get data :isStreaming) :false))))))
+
+(ert-deftest pi-coding-agent-fake-pi-test-tool-abort-ends-partial-assistant-message ()
+  "Aborting tool generation emits its authoritative partial message first."
+  (pi-coding-agent-fake-pi-test-with-process (proc "tool-abort")
+    (pi-coding-agent-fake-pi-test--send proc
+                                        '(:type "prompt" :message "abort tool"))
+    (should (equal (plist-get (pi-coding-agent-fake-pi-test--pop-object proc)
+                              :command)
+                   "prompt"))
+    (let ((events nil)
+          (delta-count 0)
+          (abort-response nil)
+          (agent-end nil))
+      (while (< delta-count 3)
+        (let ((event (pi-coding-agent-fake-pi-test--pop-object proc)))
+          (push event events)
+          (when (and (equal (plist-get event :type) "message_update")
+                     (equal (plist-get
+                             (plist-get event :assistantMessageEvent) :type)
+                            "toolcall_delta"))
+            (setq delta-count (1+ delta-count)))))
+      (pi-coding-agent-fake-pi-test--send proc '(:type "abort"))
+      (while (not (and abort-response agent-end))
+        (let ((event (pi-coding-agent-fake-pi-test--pop-object proc)))
+          (push event events)
+          (pcase (plist-get event :type)
+            ("response"
+             (when (equal (plist-get event :command) "abort")
+               (setq abort-response event)))
+            ("agent_end"
+             (setq agent-end event)))))
+      (setq events (nreverse events))
+      (let* ((aborted-end
+              (seq-find
+               (lambda (event)
+                 (and (equal (plist-get event :type) "message_end")
+                      (equal (plist-get (plist-get event :message) :stopReason)
+                             "aborted")))
+               events))
+             (aborted-message (and aborted-end
+                                   (plist-get aborted-end :message)))
+             (messages (plist-get agent-end :messages)))
+        (should (eq (plist-get abort-response :success) t))
+        (should aborted-message)
+        (should (equal (plist-get aborted-message :errorMessage)
+                       "Request was aborted"))
+        (should (equal (plist-get (aref (plist-get aborted-message :content) 0)
+                                  :name)
+                       "read"))
+        (should (< (seq-position events aborted-end #'eq)
+                   (seq-position events agent-end #'eq)))
+        (should-not
+         (seq-find
+          (lambda (event)
+            (or (equal (plist-get event :type) "tool_execution_start")
+                (and (equal (plist-get event :type) "message_update")
+                     (equal (plist-get
+                             (plist-get event :assistantMessageEvent) :type)
+                            "toolcall_end"))))
+          events))
+        (should (equal (aref messages (1- (length messages)))
+                       aborted-message))))))
 
 (ert-deftest pi-coding-agent-fake-pi-test-steer-queues-another-turn ()
   "steer queues another user turn and delivers it before agent_end."

--- a/test/pi-coding-agent-gui-tests.el
+++ b/test/pi-coding-agent-gui-tests.el
@@ -502,18 +502,15 @@ buffer (jit-lock active) to verify under real GUI conditions."
           (switch-to-buffer buf)
           (pi-coding-agent-chat-mode)
           (pi-coding-agent--handle-display-event '(:type "agent_start"))
-          (pi-coding-agent--handle-display-event '(:type "message_start"))
           (pi-coding-agent--handle-display-event
-           `(:type "message_update"
-             :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
-             :message (:role "assistant"
-                       :content [(:type "toolCall" :id "call_1"
-                                  :name "write"
-                                  :arguments (:path "/tmp/test.py"))])))
+           '(:type "message_start" :message (:role "assistant" :content [])))
+          (pi-coding-agent-test--send-assistant-message-update
+           '(:type "toolcall_start" :contentIndex 0
+             :id "call_1" :toolName "write"))
           (redisplay)
-          (pi-coding-agent-test--send-delta
-           "write" '(:path "/tmp/test.py"
-                     :content "def hello():\n    return 42\n"))
+          (pi-coding-agent-test--send-assistant-message-update
+           '(:type "toolcall_delta" :contentIndex 0
+             :delta "{\"path\":\"/tmp/test.py\",\"content\":\"def hello():\\n    return 42\\n\"}"))
           (font-lock-ensure)
           ;; Fences are in the buffer (for tree-sitter) but invisible
           (let ((visible (pi-coding-agent--visible-text

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -441,12 +441,12 @@ because it inserts at the end, while a full rewrite would lose it."
       (pi-coding-agent--handle-display-event
        '(:type "message_update"
          :assistantMessageEvent (:type "thinking_start")))
-      (pi-coding-agent--handle-display-event
-       '(:type "message_update"
-         :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
-         :message (:role "assistant"
-                   :content [(:type "toolCall" :id "call_1" :name "read"
-                              :arguments (:path "/tmp/AGENTS.md"))])))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_start" :contentIndex 1
+         :id "call_1" :toolName "read"))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_delta" :contentIndex 1
+         :delta "{\"path\":\"/tmp/AGENTS.md\"}"))
       (pi-coding-agent--handle-display-event
        '(:type "message_update"
          :assistantMessageEvent (:type "thinking_delta"
@@ -9988,18 +9988,17 @@ Edit diffs include unchanged context rows with a leading space marker."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--handle-display-event '(:type "agent_start"))
-    (pi-coding-agent--handle-display-event '(:type "message_start"))
+    (pi-coding-agent--handle-display-event
+     '(:type "message_start" :message (:role "assistant")))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "write"))
     (should
      (condition-case nil
          (progn
-           (pi-coding-agent--handle-display-event
-            '(:type "message_update"
-              :assistantMessageEvent (:type "toolcall_delta" :contentIndex 0)
-              :message (:role "assistant"
-                        :content [(:type "toolCall" :id "call_1"
-                                   :name "write"
-                                   :arguments (:path ["not" "a" "path"]
-                                               :content "hello\n"))])))
+           (pi-coding-agent-test--send-assistant-message-update
+            '(:type "toolcall_delta" :contentIndex 0
+              :delta "{\"path\":[\"not\",\"a\",\"path\"],\"content\":\"hello\\n\"}"))
            t)
        (error nil)))
     (should (string-match-p "write \\.\\.\\." (buffer-string)))
@@ -11018,17 +11017,34 @@ hooks, including `kill-buffer-hook'."
 ;; ── Toolcall streaming (during LLM generation) ─────────────────────
 
 (defun pi-coding-agent-test--tool-block-overlay-by-id (tool-call-id)
-  "Return the live tool block overlay for TOOL-CALL-ID, or nil."
-  (when-let* ((block (gethash tool-call-id pi-coding-agent--live-tool-blocks)))
-    (pi-coding-agent--tool-block-overlay block)))
+  "Return the keyed or generation-owned overlay for TOOL-CALL-ID."
+  (or (when-let* ((block (gethash tool-call-id
+                                  pi-coding-agent--live-tool-blocks)))
+        (pi-coding-agent--tool-block-overlay block))
+      (when pi-coding-agent--toolcall-streams
+        (catch 'found
+          (maphash
+           (lambda (_content-index stream)
+             (when (equal tool-call-id
+                          (pi-coding-agent--toolcall-stream-tool-call-id stream))
+               (when-let* ((block
+                            (pi-coding-agent--toolcall-stream-block stream)))
+                 (throw 'found (pi-coding-agent--tool-block-overlay block)))))
+           pi-coding-agent--toolcall-streams)
+          nil))))
+
+(defun pi-coding-agent-test--tool-header-from-overlay (overlay)
+  "Return the plain header text from tool block OVERLAY."
+  (when-let* ((header-end (overlay-get overlay 'pi-coding-agent-header-end)))
+    (buffer-substring-no-properties
+     (overlay-start overlay)
+     (1- (marker-position header-end)))))
 
 (defun pi-coding-agent-test--tool-header-by-id (tool-call-id)
   "Return the plain header text for TOOL-CALL-ID."
-  (when-let* ((ov (pi-coding-agent-test--tool-block-overlay-by-id tool-call-id))
-              (header-end (overlay-get ov 'pi-coding-agent-header-end)))
-    (buffer-substring-no-properties
-     (overlay-start ov)
-     (1- (marker-position header-end)))))
+  (when-let* ((overlay
+               (pi-coding-agent-test--tool-block-overlay-by-id tool-call-id)))
+    (pi-coding-agent-test--tool-header-from-overlay overlay)))
 
 (defun pi-coding-agent-test--tool-stream-body-from-overlay (ov)
   "Return tool overlay OV body as plain text."
@@ -11081,42 +11097,30 @@ Content lines — even those starting with ``` — are preserved."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--handle-display-event '(:type "agent_start"))
-    (pi-coding-agent--handle-display-event '(:type "message_start"))
-    ;; Text delta without trailing newline (common: LLM streams partial line)
     (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "text_delta" :delta "Let me check.")))
-    ;; toolcall_start fires immediately after
-    (pi-coding-agent--handle-display-event
-     `(:type "message_update"
-       :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
-       :message (:role "assistant"
-                 :content [(:type "toolCall" :id "call_1"
-                            :name "bash" :arguments (:command "ls"))])))
-    ;; Must have blank line between text and tool header
+     '(:type "message_start" :message (:role "assistant")))
+    ;; Text delta without trailing newline (common: LLM streams partial line).
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "text_delta" :contentIndex 0 :delta "Let me check."))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1
+       :id "call_1" :toolName "bash"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 1
+       :delta "{\"command\":\"ls\"}"))
+    ;; Must have blank line between text and tool header.
     (should (string-match-p "check\\.\n\n\\$ ls" (buffer-string)))))
 
 (ert-deftest pi-coding-agent-test-toolcall-delta-updates-header-not-path ()
   "toolcall_delta updates visible header text but not navigation metadata."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--handle-display-event '(:type "agent_start"))
-    (pi-coding-agent--handle-display-event '(:type "message_start"))
-    ;; toolcall_start with empty args (LLM just started generating JSON)
-    (pi-coding-agent--handle-display-event
-     `(:type "message_update"
-       :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
-       :message (:role "assistant"
-                 :content [(:type "toolCall" :id "call_1"
-                            :name "read" :arguments nil)])))
-    ;; Delta with path — header updates for visual feedback only.
-    (pi-coding-agent--handle-display-event
-     `(:type "message_update"
-       :assistantMessageEvent (:type "toolcall_delta" :contentIndex 0 :delta "x")
-       :message (:role "assistant"
-                 :content [(:type "toolCall" :id "call_1"
-                            :name "read"
-                            :arguments (:path "/tmp/foo.py"))])))
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "read"))
+    ;; An unfinished path string is still useful visual feedback.
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "{\"path\":\"/tmp/foo.py"))
     (should (string-match-p "read /tmp/foo\\.py" (buffer-string)))
     (should-not (overlay-get pi-coding-agent--pending-tool-overlay
                              'pi-coding-agent-tool-path))
@@ -11163,28 +11167,25 @@ Content lines — even those starting with ``` — are preserved."
   "Header updates from placeholder to real args at tool_execution_start.
 During streaming, header shows placeholder.  When execution starts with
 authoritative args, header and overlay path are updated."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--handle-display-event '(:type "agent_start"))
-    (pi-coding-agent--handle-display-event '(:type "message_start"))
-    ;; toolcall_start with nil args
-    (pi-coding-agent--handle-display-event
-     `(:type "message_update"
-       :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
-       :message (:role "assistant"
-                 :content [(:type "toolCall" :id "call_1"
-                            :name "read" :arguments nil)])))
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "read"))
     (should (string-match-p "read \\.\\.\\." (buffer-string)))
-    ;; tool_execution_start with authoritative args
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_end" :contentIndex 0
+       :toolCall (:type "toolCall" :id "call_1" :name "read"
+                  :arguments (:offset 1))))
     (pi-coding-agent--handle-display-event
-     '(:type "message_end" :message (:role "assistant")))
+     '(:type "message_end"
+       :message (:role "assistant" :stopReason "toolUse"
+                 :content [(:type "toolCall" :id "call_1" :name "read"
+                            :arguments (:offset 1))])))
     (pi-coding-agent--handle-display-event
      '(:type "tool_execution_start" :toolCallId "call_1"
        :toolName "read" :args (:path "/tmp/foo.py")))
-    ;; Now header should show the real path
     (should (string-match-p "read /tmp/foo\\.py" (buffer-string)))
     (should-not (string-match-p "read \\.\\.\\." (buffer-string)))
-    ;; And overlay should have the path
     (should (equal "/tmp/foo.py"
                    (overlay-get pi-coding-agent--pending-tool-overlay
                                 'pi-coding-agent-tool-path)))))
@@ -11371,40 +11372,48 @@ authoritative args, header and overlay path are updated."
       (should (= 2 (hash-table-count pi-coding-agent--live-tool-blocks))))))
 
 (ert-deftest pi-coding-agent-test-toolcall-reconcile-removes-stale-preview-blocks ()
-  "Authoritative assistant toolcall content should drop stale previews."
+  "Authoritative message_end content drops stale streamed previews."
   (pi-coding-agent-test--with-streaming-assistant
-    (let ((toolcalls (list (pi-coding-agent-test--toolcall
-                            "call_1" "write" '(:path "/tmp/a.py"))
-                           (pi-coding-agent-test--toolcall
-                            "call_2" "write" '(:path "/tmp/b.py")))))
-      (pi-coding-agent-test--send-toolcall-message-update
-       "toolcall_start" 0 toolcalls)
-      (pi-coding-agent-test--send-toolcall-message-update
-       "toolcall_start" 1 toolcalls)
-      (pi-coding-agent-test--send-toolcall-message-update
-       "toolcall_delta" 0
-       (list (pi-coding-agent-test--toolcall
-              "call_1" "write" '(:path "/tmp/a.py")))
-       "x")
-      (let ((content (buffer-string)))
-        (should (string-match-p "write /tmp/a\\.py" content))
-        (should-not (string-match-p "write /tmp/b\\.py" content)))
-      (should (pi-coding-agent--tool-block-get "call_1"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1
+       :id "call_2" :toolName "write"))
+    (let ((first (pi-coding-agent-test--tool-block-overlay-by-id "call_1"))
+          (stale (pi-coding-agent-test--tool-block-overlay-by-id "call_2")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end"
+         :message (:role "assistant" :stopReason "toolUse"
+                   :content [(:type "toolCall" :id "call_1" :name "write"
+                              :arguments (:path "/tmp/a.py"))])))
+      (should (eq first
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_1")))
+      (should-not (overlay-buffer stale))
+      (should (equal "write /tmp/a.py"
+                     (pi-coding-agent-test--tool-header-by-id "call_1")))
       (should-not (pi-coding-agent--tool-block-get "call_2"))
-      (should (= 1 (hash-table-count pi-coding-agent--live-tool-blocks)))
-      (should (equal "call_1"
-                     (pi-coding-agent--tool-block-tool-call-id
-                      (pi-coding-agent--current-tool-block)))))))
+      (should (= 1 (hash-table-count pi-coding-agent--live-tool-blocks))))))
 
 (ert-deftest pi-coding-agent-test-tool-preview-helper-inserts-before-later-live-block ()
   "Earlier preview orders insert before already-live later blocks."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
-    (pi-coding-agent--display-tool-start "write" '(:path "/tmp/b.py") "call_2" 2)
-    (pi-coding-agent--display-tool-start "write" '(:path "/tmp/a.py") "call_1" 1)
-    (let ((content (buffer-string)))
+    (let* ((later (pi-coding-agent--display-tool-start
+                   "write" '(:path "/tmp/b.py") "call_2" 2))
+           (earlier (pi-coding-agent--display-tool-start
+                     "write" '(:path "/tmp/a.py") "call_1" 1))
+           (later-overlay (pi-coding-agent--tool-block-overlay later))
+           (earlier-overlay (pi-coding-agent--tool-block-overlay earlier))
+           (content (buffer-string)))
       (should (< (string-match "write /tmp/a\\.py" content)
-                 (string-match "write /tmp/b\\.py" content))))
+                 (string-match "write /tmp/b\\.py" content)))
+      (should (< (overlay-start earlier-overlay)
+                 (overlay-end earlier-overlay)))
+      (should (< (overlay-start later-overlay)
+                 (overlay-end later-overlay)))
+      (should (<= (overlay-end earlier-overlay)
+                  (overlay-start later-overlay))))
     (should (= 2 (hash-table-count pi-coding-agent--live-tool-blocks)))))
 
 (ert-deftest pi-coding-agent-test-live-tool-block-ordering-stays-monotonic-after-explicit-previews ()
@@ -11774,6 +11783,575 @@ Multiple deltas should replace the preview instead of appending forever."
                    "write /tmp/foo\\.py" (buffer-string))))
     (should (pi-coding-agent--tool-block-get "call_1"))))
 
+(ert-deftest pi-coding-agent-test-delta-only-toolcall-full-event-flow ()
+  "Pi's delta-only toolcall stream reuses one block through execution."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "write"))
+    (let ((preview (pi-coding-agent-test--tool-block-overlay-by-id "call_1")))
+      (should preview)
+      (should (equal "write ..."
+                     (pi-coding-agent-test--tool-header-by-id "call_1")))
+      (should (= 1 (length (pi-coding-agent-test--all-tool-overlays))))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_delta" :contentIndex 0
+         :delta "{\"path\":\"/tmp/foo.py\",\"content\":\"streaming "))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_delta" :contentIndex 0
+         :delta "content\\n\"}"))
+      (should (eq preview
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_1")))
+      (should (equal "write /tmp/foo.py"
+                     (pi-coding-agent-test--tool-header-by-id "call_1")))
+      (should (equal '("streaming content")
+                     (pi-coding-agent-test--tool-content-lines-by-id "call_1")))
+      ;; Streaming previews are display-only; navigation waits for execution.
+      (should-not (overlay-get preview 'pi-coding-agent-tool-path))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 0
+         :toolCall (:type "toolCall" :id "call_1" :name "write"
+                    :arguments (:path "/tmp/foo.py"
+                                :content "streaming content\n"))))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end"
+         :message (:role "assistant" :stopReason "toolUse"
+                   :content [(:type "toolCall" :id "call_1" :name "write"
+                              :arguments (:path "/tmp/foo.py"
+                                          :content "streaming content\n"))])))
+      (should (eq preview
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_1")))
+      (should (= 1 (length (pi-coding-agent-test--all-tool-overlays))))
+      (pi-coding-agent--handle-display-event
+       '(:type "tool_execution_start" :toolCallId "call_1"
+         :toolName "write"
+         :args (:path "/tmp/foo.py" :content "final content")))
+      (should (eq preview
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_1")))
+      (should (equal "/tmp/foo.py"
+                     (overlay-get preview 'pi-coding-agent-tool-raw-path)))
+      (pi-coding-agent--handle-display-event
+       '(:type "tool_execution_end" :toolCallId "call_1"
+         :toolName "write"
+         :result (:content [(:type "text" :text "wrote 42 lines")]
+                  :details nil)
+         :isError :json-false))
+      (should (= 0 (hash-table-count pi-coding-agent--live-tool-blocks)))
+      (should-not pi-coding-agent--pending-tool-overlay)
+      (should (= 1 (length (pi-coding-agent-test--all-tool-overlays))))
+      (should (eq 'pi-coding-agent-tool-block
+                  (overlay-get preview 'face)))
+      (should (equal '("final content")
+                     (pi-coding-agent-test--tool-content-lines-from-stream
+                      (pi-coding-agent-test--tool-stream-body-from-overlay
+                       preview)))))))
+
+(ert-deftest pi-coding-agent-test-delta-only-toolcalls-interleave-by-content-index ()
+  "Interleaved argument deltas update only their indexed preview blocks."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1
+       :id "call_a" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 3
+       :id "call_b" :toolName "write"))
+    (let ((first (pi-coding-agent-test--tool-block-overlay-by-id "call_a"))
+          (second (pi-coding-agent-test--tool-block-overlay-by-id "call_b")))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_delta" :contentIndex 1
+         :delta "{\"path\":\"/tmp/a.py\",\"content\":\"alpha"))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_delta" :contentIndex 3
+         :delta "{\"path\":\"/tmp/b.py\",\"content\":\"bravo\\n\"}"))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_delta" :contentIndex 1 :delta "\\n\"}"))
+      (should (eq first
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_a")))
+      (should (eq second
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_b")))
+      (should (equal '("alpha")
+                     (pi-coding-agent-test--tool-content-lines-by-id "call_a")))
+      (should (equal '("bravo")
+                     (pi-coding-agent-test--tool-content-lines-by-id "call_b")))
+      (should (equal '("call_a" "call_b")
+                     (mapcar
+                      (lambda (index)
+                        (pi-coding-agent--toolcall-stream-tool-call-id
+                         (gethash index pi-coding-agent--toolcall-streams)))
+                      '(1 3))))
+      (should (< (overlay-start first) (overlay-start second)))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 1
+         :toolCall (:type "toolCall" :id "call_a" :name "write"
+                    :arguments (:path "/tmp/a.py" :content "alpha\n"))))
+      ;; Ending one call is not an authoritative snapshot of its siblings.
+      (should (eq second
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_b")))
+      (should (= 1 (hash-table-count pi-coding-agent--live-tool-blocks)))
+      (should (= 2 (length (pi-coding-agent-test--all-tool-overlays))))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 3
+         :toolCall (:type "toolCall" :id "call_b" :name "write"
+                    :arguments (:path "/tmp/b.py" :content "bravo\n"))))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end"
+         :message (:role "assistant" :stopReason "toolUse"
+                   :content [(:type "text" :text "Working")
+                             (:type "toolCall" :id "call_a" :name "write"
+                              :arguments (:path "/tmp/a.py" :content "alpha\n"))
+                             (:type "text" :text "and")
+                             (:type "toolCall" :id "call_b" :name "write"
+                              :arguments (:path "/tmp/b.py" :content "bravo\n"))])))
+      (should (eq first
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_a")))
+      (should (eq second
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_b")))
+      (should (= 2 (length (pi-coding-agent-test--all-tool-overlays)))))))
+
+(ert-deftest pi-coding-agent-test-delta-only-toolcall-decodes-preview-strings ()
+  "Preview parsing handles nesting, chunked escapes, and Unicode safely."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "{\"meta\":{\"path\":\"wrong\"},\"path\":\"src/ma"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "in.py\",\"content\":\"caf\\u00"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "e9 \\uD83D"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "\\uDE00\\n\"}"))
+    (should (equal "write src/main.py"
+                   (pi-coding-agent-test--tool-header-by-id "call_1")))
+    (should (equal '("café 😀")
+                   (pi-coding-agent-test--tool-content-lines-by-id "call_1")))
+    (should-not (string-match-p "wrong" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-delta-only-toolcall-preserves-invalid-backslashes ()
+  "Preview repair keeps provider-emitted Windows path backslashes visible."
+  (dolist (path '("C:\\Users\\alice" "C:\\users\\alice"))
+    (pi-coding-agent-test--with-streaming-assistant
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_start" :contentIndex 0
+         :id "call_1" :toolName "read"))
+      (pi-coding-agent-test--send-assistant-message-update
+       `(:type "toolcall_delta" :contentIndex 0
+         :delta ,(concat "{\"path\":\"" path "\"}")))
+      (should (equal (concat "read " path)
+                     (pi-coding-agent-test--tool-header-by-id "call_1"))))))
+
+(ert-deftest pi-coding-agent-test-delta-only-write-preview-retains-bounded-tail ()
+  "Large streamed write values retain only the configured preview tail."
+  (let ((pi-coding-agent-preview-max-bytes 24))
+    (pi-coding-agent-test--with-streaming-assistant
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_start" :contentIndex 0
+         :id "call_1" :toolName "write"))
+      (pi-coding-agent-test--send-assistant-message-update
+       `(:type "toolcall_delta" :contentIndex 0
+         :delta ,(concat "{\"content\":\""
+                         (make-string 80 ?x)
+                         "TAIL\\n\"}")))
+      (let ((body (pi-coding-agent-test--tool-stream-body-by-id "call_1")))
+        (should (string-match-p "TAIL" body))
+        (should (string-match-p "earlier output" body))
+        (should (< (length body) 80))))))
+
+(ert-deftest pi-coding-agent-test-delta-only-late-path-relabels-write-fence ()
+  "A path arriving after complete content refreshes the fence language."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "{\"content\":\"value = 1\\n\","))
+    (should-not (string-match-p "```python" (buffer-string)))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "\"path\":\"/tmp/value.py\"}"))
+    (should (equal "write /tmp/value.py"
+                   (pi-coding-agent-test--tool-header-by-id "call_1")))
+    (should (string-match-p "```python" (buffer-string)))
+    (should (string-match-p "value = 1" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-delta-only-truncation-resets-for-later-content ()
+  "A later content key clears obsolete truncation presentation state."
+  (let ((pi-coding-agent-preview-max-bytes 12))
+    (pi-coding-agent-test--with-streaming-assistant
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_start" :contentIndex 0
+         :id "call_1" :toolName "write"))
+      (pi-coding-agent-test--send-assistant-message-update
+       `(:type "toolcall_delta" :contentIndex 0
+         :delta ,(concat "{\"content\":\"" (make-string 40 ?x)
+                         "\\n\",\"content\":\"ok\\n\"}")))
+      (let ((body (pi-coding-agent-test--tool-stream-body-by-id "call_1")))
+        (should (string-match-p "ok" body))
+        (should-not (string-match-p "earlier output" body))))))
+
+(ert-deftest pi-coding-agent-test-delta-only-later-nonstring-clears-preview-value ()
+  "A later non-string duplicate follows JSON last-key semantics."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "read"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "{\"path\":\"/tmp/stale\",\"path\":null}"))
+    (should (equal "read ..."
+                   (pi-coding-agent-test--tool-header-by-id "call_1")))))
+
+(ert-deftest pi-coding-agent-test-message-end-rekeys-streamed-toolcall-preview ()
+  "Authority changes across both end events preserve one preview block."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "provisional" :toolName "read"))
+    (let ((preview
+           (pi-coding-agent-test--tool-block-overlay-by-id "provisional")))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 0
+         :toolCall (:type "toolCall" :id "ended" :name "read"
+                    :arguments (:path "/tmp/ended.txt"))))
+      (should (eq preview
+                  (pi-coding-agent-test--tool-block-overlay-by-id "ended")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end"
+         :message (:role "assistant" :stopReason "toolUse"
+                   :content [(:type "toolCall" :id "final" :name "read"
+                              :arguments (:path "/tmp/final.txt"))])))
+      (should-not (pi-coding-agent--tool-block-get "provisional"))
+      (should-not (pi-coding-agent--tool-block-get "ended"))
+      (should (eq preview
+                  (pi-coding-agent-test--tool-block-overlay-by-id "final")))
+      (should (equal "read /tmp/final.txt"
+                     (pi-coding-agent-test--tool-header-by-id "final")))
+      (should (= 1 (length (pi-coding-agent-test--all-tool-overlays)))))))
+
+(ert-deftest pi-coding-agent-test-toolcall-end-clears-stale-write-preview-body ()
+  "Authoritative non-write toolcall_end removes streamed write content."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "{\"path\":\"/tmp/file.txt\",\"content\":\"stale\\n\"}"))
+    (let ((preview (pi-coding-agent-test--tool-block-overlay-by-id "call_1")))
+      (should (equal '("stale")
+                     (pi-coding-agent-test--tool-content-lines-by-id "call_1")))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 0
+         :toolCall (:type "toolCall" :id "call_1" :name "read"
+                    :arguments (:path "/tmp/file.txt"))))
+      (should (eq preview
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_1")))
+      (should (equal "read /tmp/file.txt"
+                     (pi-coding-agent-test--tool-header-by-id "call_1")))
+      (should (string-empty-p
+               (string-trim
+                (pi-coding-agent-test--tool-stream-body-from-overlay preview)))))))
+
+(ert-deftest pi-coding-agent-test-empty-start-ids-keep-indexed-previews-independent ()
+  "Provisional empty IDs do not collapse distinct content-index previews."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0 :id "" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1 :id "" :toolName "write"))
+    (let* ((overlays (pi-coding-agent-test--all-tool-overlays))
+           (first (nth 0 overlays))
+           (second (nth 1 overlays)))
+      (should (= 2 (length overlays)))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_delta" :contentIndex 0
+         :delta "{\"path\":\"/tmp/a.py\"}"))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_delta" :contentIndex 1
+         :delta "{\"path\":\"/tmp/b.py\"}"))
+      (should (equal "write /tmp/a.py"
+                     (pi-coding-agent-test--tool-header-from-overlay first)))
+      (should (equal "write /tmp/b.py"
+                     (pi-coding-agent-test--tool-header-from-overlay second)))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 0
+         :toolCall (:type "toolCall" :id "call_a" :name "write"
+                    :arguments (:path "/tmp/a.py"))))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 1
+         :toolCall (:type "toolCall" :id "call_b" :name "write"
+                    :arguments (:path "/tmp/b.py"))))
+      (should (eq first
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_a")))
+      (should (eq second
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_b")))
+      (should (= 2 (length (pi-coding-agent-test--all-tool-overlays)))))))
+
+(ert-deftest pi-coding-agent-test-metadata-less-toolcall-start-finalizes-at-end ()
+  "Tagged Pi 0.84.2 falls back cleanly when start metadata is unavailable."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "{\"path\":\"/tmp/released.txt\"}"))
+    (should-not (pi-coding-agent-test--all-tool-overlays))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_end" :contentIndex 0
+       :toolCall (:type "toolCall" :id "call_1" :name "read"
+                  :arguments (:path "/tmp/released.txt"))))
+    (should (equal "read /tmp/released.txt"
+                   (pi-coding-agent-test--tool-header-by-id "call_1")))
+    (should (= 1 (length (pi-coding-agent-test--all-tool-overlays))))))
+
+(ert-deftest pi-coding-agent-test-metadata-less-reversed-ends-preserve-distinct-blocks ()
+  "Reversed finalization keeps indexed blocks distinct through execution."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_end" :contentIndex 1
+       :toolCall (:type "toolCall" :id "call_b" :name "read"
+                  :arguments (:path "/tmp/b"))))
+    (let ((later (pi-coding-agent-test--tool-block-overlay-by-id "call_b")))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 0
+         :toolCall (:type "toolCall" :id "call_a" :name "read"
+                    :arguments (:path "/tmp/a"))))
+      (let ((earlier (pi-coding-agent-test--tool-block-overlay-by-id "call_a")))
+        (should (= 2 (length (pi-coding-agent-test--all-tool-overlays))))
+        (should (< (overlay-start earlier) (overlay-end earlier)))
+        (should (< (overlay-start later) (overlay-end later)))
+        (should (<= (overlay-end earlier) (overlay-start later)))
+        (pi-coding-agent--handle-display-event
+         '(:type "message_end"
+           :message (:role "assistant" :stopReason "toolUse"
+                     :content [(:type "toolCall" :id "call_a" :name "read"
+                                :arguments (:path "/tmp/a"))
+                               (:type "toolCall" :id "call_b" :name "read"
+                                :arguments (:path "/tmp/b"))])))
+        (should (eq earlier
+                    (pi-coding-agent-test--tool-block-overlay-by-id "call_a")))
+        (should (eq later
+                    (pi-coding-agent-test--tool-block-overlay-by-id "call_b")))
+        (pi-coding-agent--handle-display-event
+         '(:type "tool_execution_start" :toolCallId "call_a"
+           :toolName "read" :args (:path "/tmp/a")))
+        (pi-coding-agent--handle-display-event
+         '(:type "tool_execution_start" :toolCallId "call_b"
+           :toolName "read" :args (:path "/tmp/b")))
+        (should (eq earlier
+                    (pi-coding-agent-test--tool-block-overlay-by-id "call_a")))
+        (should (eq later
+                    (pi-coding-agent-test--tool-block-overlay-by-id "call_b")))
+        (should (equal "read /tmp/a"
+                       (pi-coding-agent-test--tool-header-by-id "call_a")))
+        (should (equal "read /tmp/b"
+                       (pi-coding-agent-test--tool-header-by-id "call_b")))))))
+
+(ert-deftest pi-coding-agent-test-metadata-less-duplicate-final-ids-keep-indexed-blocks ()
+  "Metadata-less streams stay distinct until duplicate authority is deduped."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_end" :contentIndex 0
+       :toolCall (:type "toolCall" :id "duplicate" :name "read"
+                  :arguments (:path "/tmp/a"))))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_end" :contentIndex 1
+       :toolCall (:type "toolCall" :id "duplicate" :name "read"
+                  :arguments (:path "/tmp/b"))))
+    (let* ((first-stream (gethash 0 pi-coding-agent--toolcall-streams))
+           (second-stream (gethash 1 pi-coding-agent--toolcall-streams))
+           (first-block (pi-coding-agent--toolcall-stream-block first-stream))
+           (second-block (pi-coding-agent--toolcall-stream-block second-stream))
+           (first-overlay (pi-coding-agent--tool-block-overlay first-block))
+           (second-overlay (pi-coding-agent--tool-block-overlay second-block)))
+      (should-not (eq first-block second-block))
+      (should (= 2 (length (pi-coding-agent-test--all-tool-overlays))))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end"
+         :message (:role "assistant" :stopReason "toolUse"
+                   :content [(:type "toolCall" :id "duplicate" :name "read"
+                              :arguments (:path "/tmp/a"))
+                             (:type "toolCall" :id "duplicate" :name "read"
+                              :arguments (:path "/tmp/b"))])))
+      (should (= 1 (length (pi-coding-agent-test--all-tool-overlays))))
+      (should (overlay-buffer first-overlay))
+      (should-not (overlay-buffer second-overlay))
+      (should (equal "read /tmp/a"
+                     (pi-coding-agent-test--tool-header-from-overlay
+                      first-overlay))))))
+
+(ert-deftest pi-coding-agent-test-duplicate-start-ids-keep-indexed-previews-independent ()
+  "Duplicate provisional IDs cannot collapse distinct generation blocks."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "duplicate" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1
+       :id "duplicate" :toolName "write"))
+    (let ((overlays (pi-coding-agent-test--all-tool-overlays)))
+      (should (= 2 (length overlays)))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 0
+         :toolCall (:type "toolCall" :id "call_a" :name "write"
+                    :arguments (:path "/tmp/a"))))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 1
+         :toolCall (:type "toolCall" :id "call_b" :name "write"
+                    :arguments (:path "/tmp/b"))))
+      (should (eq (nth 0 overlays)
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_a")))
+      (should (eq (nth 1 overlays)
+                  (pi-coding-agent-test--tool-block-overlay-by-id "call_b"))))))
+
+(ert-deftest pi-coding-agent-test-colliding-provisional-id-rekeys-by-content-index ()
+  "Final IDs recover distinct blocks after a provisional registry collision."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "duplicate" :toolName "read"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1
+       :id "duplicate" :toolName "read"))
+    (let* ((overlays (pi-coding-agent-test--all-tool-overlays))
+           (first (nth 0 overlays))
+           (second (nth 1 overlays)))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 0
+         :toolCall (:type "toolCall" :id "duplicate" :name "read"
+                    :arguments (:path "/tmp/a"))))
+      (pi-coding-agent-test--send-assistant-message-update
+       '(:type "toolcall_end" :contentIndex 1
+         :toolCall (:type "toolCall" :id "duplicate" :name "read"
+                    :arguments (:path "/tmp/b"))))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end"
+         :message (:role "assistant" :stopReason "toolUse"
+                   :content [(:type "toolCall" :id "duplicate" :name "read"
+                              :arguments (:path "/tmp/a"))
+                             (:type "toolCall" :id "fixed" :name "read"
+                              :arguments (:path "/tmp/b"))])))
+      (should (eq first
+                  (pi-coding-agent-test--tool-block-overlay-by-id "duplicate")))
+      (should (eq second
+                  (pi-coding-agent-test--tool-block-overlay-by-id "fixed")))
+      (pi-coding-agent--handle-display-event
+       '(:type "tool_execution_start" :toolCallId "duplicate"
+         :toolName "read" :args (:path "/tmp/a")))
+      (pi-coding-agent--handle-display-event
+       '(:type "tool_execution_start" :toolCallId "fixed"
+         :toolName "read" :args (:path "/tmp/b")))
+      (should (= 2 (length (pi-coding-agent-test--all-tool-overlays)))))))
+
+(ert-deftest pi-coding-agent-test-duplicate-final-ids-leave-one-owned-preview ()
+  "Duplicate authoritative IDs fail closed without orphaning a live block."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0 :id "a" :toolName "read"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1 :id "b" :toolName "read"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_end" :contentIndex 0
+       :toolCall (:type "toolCall" :id "duplicate" :name "read"
+                  :arguments (:path "/tmp/a"))))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_end" :contentIndex 1
+       :toolCall (:type "toolCall" :id "duplicate" :name "read"
+                  :arguments (:path "/tmp/b"))))
+    (pi-coding-agent--handle-display-event
+     '(:type "message_end"
+       :message (:role "assistant" :stopReason "toolUse"
+                 :content [(:type "toolCall" :id "duplicate" :name "read"
+                            :arguments (:path "/tmp/a"))
+                           (:type "toolCall" :id "duplicate" :name "read"
+                            :arguments (:path "/tmp/b"))])))
+    (should (= 1 (length (pi-coding-agent-test--all-tool-overlays))))
+    (should (pi-coding-agent--tool-block-get "duplicate"))
+    (pi-coding-agent--handle-display-event
+     '(:type "agent_end" :messages [] :willRetry :json-false))
+    (should (= 0 (hash-table-count pi-coding-agent--live-tool-blocks)))))
+
+(ert-deftest pi-coding-agent-test-message-end-removal-leaves-no-dangling-preview ()
+  "Extension removal at message_end cannot poison later agent cleanup."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "read"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_end" :contentIndex 0
+       :toolCall (:type "toolCall" :id "call_1" :name "read"
+                  :arguments (:path "/tmp/removed"))))
+    (let ((preview (pi-coding-agent-test--tool-block-overlay-by-id "call_1")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end"
+         :message (:role "assistant" :stopReason "stop" :content [])))
+      (should-not (overlay-buffer preview))
+      (should-not pi-coding-agent--pending-tool-overlay)
+      (should
+       (condition-case nil
+           (progn
+             (pi-coding-agent--handle-display-event
+              '(:type "agent_end" :messages [] :willRetry :json-false))
+             t)
+         (error nil))))))
+
+(ert-deftest pi-coding-agent-test-process-exit-finalizes-generation-blocks ()
+  "Unexpected process exit finalizes every stream-owned preview block."
+  (let ((process (start-process "pi-render-exit-test" nil "cat")))
+    (unwind-protect
+        (pi-coding-agent-test--with-streaming-assistant
+          (setq pi-coding-agent--process process)
+          (pi-coding-agent-test--send-assistant-message-update
+           '(:type "toolcall_start" :contentIndex 0
+             :id "" :toolName "read"))
+          (pi-coding-agent-test--send-assistant-message-update
+           '(:type "toolcall_start" :contentIndex 1
+             :id "" :toolName "read"))
+          (let ((overlays (pi-coding-agent-test--all-tool-overlays)))
+            (should (= 2 (length overlays)))
+            (pi-coding-agent--mark-process-exited
+             process '(:error "Process exited" :exitCode 1))
+            (dolist (overlay overlays)
+              (should (eq (overlay-get overlay 'face)
+                          'pi-coding-agent-tool-block-error)))
+            (should (= 0 (hash-table-count
+                          pi-coding-agent--toolcall-streams)))
+            (should-not pi-coding-agent--pending-tool-overlay)))
+      (when (process-live-p process)
+        (delete-process process)))))
+
+(ert-deftest pi-coding-agent-test-abort-finalizes-empty-id-generation-blocks ()
+  "Abort finalizes every content-index-owned block before clearing streams."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0 :id "" :toolName "read"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 1 :id "" :toolName "read"))
+    (let ((overlays (pi-coding-agent-test--all-tool-overlays)))
+      (should (= 2 (length overlays)))
+      (setq pi-coding-agent--aborted t)
+      (pi-coding-agent--handle-display-event
+       '(:type "agent_end" :messages [] :willRetry :json-false))
+      (dolist (overlay overlays)
+        (should (eq (overlay-get overlay 'face)
+                    'pi-coding-agent-tool-block-error)))
+      (should (= 0 (hash-table-count pi-coding-agent--toolcall-streams)))
+      (should-not pi-coding-agent--pending-tool-overlay))))
+
 (ert-deftest pi-coding-agent-test-toolcall-full-event-flow ()
   "Full toolcall streaming flow produces correct final output."
   (pi-coding-agent-test--with-toolcall "write" '(:path "/tmp/foo.py")
@@ -11811,12 +12389,32 @@ Multiple deltas should replace the preview instead of appending forever."
     (should-not (string-match-p "offset" (buffer-string)))))
 
 (ert-deftest pi-coding-agent-test-toolcall-abort-cleans-up ()
-  "Abort during toolcall streaming cleans up properly."
-  (pi-coding-agent-test--with-toolcall "write" '(:path "/tmp/foo.py")
+  "Abort drops incomplete argument state before a content index is reused."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_1" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "{\"path\":\"/tmp/old.py\",\"content\":\"old"))
     (let ((pi-coding-agent--aborted t))
       (pi-coding-agent--handle-display-event '(:type "agent_end")))
     (should-not pi-coding-agent--pending-tool-overlay)
-    (should (= 0 (hash-table-count pi-coding-agent--live-tool-blocks)))))
+    (should (= 0 (hash-table-count pi-coding-agent--live-tool-blocks)))
+    (should (= 0 (hash-table-count pi-coding-agent--toolcall-streams)))
+    (pi-coding-agent--handle-display-event '(:type "agent_start"))
+    (pi-coding-agent--handle-display-event
+     '(:type "message_start" :message (:role "assistant")))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_start" :contentIndex 0
+       :id "call_2" :toolName "write"))
+    (pi-coding-agent-test--send-assistant-message-update
+     '(:type "toolcall_delta" :contentIndex 0
+       :delta "{\"path\":\"/tmp/new.py\",\"content\":\"new\\n\"}"))
+    (should (equal "write /tmp/new.py"
+                   (pi-coding-agent-test--tool-header-by-id "call_2")))
+    (should (equal '("new")
+                   (pi-coding-agent-test--tool-content-lines-by-id "call_2")))))
 
 (ert-deftest pi-coding-agent-test-abort-finalizes-all-live-tool-blocks ()
   "Abort finalizes every live tool block and clears keyed tool state."

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -11026,9 +11026,9 @@ hooks, including `kill-buffer-hook'."
           (maphash
            (lambda (_content-index stream)
              (when (equal tool-call-id
-                          (pi-coding-agent--toolcall-stream-tool-call-id stream))
+                          (pi-coding-agent--tool-stream-tool-call-id stream))
                (when-let* ((block
-                            (pi-coding-agent--toolcall-stream-block stream)))
+                            (pi-coding-agent--tool-stream-block stream)))
                  (throw 'found (pi-coding-agent--tool-block-overlay block)))))
            pi-coding-agent--toolcall-streams)
           nil))))
@@ -11876,7 +11876,7 @@ Multiple deltas should replace the preview instead of appending forever."
       (should (equal '("call_a" "call_b")
                      (mapcar
                       (lambda (index)
-                        (pi-coding-agent--toolcall-stream-tool-call-id
+                        (pi-coding-agent--tool-stream-tool-call-id
                          (gethash index pi-coding-agent--toolcall-streams)))
                       '(1 3))))
       (should (< (overlay-start first) (overlay-start second)))
@@ -12174,8 +12174,8 @@ Multiple deltas should replace the preview instead of appending forever."
                   :arguments (:path "/tmp/b"))))
     (let* ((first-stream (gethash 0 pi-coding-agent--toolcall-streams))
            (second-stream (gethash 1 pi-coding-agent--toolcall-streams))
-           (first-block (pi-coding-agent--toolcall-stream-block first-stream))
-           (second-block (pi-coding-agent--toolcall-stream-block second-stream))
+           (first-block (pi-coding-agent--tool-stream-block first-stream))
+           (second-block (pi-coding-agent--tool-stream-block second-stream))
            (first-overlay (pi-coding-agent--tool-block-overlay first-block))
            (second-overlay (pi-coding-agent--tool-block-overlay second-block)))
       (should-not (eq first-block second-block))

--- a/test/pi-coding-agent-test-common.el
+++ b/test/pi-coding-agent-test-common.el
@@ -190,24 +190,22 @@ Returns non-nil if the process exits before the timeout."
   "Return a toolCall content block for ID, TOOL-NAME, and ARGS."
   `(:type "toolCall" :id ,id :name ,tool-name :arguments ,args))
 
-(defun pi-coding-agent-test--toolcall-message-update
-    (event-type content-index toolcalls &optional delta)
-  "Return a message_update event for EVENT-TYPE over TOOLCALLS.
-CONTENT-INDEX is written into `assistantMessageEvent'.  DELTA is added
-when non-nil.  TOOLCALLS is a list of toolCall content block plists."
-  `(:type "message_update"
-    :assistantMessageEvent ,(append (list :type event-type :contentIndex content-index)
-                                    (when delta (list :delta delta)))
-    :message (:role "assistant" :content ,(vconcat toolcalls))))
+(defun pi-coding-agent-test--send-assistant-message-update (message-event)
+  "Send delta-only MESSAGE-EVENT using Pi's current RPC wire shape."
+  (pi-coding-agent--handle-display-event
+   `(:type "message_update" :assistantMessageEvent ,message-event)))
 
 (defun pi-coding-agent-test--send-toolcall-message-update
-    (event-type content-index toolcalls &optional delta)
-  "Send a toolcall message update for EVENT-TYPE over TOOLCALLS.
-CONTENT-INDEX and optional DELTA are forwarded to
-`pi-coding-agent-test--toolcall-message-update'."
-  (pi-coding-agent--handle-display-event
-   (pi-coding-agent-test--toolcall-message-update
-    event-type content-index toolcalls delta)))
+    (event-type content-index toolcalls &optional _delta)
+  "Render one cumulative toolcall snapshot for focused display tests.
+EVENT-TYPE controls streaming versus completed presentation.  CONTENT-INDEX
+selects the toolCall in TOOLCALLS.  Protocol-facing tests should instead use
+`pi-coding-agent-test--send-assistant-message-update' with raw JSON deltas."
+  (let ((tool-call (nth content-index toolcalls)))
+    (unless tool-call
+      (error "No test tool call at content index %s" content-index))
+    (pi-coding-agent--reconcile-toolcall-preview-block
+     content-index tool-call event-type)))
 
 (defmacro pi-coding-agent-test--with-toolcall (tool-name args &rest body)
   "Set up a chat buffer with a streaming tool call, then run BODY.

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -887,8 +887,9 @@ without an input window."
   "Compare pi versions numerically, not lexically."
   (should (pi-coding-agent--pi-version-outdated-p "0.79.0"))
   (should (pi-coding-agent--pi-version-outdated-p "0.80.99"))
-  (should-not (pi-coding-agent--pi-version-outdated-p "0.81.0"))
-  (should-not (pi-coding-agent--pi-version-outdated-p "0.81.1"))
+  (should (pi-coding-agent--pi-version-outdated-p "0.84.1"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "0.84.2"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "0.84.3"))
   (should-not (pi-coding-agent--pi-version-outdated-p "1.0.0")))
 
 (ert-deftest pi-coding-agent-test-finish-pi-version-process-parses-stderr ()
@@ -1055,7 +1056,7 @@ without an input window."
             (funcall callback "0.79.0")
             (should (equal pi-coding-agent--process-version "0.79.0"))
             (should (string-match-p "0.79.0" warning-text))
-            (should (string-match-p "0.81.0" warning-text))
+            (should (string-match-p "0.84.2" warning-text))
             (should (string-match-p
                      "npm install -g @earendil-works/pi-coding-agent"
                      warning-text))
@@ -1084,8 +1085,8 @@ without an input window."
                        (setq warning-called t))))
             (pi-coding-agent--set-process proc)
             (should callback)
-            (funcall callback "0.81.0")
-            (should (equal pi-coding-agent--process-version "0.81.0"))
+            (funcall callback "0.84.2")
+            (should (equal pi-coding-agent--process-version "0.84.2"))
             (should-not warning-called)))
       (when (process-live-p proc)
         (delete-process proc)))))

--- a/test/support/fake-pi-contract.md
+++ b/test/support/fake-pi-contract.md
@@ -179,13 +179,22 @@ Required behavior:
 
 ### Tool execution path
 
-For deterministic GUI tests, the fake must be able to emit:
+For deterministic GUI and benchmark tests, the fake must emit the current
+lifecycle:
 
-- `message_update` with `assistantMessageEvent.type: "toolcall_start"`
-- optional `toolcall_delta`
-- `tool_execution_start`
-- `tool_execution_update` with accumulated `partialResult`
-- `tool_execution_end`
+1. an assistant `message_start` with pending, empty content;
+2. delta-only `message_update` events for `toolcall_start`, optional
+   `toolcall_delta`, and authoritative `toolcall_end`;
+3. the authoritative assistant `message_end` before execution starts;
+4. `tool_execution_start`, optional updates with accumulated `partialResult`,
+   and `tool_execution_end`;
+5. a correlated `toolResult` message; and
+6. the final assistant response before `agent_end`.
+
+Every `message_update` carries cumulative `usage`, and carries neither the
+legacy top-level `message` nor nested `partial` fields.  Published Pi 0.84.2
+starts may omit `id` and `toolName`; `toolcall_end.toolCall` remains
+authoritative.
 
 Required fields currently consumed by Emacs rendering:
 

--- a/test/support/fake_pi.py
+++ b/test/support/fake_pi.py
@@ -486,7 +486,7 @@ class FakePiHarness:
                 ),
             )
             if not completed:
-                self._finish_aborted_run()
+                self._finish_aborted_run(assistant_message)
                 return
             emitted_messages.append(assistant_message)
             pending_steer = self._take_pending_steer()
@@ -504,8 +504,9 @@ class FakePiHarness:
     ) -> tuple[bool, JsonDict]:
         """Emit one user->assistant text exchange.
 
-        Returns ``(completed, assistant_message)``.  When ``completed`` is
-        false, the assistant message is undefined because the run was aborted.
+        Returns ``(completed, assistant_message)``.  After an assistant
+        ``message_start``, an aborted result contains the authoritative partial
+        message that must be emitted before ``agent_end``.
         """
         user_message = self._build_user_message(user_text)
         self._persist_user_message(user_message)
@@ -517,22 +518,24 @@ class FakePiHarness:
         if not self._sleep_ms(behavior.delay_ms, abortable=True):
             return False, {}
         self._write_json({"type": "message_start", "message": assistant_placeholder})
+        emitted_chunks: list[str] = []
         for chunk in self._chunk_text(assistant_text, behavior.chunk_count):
             if self._abort_requested.is_set():
-                return False, {}
-            self._write_json(
+                return False, self._build_aborted_assistant_message(
+                    "".join(emitted_chunks)
+                )
+            self._write_message_update(
                 {
-                    "type": "message_update",
-                    "message": assistant_placeholder,
-                    "assistantMessageEvent": {
-                        "type": "text_delta",
-                        "contentIndex": 0,
-                        "delta": chunk,
-                    },
+                    "type": "text_delta",
+                    "contentIndex": 0,
+                    "delta": chunk,
                 }
             )
+            emitted_chunks.append(chunk)
             if not self._sleep_ms(behavior.delay_ms, abortable=True):
-                return False, {}
+                return False, self._build_aborted_assistant_message(
+                    "".join(emitted_chunks)
+                )
         assistant_message = self._build_assistant_message(assistant_text)
         self._persist_assistant_message(assistant_message)
         self._write_json({"type": "message_end", "message": assistant_message})
@@ -590,6 +593,7 @@ class FakePiHarness:
         if self._abort_requested.is_set():
             self._finish_aborted_run()
             return
+
         tool_call_id = f"call-{uuid.uuid4().hex[:8]}"
         tool_call = {
             "type": "toolCall",
@@ -597,35 +601,57 @@ class FakePiHarness:
             "name": behavior.tool_name,
             "arguments": behavior.tool_args,
         }
-        assistant_message: JsonDict = {"role": "assistant", "content": [tool_call]}
+        tool_assistant_message: JsonDict = {
+            "role": "assistant",
+            "content": [tool_call],
+            "timestamp": now_ms(),
+            "stopReason": "toolUse",
+        }
+        tool_assistant_start = {
+            **tool_assistant_message,
+            "content": [],
+            "stopReason": "pending",
+        }
         if not self._sleep_ms(behavior.delay_ms, abortable=True):
             self._finish_aborted_run()
             return
-        self._write_json({"type": "message_start", "message": assistant_message})
-        self._write_json(
+        self._write_json({"type": "message_start", "message": tool_assistant_start})
+        self._write_message_update(
             {
-                "type": "message_update",
-                "message": assistant_message,
-                "assistantMessageEvent": {
-                    "type": "toolcall_start",
-                    "contentIndex": 0,
-                },
+                "type": "toolcall_start",
+                "contentIndex": 0,
+                "id": tool_call_id,
+                "toolName": behavior.tool_name,
             }
         )
-        self._write_json(
-            {
-                "type": "message_update",
-                "message": assistant_message,
-                "assistantMessageEvent": {
+        raw_arguments = json.dumps(
+            behavior.tool_args, separators=(",", ":"), ensure_ascii=False
+        )
+        for chunk in self._chunk_text(raw_arguments, 3):
+            self._write_message_update(
+                {
                     "type": "toolcall_delta",
                     "contentIndex": 0,
-                    "delta": json.dumps(behavior.tool_args, ensure_ascii=False),
-                },
+                    "delta": chunk,
+                }
+            )
+        if not self._sleep_ms(behavior.delay_ms, abortable=True):
+            aborted_message = {
+                **tool_assistant_message,
+                "stopReason": "aborted",
+                "errorMessage": "Request was aborted",
+            }
+            self._finish_aborted_run(aborted_message)
+            return
+        self._write_message_update(
+            {
+                "type": "toolcall_end",
+                "contentIndex": 0,
+                "toolCall": tool_call,
             }
         )
-        if not self._sleep_ms(behavior.delay_ms, abortable=True):
-            self._finish_aborted_run()
-            return
+        self._persist_assistant_message(tool_assistant_message)
+        self._write_json({"type": "message_end", "message": tool_assistant_message})
         self._write_json(
             {
                 "type": "tool_execution_start",
@@ -647,32 +673,49 @@ class FakePiHarness:
         if not self._sleep_ms(behavior.delay_ms, abortable=True):
             self._finish_aborted_run()
             return
+        result = self._tool_result_payload(behavior.result_text)
         self._write_json(
             {
                 "type": "tool_execution_end",
                 "toolCallId": tool_call_id,
                 "toolName": behavior.tool_name,
-                "result": self._tool_result_payload(behavior.result_text),
+                "result": result,
                 "isError": False,
             }
         )
+        tool_result_message: JsonDict = {
+            "role": "toolResult",
+            "toolCallId": tool_call_id,
+            "toolName": behavior.tool_name,
+            **result,
+            "isError": False,
+            "timestamp": now_ms(),
+        }
+        self._persist_tool_result_message(tool_result_message)
+        self._write_json({"type": "message_start", "message": tool_result_message})
+        self._write_json({"type": "message_end", "message": tool_result_message})
+
         final_message = self._build_assistant_message(behavior.assistant_text)
+        final_message_start = {
+            **final_message,
+            "content": [],
+            "stopReason": "pending",
+        }
+        self._write_json({"type": "message_start", "message": final_message_start})
         if behavior.assistant_text:
             for chunk in self._chunk_text(behavior.assistant_text, 2):
-                self._write_json(
+                self._write_message_update(
                     {
-                        "type": "message_update",
-                        "message": final_message,
-                        "assistantMessageEvent": {
-                            "type": "text_delta",
-                            "contentIndex": 0,
-                            "delta": chunk,
-                        },
+                        "type": "text_delta",
+                        "contentIndex": 0,
+                        "delta": chunk,
                     }
                 )
         self._persist_assistant_message(final_message)
         self._write_json({"type": "message_end", "message": final_message})
-        self._finish_run([final_message])
+        self._finish_run(
+            [user_message, tool_assistant_message, tool_result_message, final_message]
+        )
 
     def _build_extension_request(
         self, request_id: str, behavior: ExtensionDialogPrompt
@@ -787,14 +830,21 @@ class FakePiHarness:
 
     def _finish_run(self, messages: list[JsonDict]) -> None:
         """Emit agent_end and reset transient run state."""
-        self._write_json({"type": "agent_end", "messages": messages})
+        self._write_json(
+            {"type": "agent_end", "messages": messages, "willRetry": False}
+        )
         self.state.is_streaming = False
         self._abort_requested.clear()
         self._pending_steer_message = None
 
-    def _finish_aborted_run(self) -> None:
-        """Finish the current run as aborted."""
-        self._finish_run([])
+    def _finish_aborted_run(self, message: JsonDict | None = None) -> None:
+        """Finish the current run, emitting an active aborted MESSAGE first."""
+        messages: list[JsonDict] = []
+        if message:
+            self._persist_assistant_message(message)
+            self._write_json({"type": "message_end", "message": message})
+            messages.append(message)
+        self._finish_run(messages)
 
     def _sleep_ms(self, delay_ms: int, *, abortable: bool) -> bool:
         """Sleep for ``delay_ms`` milliseconds.
@@ -809,6 +859,34 @@ class FakePiHarness:
                 return False
             time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
         return not (abortable and self._abort_requested.is_set())
+
+    def _write_message_update(self, event: JsonDict) -> None:
+        """Emit a delta-only assistant message update in current RPC shape."""
+        self._write_json(
+            {
+                "type": "message_update",
+                "usage": self._zero_usage(),
+                "assistantMessageEvent": event,
+            }
+        )
+
+    @staticmethod
+    def _zero_usage() -> JsonDict:
+        """Return deterministic cumulative usage for fake streaming updates."""
+        return {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "totalTokens": 0,
+            "cost": {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "total": 0,
+            },
+        }
 
     @staticmethod
     def _tool_result_payload(text: str) -> JsonDict:
@@ -833,6 +911,16 @@ class FakePiHarness:
             "content": [{"type": "text", "text": text}],
             "timestamp": now_ms(),
             "stopReason": "stop",
+        }
+
+    def _build_aborted_assistant_message(self, text: str) -> JsonDict:
+        """Return an authoritative partial assistant message for an abort."""
+        return {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+            "timestamp": now_ms(),
+            "stopReason": "aborted",
+            "errorMessage": "Request was aborted",
         }
 
     def _build_custom_message(self, text: str) -> JsonDict:
@@ -863,6 +951,17 @@ class FakePiHarness:
         """Append a custom message to the real session file."""
         self._append_session_line(
             {"type": "message", "entryId": self._entry_id("custom"), "message": message}
+        )
+        self.state.message_count += 1
+
+    def _persist_tool_result_message(self, message: JsonDict) -> None:
+        """Append a tool-result message to the real session file."""
+        self._append_session_line(
+            {
+                "type": "message",
+                "entryId": self._entry_id("tool-result"),
+                "message": message,
+            }
         )
         self.state.message_count += 1
 


### PR DESCRIPTION
## Summary

- Support Pi 0.84.2's delta-only tool-call events without losing or duplicating tool blocks.
- Show live command, path, and bounded write previews when Pi provides start metadata, with a clean end-of-call fallback for published 0.84.2.
- Keep multiple tool calls isolated through execution and clean up partial previews on aborts or process exits.
- Update the documented minimum Pi version and align the fake backend with the current RPC lifecycle.

## Validation

Validated through unit, integration, and GUI checks, plus real terminal sessions with GLM-5.3 and Codex against current Pi and the published 0.84.2 CLI.
