### PR TITLE
Cool old tool output without blocking the interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ module, direct `setq` is fine.
 | `pi-coding-agent.el` | Entry point, autoloads, `--setup-session` |
 | `pi-coding-agent-core.el` | JSON parsing, line buffering, RPC request correlation, and process protocol |
 | `pi-coding-agent-ui.el` | Shared session/buffer state, accessors, faces, customization, chat/input modes and keymaps, header/activity UI, and local slash-command dispatch; requires core and grammars, not jsonl |
-| `pi-coding-agent-render.el` | Streaming and history rendering for user, assistant, branch-summary, and compaction messages; tool output, fontification, diffs, and deferred history table postprocessing |
+| `pi-coding-agent-render.el` | Streaming and history rendering for user, assistant, branch-summary, and compaction messages; tool output, deferred completed-tool cooling outside the hot tail, fontification, diffs, and deferred history table postprocessing |
 | `pi-coding-agent-table.el` | Display-only pipe table decoration, wrapping, overlay management, and resize refresh over UI visible-text/scroll seams |
 | `pi-coding-agent-input.el` | Input history/isearch, send/abort, file/path/slash completion, queuing, and local `/resume` dispatch to the session browser |
 | `pi-coding-agent-menu.el` | Transient menu; guarded new/reload/resume transitions; canonical jsonl cwd/name metadata; model, thinking, command, export, and stats actions; `r` sessions and `w` tree entries |
@@ -95,9 +95,9 @@ module, direct `setq` is fine.
 | `bench/pi-coding-agent-reload-resume-bench.el` | Synthetic reload/resume harness; the resume lane opens the real async disk-backed session browser, selects the target magit section, switches through browser RET behavior, and checks rebuilt history |
 | `bench/fake-pi-reload-resume.py` | Fake JSON-over-stdio backend for reload/resume benchmark state, switch, history, commands, and content-free traffic evidence |
 | `bench/run-reload-resume-bench.sh` | Reload/resume benchmark runner; GUI uses `xvfb-run`, `--batch` for headless lane |
-| `bench/pi-coding-agent-tool-update-bench.el` | Synthetic tool-update storm benchmark harness |
-| `bench/fake-pi-tool-update-storm.py` | Fake JSON-over-stdio pi backend emitting a tool-update storm |
-| `bench/run-tool-update-bench.sh` | Tool-update storm benchmark runner; GUI uses `xvfb-run`, `--batch` for headless lane |
+| `bench/pi-coding-agent-tool-update-bench.el` | Synthetic tool-update storm and deferred agent_end cooling benchmark harness |
+| `bench/fake-pi-tool-update-storm.py` | Fake JSON-over-stdio pi backend emitting tool-update storm and cooling scenarios |
+| `bench/run-tool-update-bench.sh` | Tool-update/cooling benchmark runner; GUI uses `xvfb-run`, `--batch` for headless lane |
 | `bench/fixtures/tables.md` | Sample pipe tables used by the table benchmark |
 | `test/support/fake_pi.py` | Deterministic JSONL RPC subprocess double with scenario-driven events, valid v3 persistence, inspection RPCs, and transactional session switching |
 | `test/support/fake-pi-contract.md` | Maintainer-facing wire, scenario/event/tool, v3 record, projection, and switch contract for `fake_pi.py` |
@@ -166,6 +166,9 @@ make bench-reload-resume-smoke     # cheap synthetic correctness smoke
 make bench-tool-update             # tool-update storm GUI lane via xvfb (primary)
 make bench-tool-update-batch       # tool-update storm batch lane (secondary)
 make bench-tool-update-smoke       # cheap synthetic correctness smoke
+make bench-agent-end-cooling       # deferred agent_end cooling GUI lane (primary)
+make bench-agent-end-cooling-batch # deferred cooling batch lane (secondary)
+make bench-agent-end-cooling-smoke # cheap deferred cooling correctness smoke
 ```
 
 The GUI lanes are the primary measurements; batch lanes are quick sanity
@@ -173,9 +176,18 @@ checks and CI artifact generators.  Reload/resume benchmarks use synthetic
 JSONL fixtures only and fail on correctness errors, not timing thresholds.
 Tool-update storm benchmarks replay a deterministic synthetic
 `tool_execution_update` storm against a fake pi and likewise fail only on
-correctness errors.  Table fixtures live in `bench/fixtures/tables.md`.
-Reload/resume artifacts are written under `tmp/reload-resume-bench/` and
-tool-update artifacts under `tmp/tool-update-bench/` by default.
+correctness errors.  The deferred agent_end scenario reuses that harness and
+fake backend to cross a 90-overlay cohort at the final real process-filter
+event, then observes production one-shot cooling timers and routed scroll
+heartbeats without enforcing timing thresholds.  Its runner deliberately uses
+`-Q`: slice/root timings are structural diagnostics, zero root calls is valid,
+and these results must not be cited as evidence that md-ts root cost was
+reduced.  Exact normal-init GUI replay is the performance-fidelity evidence.
+Table fixtures live in `bench/fixtures/tables.md`.  Reload/resume artifacts are
+written under `tmp/reload-resume-bench/`, tool-update artifacts under
+`tmp/tool-update-bench/`, and dedicated cooling target artifacts under
+`tmp/agent-end-cooling-bench/{gui,batch,smoke}/` by default, so those public
+lanes do not overwrite one another.
 
 ## Linting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,12 +182,14 @@ event, then observes production one-shot cooling timers and routed scroll
 heartbeats without enforcing timing thresholds.  Its runner deliberately uses
 `-Q`: slice/root timings are structural diagnostics, zero root calls is valid,
 and these results must not be cited as evidence that md-ts root cost was
-reduced.  Exact normal-init GUI replay is the performance-fidelity evidence.
+reduced.
 Table fixtures live in `bench/fixtures/tables.md`.  Reload/resume artifacts are
 written under `tmp/reload-resume-bench/`, tool-update artifacts under
-`tmp/tool-update-bench/`, and dedicated cooling target artifacts under
-`tmp/agent-end-cooling-bench/{gui,batch,smoke}/` by default, so those public
-lanes do not overwrite one another.
+`tmp/tool-update-bench/`, and agent-end-cooling artifacts under
+`tmp/agent-end-cooling-bench/{gui,batch}/` by default (the runner picks that
+directory per scenario and lane when no `--out-dir` is given; the dedicated
+smoke target writes `smoke/`), so those public lanes do not overwrite one
+another.
 
 ## Linting
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ VERBOSE ?=
 .PHONY: test-integration test-integration-fake test-integration-real test-integration-ci test-integration-ci-real test-gui test-gui-ci test-all
 .PHONY: bench bench-batch bench-reload-resume bench-reload-resume-batch bench-reload-resume-smoke
 .PHONY: bench-tool-update bench-tool-update-batch bench-tool-update-smoke
+.PHONY: bench-agent-end-cooling bench-agent-end-cooling-batch bench-agent-end-cooling-smoke
 .PHONY: check check-parens compile lint lint-checkdoc lint-package clean clean-cache help
 .PHONY: ollama-start ollama-stop ollama-status setup-pi install-hooks
 
@@ -52,6 +53,9 @@ help:
 	@echo "  make bench-tool-update             Tool-update storm benchmarks (GUI via xvfb)"
 	@echo "  make bench-tool-update-batch       Tool-update storm benchmarks (batch, secondary lane)"
 	@echo "  make bench-tool-update-smoke       Tool-update storm smoke benchmark (batch, no timing thresholds)"
+	@echo "  make bench-agent-end-cooling       Deferred agent_end cooling benchmark (GUI via xvfb)"
+	@echo "  make bench-agent-end-cooling-batch Deferred agent_end cooling benchmark (batch, secondary lane)"
+	@echo "  make bench-agent-end-cooling-smoke Cheap deferred cooling smoke (batch, no timing thresholds)"
 	@echo "  make lint             Checkdoc + package-lint"
 	@echo "  make check            Compile, lint, unit tests (pre-commit)"
 	@echo "  make install-hooks    Set up git pre-commit hook"
@@ -287,6 +291,20 @@ bench-tool-update-batch: .deps-stamp
 # Cheap correctness/regression smoke; no timing thresholds are enforced.
 bench-tool-update-smoke: .deps-stamp
 	@./bench/run-tool-update-bench.sh --batch --scenario smoke -c 1
+
+# Deferred agent_end regression: a 90-overlay cohort drains through the real
+# process filter and production one-shot cooling timers.  Timing is diagnostic.
+bench-agent-end-cooling: .deps-stamp
+	@./bench/run-tool-update-bench.sh --scenario agent-end-cooling \
+		--out-dir tmp/agent-end-cooling-bench/gui
+
+bench-agent-end-cooling-batch: .deps-stamp
+	@./bench/run-tool-update-bench.sh --batch --scenario agent-end-cooling \
+		--out-dir tmp/agent-end-cooling-bench/batch
+
+bench-agent-end-cooling-smoke: .deps-stamp
+	@./bench/run-tool-update-bench.sh --batch --scenario agent-end-cooling-smoke -c 1 \
+		--out-dir tmp/agent-end-cooling-bench/smoke
 
 # ============================================================
 # Ollama management (local development)

--- a/bench/fake-pi-tool-update-storm.py
+++ b/bench/fake-pi-tool-update-storm.py
@@ -41,8 +41,11 @@ by default to keep benchmark wall time practical).
 
 Configuration comes from ``PI_TU_BENCH_*`` environment variables, with CLI
 flags taking precedence; ``--size smoke`` selects a tiny fast preset before
-other overrides apply.  The Emacs harness reads the same environment to
-derive expected event counts, so a runner must export matching values.
+other overrides apply.  The ``agent-end-cooling`` scenarios reuse the fill
+controls to build a completed-tool cohort, then emit a boundary user message,
+a hot-tail table, one still-live tool, and ``agent_end``.  The Emacs harness
+reads the same environment to derive expected event counts, so a runner must
+export matching values.
 
 The optional ``--log-file`` records command names, event counts, and
 configuration only; it never records message content.
@@ -289,6 +292,55 @@ def fill_tool_call(block_index: int, tool: str, output_lines: int) -> tuple[Json
     )
 
 
+def cooling_fill_tool_call(
+    block_index: int, tool: str, output_lines: int
+) -> tuple[JsonDict, str]:
+    """Return a realistic long-or-short cooling fixture tool result."""
+    tool_call_id = f"call-cooling-{block_index:04d}"
+    sentinel = f"COOLING-SEMANTIC {tool_call_id}"
+    # Keep a deterministic minority short while the rest exercise collapsed
+    # previews.  Edit results are short by construction; every ninth other
+    # result is short as well.
+    lines = 2 if tool == "edit" or block_index % 9 == 0 else output_lines
+    body = "\n".join(
+        [sentinel]
+        + [
+            f"cooling fixture {tool} block {block_index:04d} line {line:02d}: "
+            "deterministic representative output"
+            for line in range(1, max(1, lines))
+        ]
+    )
+    if tool == "bash":
+        return (
+            {"command": f"benchmark-scan --cohort {block_index:04d}"},
+            body,
+        )
+    if tool == "read":
+        return (
+            {
+                "path": f"synthetic/cooling/src/file-{block_index:04d}.py",
+                "offset": block_index + 1,
+            },
+            body,
+        )
+    if tool == "write":
+        return (
+            {
+                "path": f"synthetic/cooling/out/file-{block_index:04d}.txt",
+                "content": body,
+            },
+            f"Wrote cooling fixture {block_index:04d}",
+        )
+    return (
+        {
+            "path": f"synthetic/cooling/src/file-{block_index:04d}.py",
+            "oldText": f"old cooling text {block_index:04d}",
+            "newText": f"new cooling text {block_index:04d}",
+        },
+        body,
+    )
+
+
 def fill_plan(config: JsonDict) -> list[str]:
     """Return fill tool names interleaved round-robin for realism."""
     remaining = {
@@ -306,10 +358,21 @@ def fill_plan(config: JsonDict) -> list[str]:
     return plan
 
 
-def emit_fill_block(block_index: int, tool: str, output_lines: int) -> list[JsonDict]:
+def emit_fill_block(
+    block_index: int, tool: str, output_lines: int, *, cooling: bool = False
+) -> list[JsonDict]:
     """Emit one completed fill tool exchange and return its messages."""
-    tool_call_id = f"call-fill-{block_index:04d}"
-    arguments, result_text = fill_tool_call(block_index, tool, output_lines)
+    tool_call_id = (
+        f"call-cooling-{block_index:04d}"
+        if cooling
+        else f"call-fill-{block_index:04d}"
+    )
+    if cooling:
+        arguments, result_text = cooling_fill_tool_call(
+            block_index, tool, output_lines
+        )
+    else:
+        arguments, result_text = fill_tool_call(block_index, tool, output_lines)
     thinking = fill_thinking(block_index)
     thinking_block = {"type": "thinking", "thinking": thinking}
     tool_call = {
@@ -441,6 +504,115 @@ def final_result_text(tool_id: str, tool_index: int, turns: int) -> str:
         f"STORM-FINAL-RESULT {tool_id}\n"
         f"Subagent finished after {turns} synthetic turns.\n"
         f"Summary: investigated synthetic area {tool_index}; all checks passed."
+    )
+
+
+def run_agent_end_cooling_scenario(
+    config: JsonDict, log_file: Path | None
+) -> None:
+    """Emit a completed cohort and cross its hot-tail boundary at agent_end."""
+    emitted = {
+        "tool_execution_start": 0,
+        "tool_execution_update": 0,
+        "tool_execution_end": 0,
+    }
+    messages: list[JsonDict] = []
+
+    write_json({"type": "agent_start"})
+    for block_index, tool in enumerate(fill_plan(config)):
+        messages.extend(
+            emit_fill_block(
+                block_index,
+                tool,
+                int(config["fill_output_lines"]),
+                cooling=True,
+            )
+        )
+        emitted["tool_execution_start"] += 1
+        emitted["tool_execution_end"] += 1
+
+    # This real user-message event resets the Assistant heading.  The final
+    # Assistant heading is therefore the one-turn hot tail when agent_end
+    # advances the production boundary.
+    boundary_text = (
+        "COOLING-WINDOW-SENTINEL keep this logical scroll anchor stable "
+        "while older tool bodies cool."
+    )
+    boundary_message: JsonDict = {
+        "role": "user",
+        "content": [{"type": "text", "text": boundary_text}],
+        "timestamp": TIMESTAMP_BASE_MS + 200_000,
+    }
+    write_json({"type": "message_start", "message": boundary_message})
+    write_json({"type": "message_end", "message": boundary_message})
+    messages.append(boundary_message)
+
+    hot_text = (
+        "The current tool and this adjacent table belong to the hot tail.\n\n"
+        "| marker | state | deterministic note |\n"
+        "|---|---|---|\n"
+        "| COOLING-SEMANTIC-HOT-TABLE | hot | remains decorated and outside "
+        "the completed cooling cohort |\n"
+    )
+    live_call: JsonDict = {
+        "type": "toolCall",
+        "id": "call-cooling-live",
+        "name": "bash",
+        "arguments": {
+            "command": "cooling-live --sentinel COOLING-SEMANTIC-LIVE"
+        },
+    }
+    assistant_message: JsonDict = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": hot_text}, live_call],
+        "timestamp": TIMESTAMP_BASE_MS + 200_001,
+        "stopReason": "toolUse",
+    }
+    assistant_start = {
+        **assistant_message,
+        "content": [],
+        "stopReason": "pending",
+    }
+    write_json({"type": "message_start", "message": assistant_start})
+    write_message_update(
+        {"type": "text_delta", "contentIndex": 0, "delta": hot_text}
+    )
+    write_message_update({"type": "text_end", "contentIndex": 0})
+    write_message_update({"type": "toolcall_start", "contentIndex": 1})
+    write_message_update(
+        {
+            "type": "toolcall_delta",
+            "contentIndex": 1,
+            "delta": json.dumps(
+                live_call["arguments"], separators=(",", ":")
+            ),
+        }
+    )
+    write_message_update(
+        {"type": "toolcall_end", "contentIndex": 1, "toolCall": live_call}
+    )
+    write_json({"type": "message_end", "message": assistant_message})
+    messages.append(assistant_message)
+
+    write_json(
+        {
+            "type": "tool_execution_start",
+            "toolCallId": live_call["id"],
+            "toolName": live_call["name"],
+            "args": live_call["arguments"],
+        }
+    )
+    emitted["tool_execution_start"] += 1
+
+    # Deliberately omit tool_execution_end.  Production agent_end finalization
+    # makes this block completed, but its position remains inside the new hot
+    # tail and must not enter the cooling queue.
+    write_json(
+        {"type": "agent_end", "messages": messages, "willRetry": False}
+    )
+    log_line(
+        log_file,
+        {"event": "agent-end-cooling-complete", "emitted": emitted},
     )
 
 
@@ -619,6 +791,7 @@ def resolve_config(args: argparse.Namespace) -> JsonDict:
     size = args.size or os_environ_get("PI_TU_BENCH_SIZE") or "full"
     defaults = dict(SMOKE_DEFAULTS if size == "smoke" else FULL_DEFAULTS)
     config: JsonDict = {
+        "scenario": os_environ_get("PI_TU_BENCH_SCENARIO") or "storm",
         "fill_bash": env_int("PI_TU_BENCH_FILL_BASH", int(defaults["fill_bash"])),
         "fill_read": env_int("PI_TU_BENCH_FILL_READ", int(defaults["fill_read"])),
         "fill_write": env_int("PI_TU_BENCH_FILL_WRITE", int(defaults["fill_write"])),
@@ -683,8 +856,13 @@ def main(argv: list[str] | None = None) -> int:
             respond(command, data={"text": ""})
         elif command_type == "prompt":
             respond(command)
+            target = (
+                run_agent_end_cooling_scenario
+                if str(config["scenario"]).startswith("agent-end-cooling")
+                else run_scenario
+            )
             storm_thread = threading.Thread(
-                target=run_scenario, args=(config, log_file), daemon=True
+                target=target, args=(config, log_file), daemon=True
             )
             storm_thread.start()
         elif command_type in ("abort", "steer", "set_thinking_level"):

--- a/bench/pi-coding-agent-tool-update-bench.el
+++ b/bench/pi-coding-agent-tool-update-bench.el
@@ -16,10 +16,10 @@
 ;; counts via advice on `pi-coding-agent--tool-block-replace-body' and
 ;; `pi-coding-agent--display-tool-end' (the environment-independent
 ;; coalescing metric).  The agent-end-cooling scenario reuses the same fake
-;; process and runner to queue a 90-overlay cohort at final agent_end, observe
-;; real one-shot cooling callbacks, and route scroll heartbeats through unread
-;; command events.  All content is synthetic; no private session files are
-;; read.
+;; process and runner to queue the `PI_TU_BENCH_FILL_*'-sized tool cohort at
+;; final agent_end, observe real one-shot cooling callbacks, and route scroll
+;; heartbeats through unread command events.  All content is synthetic; no
+;; private session files are read.
 ;;
 ;; Run with:
 ;;
@@ -40,9 +40,8 @@
 ;;
 ;; The runner deliberately uses `-Q'.  Cooling slice/root timings in this lane
 ;; are structural diagnostics, and zero tree-root calls is a valid result.
-;; They must not be cited as evidence that md-ts root cost was reduced.  An
-;; exact normal-init GUI replay is the performance-fidelity evidence for that
-;; claim; this benchmark proves deferred scheduling and final correctness.
+;; They must not be cited as evidence that md-ts root cost was reduced; this
+;; benchmark proves deferred scheduling and final correctness only.
 
 ;;; Code:
 
@@ -368,12 +367,6 @@ how expensive each render is on the host.")
               lines))
       (nreverse lines))))
 
-(defun pi-coding-agent-tu-bench--semantic-hash ()
-  "Return SHA-256 of the current cooling semantic sentinel projection."
-  (secure-hash 'sha256
-               (string-join
-                (pi-coding-agent-tu-bench--semantic-lines) "\n")))
-
 (defun pi-coding-agent-tu-bench--expected-semantic-lines ()
   "Return exact semantic sentinel lines expected from the cooling fixture."
   (append
@@ -434,88 +427,100 @@ how expensive each render is on the host.")
         (setq pi-coding-agent-tu-bench--agent-end-filter row)))
     value))
 
+(defun pi-coding-agent-tu-bench--time-display-event (orig event type)
+  "Call the real display-event handler ORIG with EVENT, timed as TYPE.
+Append (TYPE . elapsed-ms) to the event log and return a plist with
+:VALUE, :END, and :ELAPSED-MS.  Observation only: the production
+handler runs unmodified, with no delays or state overrides."
+  (let* ((start (float-time))
+         (value (funcall orig event))
+         (end (float-time)))
+    (push (cons type (* 1000.0 (- end start)))
+          pi-coding-agent-tu-bench--event-log)
+    (list :value value :end end :elapsedMs (* 1000.0 (- end start)))))
+
+(defun pi-coding-agent-tu-bench--cooling-state-counts ()
+  "Return the shared deferred-cooling state counts for the current buffer.
+The agent_end boundary observation (before and after the real handler)
+and the settled final state both read these fields through this one
+helper, so the two views cannot drift apart.  Pure observation."
+  (list :hotTailBoundary
+        (and (markerp pi-coding-agent--hot-tail-start)
+             (marker-position pi-coding-agent--hot-tail-start))
+        :queueLength (length pi-coding-agent--tool-cooling-queue)
+        :timer (and pi-coding-agent--tool-cooling-timer t)
+        :coldTools (length (pi-coding-agent-tu-bench--cold-tool-metadata))
+        :toolOverlays (length (pi-coding-agent-tu-bench--tool-overlays))
+        :liveRegistry
+        (if (hash-table-p pi-coding-agent--live-tool-blocks)
+            (hash-table-count pi-coding-agent--live-tool-blocks)
+          0)
+        :currentOverlays
+        (pi-coding-agent-tu-bench--overlay-count-for-id
+         pi-coding-agent-tu-bench-cooling-live-id)))
+
+(defun pi-coding-agent-tu-bench--semantic-summary ()
+  "Return (LINE-COUNT . SHA-256) of the current semantic projection."
+  (let ((lines (pi-coding-agent-tu-bench--semantic-lines)))
+    (cons (length lines)
+          (secure-hash 'sha256 (string-join lines "\n")))))
+
 (defun pi-coding-agent-tu-bench--around-handle-event (orig event)
   "Around advice recording handling time for display EVENT.
 Calls ORIG with EVENT and appends to the benchmark event log."
   (let ((type (or (plist-get event :type) "unknown")))
     (if (and (equal type "agent_end")
              (pi-coding-agent-tu-bench--cooling-scenario-p))
-        (let* ((boundary-before
-                (and (markerp pi-coding-agent--hot-tail-start)
-                     (marker-position pi-coding-agent--hot-tail-start)))
-               (queue-before (length pi-coding-agent--tool-cooling-queue))
-               (timer-before (and pi-coding-agent--tool-cooling-timer t))
-               (cold-before
-                (length (pi-coding-agent-tu-bench--cold-tool-metadata)))
-               (overlays-before
-                (length (pi-coding-agent-tu-bench--tool-overlays)))
+        (let* ((before (pi-coding-agent-tu-bench--cooling-state-counts))
                (collapsed-before
                 (pi-coding-agent-tu-bench--collapsed-tool-count))
-               (live-before
-                (if (hash-table-p pi-coding-agent--live-tool-blocks)
-                    (hash-table-count pi-coding-agent--live-tool-blocks)
-                  0))
-               (current-before
-                (pi-coding-agent-tu-bench--overlay-count-for-id
-                 pi-coding-agent-tu-bench-cooling-live-id))
                (gc-before gcs-done)
                (gc-time-before gc-elapsed)
-               (start (float-time))
-               (pi-coding-agent-tu-bench--tree-root-phase "agent_end")
-               (pi-coding-agent-tu-bench--tree-root-count 0)
-               (pi-coding-agent-tu-bench--tree-root-ms 0.0)
-               (pi-coding-agent-tu-bench--tree-root-max-ms 0.0)
-               value end elapsed tree-row)
-          (setq value (funcall orig event)
-                end (float-time)
-                elapsed (* 1000.0 (- end start))
-                tree-row (pi-coding-agent-tu-bench--tree-root-row))
-          (push (cons type elapsed) pi-coding-agent-tu-bench--event-log)
-          (setq pi-coding-agent-tu-bench--agent-end-time end
-                pi-coding-agent-tu-bench--drain-start-time end
-                pi-coding-agent-tu-bench--agent-end-observation
-                (list
-                 :wallMs elapsed
-                 :filterId pi-coding-agent-tu-bench--current-filter-id
-                 :boundaryBefore boundary-before
-                 :boundaryAfter
-                 (and (markerp pi-coding-agent--hot-tail-start)
-                      (marker-position pi-coding-agent--hot-tail-start))
-                 :queueBefore queue-before
-                 :queueAfter (length pi-coding-agent--tool-cooling-queue)
-                 :timerBefore timer-before
-                 :timerAfter (and pi-coding-agent--tool-cooling-timer t)
-                 :coldBefore cold-before
-                 :coldAfter
-                 (length (pi-coding-agent-tu-bench--cold-tool-metadata))
-                 :toolOverlaysBefore overlays-before
-                 :toolOverlaysAfter
-                 (length (pi-coding-agent-tu-bench--tool-overlays))
-                 :collapsedToolOverlaysBefore collapsed-before
-                 :liveRegistryBefore live-before
-                 :liveRegistryAfter
-                 (if (hash-table-p pi-coding-agent--live-tool-blocks)
-                     (hash-table-count pi-coding-agent--live-tool-blocks)
-                   0)
-                 :currentOverlayBefore current-before
-                 :currentOverlayAfter
-                 (pi-coding-agent-tu-bench--overlay-count-for-id
-                  pi-coding-agent-tu-bench-cooling-live-id)
-                 :semanticLinesAfter
-                 (length (pi-coding-agent-tu-bench--semantic-lines))
-                 :semanticHashAfter
-                 (pi-coding-agent-tu-bench--semantic-hash)
-                 :gcs (- gcs-done gc-before)
-                 :gcMs (* 1000.0 (- gc-elapsed gc-time-before))
-                 :treeRoots tree-row))
-          value)
-      (let ((start (float-time)))
-        (prog1 (funcall orig event)
-          (let ((end (float-time)))
-            (push (cons type (* 1000.0 (- end start)))
-                  pi-coding-agent-tu-bench--event-log)
-            (when (equal type "agent_end")
-              (setq pi-coding-agent-tu-bench--agent-end-time end))))))))
+               timed tree-row)
+          (let ((pi-coding-agent-tu-bench--tree-root-phase "agent_end")
+                (pi-coding-agent-tu-bench--tree-root-count 0)
+                (pi-coding-agent-tu-bench--tree-root-ms 0.0)
+                (pi-coding-agent-tu-bench--tree-root-max-ms 0.0))
+            (setq timed (pi-coding-agent-tu-bench--time-display-event
+                         orig event type)
+                  tree-row (pi-coding-agent-tu-bench--tree-root-row)))
+          (let* ((after (pi-coding-agent-tu-bench--cooling-state-counts))
+                 (semantic (pi-coding-agent-tu-bench--semantic-summary)))
+            (setq pi-coding-agent-tu-bench--agent-end-time
+                  (plist-get timed :end)
+                  pi-coding-agent-tu-bench--drain-start-time
+                  (plist-get timed :end)
+                  pi-coding-agent-tu-bench--agent-end-observation
+                  (list
+                   :wallMs (plist-get timed :elapsedMs)
+                   :filterId pi-coding-agent-tu-bench--current-filter-id
+                   :boundaryBefore (plist-get before :hotTailBoundary)
+                   :boundaryAfter (plist-get after :hotTailBoundary)
+                   :queueBefore (plist-get before :queueLength)
+                   :queueAfter (plist-get after :queueLength)
+                   :timerBefore (plist-get before :timer)
+                   :timerAfter (plist-get after :timer)
+                   :coldBefore (plist-get before :coldTools)
+                   :coldAfter (plist-get after :coldTools)
+                   :toolOverlaysBefore (plist-get before :toolOverlays)
+                   :toolOverlaysAfter (plist-get after :toolOverlays)
+                   :collapsedToolOverlaysBefore collapsed-before
+                   :liveRegistryBefore (plist-get before :liveRegistry)
+                   :liveRegistryAfter (plist-get after :liveRegistry)
+                   :currentOverlayBefore (plist-get before :currentOverlays)
+                   :currentOverlayAfter (plist-get after :currentOverlays)
+                   :semanticLinesAfter (car semantic)
+                   :semanticHashAfter (cdr semantic)
+                   :gcs (- gcs-done gc-before)
+                   :gcMs (* 1000.0 (- gc-elapsed gc-time-before))
+                   :treeRoots tree-row))
+            (plist-get timed :value)))
+      (let ((timed (pi-coding-agent-tu-bench--time-display-event
+                    orig event type)))
+        (when (equal type "agent_end")
+          (setq pi-coding-agent-tu-bench--agent-end-time
+                (plist-get timed :end)))
+        (plist-get timed :value)))))
 
 (defun pi-coding-agent-tu-bench--around-cooling-slice
     (orig buffer generation)
@@ -1225,7 +1230,9 @@ Each row is a plist with :type :count :totalMs :meanMs and :maxMs."
   (if (not (buffer-live-p chat-buf))
       (list :bufferLive :json-false :parser parser-state)
     (with-current-buffer chat-buf
-      (let* ((metadata (pi-coding-agent-tu-bench--cold-tool-metadata))
+      (let* ((counts (pi-coding-agent-tu-bench--cooling-state-counts))
+             (semantic (pi-coding-agent-tu-bench--semantic-summary))
+             (metadata (pi-coding-agent-tu-bench--cold-tool-metadata))
              (tool-overlays (pi-coding-agent-tu-bench--tool-overlays))
              (current
               (seq-find
@@ -1234,20 +1241,16 @@ Each row is a plist with :type :count :totalMs :meanMs and :maxMs."
                          overlay)
                         pi-coding-agent-tu-bench-cooling-live-id))
                tool-overlays))
-             (boundary
-              (and (markerp pi-coding-agent--hot-tail-start)
-                   (marker-position pi-coding-agent--hot-tail-start)))
-             (semantic-lines
-              (pi-coding-agent-tu-bench--semantic-lines))
+             (boundary (plist-get counts :hotTailBoundary))
              (window (get-buffer-window chat-buf t)))
         (list
          :bufferLive t
-         :coldTools (length metadata)
+         :coldTools (plist-get counts :coldTools)
          :coldToolNames
          (pi-coding-agent-tu-bench--tool-name-counts metadata)
          :pathBearingColdTools
          (cl-count-if (lambda (entry) (plist-get entry :path)) metadata)
-         :toolOverlays (length tool-overlays)
+         :toolOverlays (plist-get counts :toolOverlays)
          :toolOverlayIds
          (vconcat
           (sort (delq nil
@@ -1280,19 +1283,16 @@ Each row is a plist with :type :count :totalMs :meanMs and :maxMs."
           (lambda (overlay)
             (overlay-get overlay 'pi-coding-agent-table-display))
           (overlays-in (point-min) (point-max)))
-         :liveToolRegistry
-         (if (hash-table-p pi-coding-agent--live-tool-blocks)
-             (hash-table-count pi-coding-agent--live-tool-blocks)
-           0)
+         :liveToolRegistry (plist-get counts :liveRegistry)
          :pendingToolOverlay
          (pi-coding-agent-tu-bench--json-bool
           pi-coding-agent--pending-tool-overlay)
-         :queueLength (length pi-coding-agent--tool-cooling-queue)
+         :queueLength (plist-get counts :queueLength)
          :timerOwned
          (pi-coding-agent-tu-bench--json-bool
-          pi-coding-agent--tool-cooling-timer)
-         :semanticLineCount (length semantic-lines)
-         :semanticHash (pi-coding-agent-tu-bench--semantic-hash)
+          (plist-get counts :timer))
+         :semanticLineCount (car semantic)
+         :semanticHash (cdr semantic)
          :expectedSemanticHash
          (pi-coding-agent-tu-bench--expected-semantic-hash)
          :window (pi-coding-agent-tu-bench--capture-window-state)
@@ -2188,7 +2188,7 @@ the storm scenarios retain their existing prompt-to-agent_end settle path."
       (insert "Timing guidance is diagnostic only: `<100 ms` target, `>250 ms` concern, `>1 s` severe.  No timing threshold fails the run.\n\n")
       (when cooling
         (insert "## Measurement-fidelity caveat\n\n")
-        (insert "This runner uses `-Q`.  Slice and tree-root timings are structural diagnostics, and zero root calls is valid.  Do not cite this benchmark as evidence that md-ts root cost was reduced; an exact normal-init GUI replay is the performance-fidelity evidence.\n\n")
+        (insert "This runner uses `-Q`.  Slice and tree-root timings are structural diagnostics, and zero root calls is valid.  Do not cite this benchmark as evidence that md-ts root cost was reduced; it proves deferred scheduling and final correctness only.\n\n")
         (let* ((agent-end pi-coding-agent-tu-bench--agent-end-observation)
                (filter pi-coding-agent-tu-bench--agent-end-filter)
                (drain (plist-get metrics :drain))

--- a/bench/pi-coding-agent-tool-update-bench.el
+++ b/bench/pi-coding-agent-tool-update-bench.el
@@ -15,14 +15,20 @@
 ;; blocking via a 50 ms probe timer's lateness, and tool block re-render
 ;; counts via advice on `pi-coding-agent--tool-block-replace-body' and
 ;; `pi-coding-agent--display-tool-end' (the environment-independent
-;; coalescing metric).  All content is synthetic; no private session files
-;; are read.
+;; coalescing metric).  The agent-end-cooling scenario reuses the same fake
+;; process and runner to queue a 90-overlay cohort at final agent_end, observe
+;; real one-shot cooling callbacks, and route scroll heartbeats through unread
+;; command events.  All content is synthetic; no private session files are
+;; read.
 ;;
 ;; Run with:
 ;;
-;;   make bench-tool-update            # GUI via xvfb, primary lane
-;;   make bench-tool-update-batch      # --batch, secondary lane
-;;   make bench-tool-update-smoke      # cheap correctness smoke
+;;   make bench-tool-update             # GUI via xvfb, primary lane
+;;   make bench-tool-update-batch       # --batch, secondary lane
+;;   make bench-tool-update-smoke       # cheap correctness smoke
+;;   make bench-agent-end-cooling       # deferred cooling GUI lane
+;;   make bench-agent-end-cooling-batch # deferred cooling batch lane
+;;   make bench-agent-end-cooling-smoke # cheap cooling correctness smoke
 ;;
 ;; or directly through `bench/run-tool-update-bench.sh'.
 ;;
@@ -31,6 +37,12 @@
 ;; reproduce.  Batch numbers are useful for CI trend artifacts.  The run
 ;; fails on correctness violations (lost or duplicated tool blocks and
 ;; events), not on timing thresholds.
+;;
+;; The runner deliberately uses `-Q'.  Cooling slice/root timings in this lane
+;; are structural diagnostics, and zero tree-root calls is a valid result.
+;; They must not be cited as evidence that md-ts root cost was reduced.  An
+;; exact normal-init GUI replay is the performance-fidelity evidence for that
+;; claim; this benchmark proves deferred scheduling and final correctness.
 
 ;;; Code:
 
@@ -131,6 +143,23 @@ The fake backend applies the scale when scheduling events.")
   0.05
   "Probe timer interval in seconds for measuring main thread blocking.")
 
+(defvar pi-coding-agent-tu-bench-hot-tail-turns
+  (pi-coding-agent-tu-bench--env-int "PI_TU_BENCH_HOT_TAIL_TURNS" 1)
+  "Number of headed turns kept hot by the cooling benchmark scenario.")
+
+(defvar pi-coding-agent-tu-bench-command-interval
+  (/ (pi-coding-agent-tu-bench--env-float
+      "PI_TU_BENCH_COMMAND_INTERVAL_MS" 100.0)
+     1000.0)
+  "Seconds between routed scroll-heartbeat commands during cooling.")
+
+(defconst pi-coding-agent-tu-bench-cooling-live-id "call-cooling-live"
+  "Tool call ID of the live hot-tail sentinel fixture.")
+
+(defconst pi-coding-agent-tu-bench-command-event
+  'pi-coding-agent-tu-bench-scroll-heartbeat
+  "Synthetic benchmark-safe command event routed during natural drain.")
+
 (defvar pi-coding-agent-tu-bench-out-dir
   (file-name-as-directory
    (expand-file-name (pi-coding-agent-tu-bench--env
@@ -168,6 +197,14 @@ The fake backend applies the scale when scheduling events.")
   (expand-file-name "times.tsv" pi-coding-agent-tu-bench-out-dir)
   "Per-event-type timing artifact path for one benchmark run.")
 
+(defvar pi-coding-agent-tu-bench-cooling-slices-file
+  (expand-file-name "cooling-slices.tsv" pi-coding-agent-tu-bench-out-dir)
+  "Per-callback deferred cooling artifact path for one benchmark run.")
+
+(defvar pi-coding-agent-tu-bench-commands-file
+  (expand-file-name "commands.tsv" pi-coding-agent-tu-bench-out-dir)
+  "Per-command scroll-heartbeat artifact path for one benchmark run.")
+
 (defvar pi-coding-agent-tu-bench--event-log nil
   "List of (TYPE . ELAPSED-MS) entries for handled display events.")
 
@@ -193,34 +230,414 @@ MAX-MS) lists.  This is the environment-independent coalescing metric: it
 counts how often the frontend re-renders tool block bodies, independent of
 how expensive each render is on the host.")
 
+(defvar pi-coding-agent-tu-bench--current-filter-id nil
+  "Dynamically bound `process-filter' invocation ID, or nil.")
+
+(defvar pi-coding-agent-tu-bench--filter-sequence 0
+  "Monotonic `process-filter' invocation counter.")
+
+(defvar pi-coding-agent-tu-bench--filter-log nil
+  "Process-filter timing rows, newest first.")
+
+(defvar pi-coding-agent-tu-bench--agent-end-observation nil
+  "Structural state captured immediately around the real agent_end handler.")
+
+(defvar pi-coding-agent-tu-bench--agent-end-filter nil
+  "Timing row for the `process-filter' invocation enclosing agent_end.")
+
+(defvar pi-coding-agent-tu-bench--drain-start-time nil
+  "Time when production agent_end returned and deferred drain began.")
+
+(defvar pi-coding-agent-tu-bench--cooling-slice-log nil
+  "Deferred cooling callback rows, newest first.")
+
+(defvar pi-coding-agent-tu-bench--cooling-slice-sequence 0
+  "Monotonic deferred cooling callback counter.")
+
+(defvar pi-coding-agent-tu-bench--scheduler-errors nil
+  "Deferred cooling warning strings observed during a run.")
+
+(defvar pi-coding-agent-tu-bench--tree-root-phase nil
+  "Dynamically bound tree-root measurement phase, or nil.")
+
+(defvar pi-coding-agent-tu-bench--tree-root-count 0
+  "Dynamically accumulated tree-root call count.")
+
+(defvar pi-coding-agent-tu-bench--tree-root-ms 0.0
+  "Dynamically accumulated tree-root call wall time in milliseconds.")
+
+(defvar pi-coding-agent-tu-bench--tree-root-max-ms 0.0
+  "Dynamically accumulated maximum tree-root call wall time.")
+
+(defvar pi-coding-agent-tu-bench--cooling-chat-buffer nil
+  "Chat buffer owned by the active cooling benchmark command route.")
+
+(defvar pi-coding-agent-tu-bench--command-timer nil
+  "One-shot timer scheduling the next scroll-heartbeat command event.")
+
+(defvar pi-coding-agent-tu-bench--command-pending nil
+  "FIFO list of scroll-heartbeat command jobs awaiting command routing.")
+
+(defvar pi-coding-agent-tu-bench--command-log nil
+  "Routed command timing rows, newest first.")
+
+(defvar pi-coding-agent-tu-bench--command-sequence 0
+  "Monotonic scroll-heartbeat command counter.")
+
+(defvar pi-coding-agent-tu-bench--command-current-job nil
+  "Job currently moving through pre-command and post-command hooks.")
+
+(defvar pi-coding-agent-tu-bench--command-drain-active nil
+  "Non-nil while command heartbeats may be scheduled for a cooling drain.")
+
+(defvar pi-coding-agent-tu-bench--command-last-route "follow"
+  "Last logical scroll route, either \"sentinel\" or \"follow\".")
+
+(defvar pi-coding-agent-tu-bench--window-sentinel-marker nil
+  "Marker tracking the logical scroll sentinel during cooling.")
+
+(defun pi-coding-agent-tu-bench--cooling-scenario-p ()
+  "Return non-nil for an agent-end cooling benchmark scenario."
+  (string-prefix-p "agent-end-cooling"
+                   pi-coding-agent-tu-bench-scenario))
+
+(defun pi-coding-agent-tu-bench--tool-overlays (&optional buffer)
+  "Return tool block overlays in BUFFER, or the current buffer."
+  (with-current-buffer (or buffer (current-buffer))
+    (seq-filter
+     (lambda (overlay)
+       (overlay-get overlay 'pi-coding-agent-tool-block))
+     (overlays-in (point-min) (point-max)))))
+
+(defun pi-coding-agent-tu-bench--overlay-tool-call-id (overlay)
+  "Return OVERLAY's tool call ID, or nil."
+  (when-let* ((record
+               (overlay-get overlay 'pi-coding-agent-tool-block-record)))
+    (pi-coding-agent--tool-block-tool-call-id record)))
+
+(defun pi-coding-agent-tu-bench--overlay-count-for-id (tool-call-id)
+  "Return the current buffer's tool overlay count for TOOL-CALL-ID."
+  (cl-count tool-call-id (pi-coding-agent-tu-bench--tool-overlays)
+            :key #'pi-coding-agent-tu-bench--overlay-tool-call-id
+            :test #'equal))
+
+(defun pi-coding-agent-tu-bench--cold-tool-metadata ()
+  "Return cold tool metadata segments in `current-buffer' order."
+  (let ((position (point-min))
+        metadata)
+    (while (< position (point-max))
+      (let* ((value (get-text-property
+                     position 'pi-coding-agent-cold-tool-block))
+             (next (or (next-single-property-change
+                        position 'pi-coding-agent-cold-tool-block
+                        nil (point-max))
+                       (point-max))))
+        (when value
+          (push value metadata))
+        (setq position (max (1+ position) next))))
+    (nreverse metadata)))
+
+(defun pi-coding-agent-tu-bench--button-count ()
+  "Return the number of distinct text buttons in the current buffer."
+  (let ((position (point-min))
+        (count 0))
+    (while (< position (point-max))
+      (if-let* ((button (button-at position)))
+          (progn
+            (setq count (1+ count))
+            (setq position (max (1+ position) (button-end button))))
+        (setq position (1+ position))))
+    count))
+
+(defun pi-coding-agent-tu-bench--collapsed-tool-count ()
+  "Return how many current tool overlays carry a collapse button."
+  (cl-count-if
+   (lambda (overlay)
+     (pi-coding-agent--find-toggle-button-in-region
+      (overlay-start overlay) (overlay-end overlay)))
+   (pi-coding-agent-tu-bench--tool-overlays)))
+
+(defun pi-coding-agent-tu-bench--semantic-lines ()
+  "Return deterministic cooling semantic sentinel lines in buffer order."
+  (save-excursion
+    (goto-char (point-min))
+    (let (lines)
+      (while (re-search-forward "^.*COOLING-SEMANTIC.*$" nil t)
+        (push (buffer-substring-no-properties
+               (match-beginning 0) (match-end 0))
+              lines))
+      (nreverse lines))))
+
+(defun pi-coding-agent-tu-bench--semantic-hash ()
+  "Return SHA-256 of the current cooling semantic sentinel projection."
+  (secure-hash 'sha256
+               (string-join
+                (pi-coding-agent-tu-bench--semantic-lines) "\n")))
+
+(defun pi-coding-agent-tu-bench--expected-semantic-lines ()
+  "Return exact semantic sentinel lines expected from the cooling fixture."
+  (append
+   (cl-loop for index below (pi-coding-agent-tu-bench--fill-tool-count)
+            collect (format "COOLING-SEMANTIC call-cooling-%04d" index))
+   '("| COOLING-SEMANTIC-HOT-TABLE | hot | remains decorated and outside the completed cooling cohort |"
+     "$ cooling-live --sentinel COOLING-SEMANTIC-LIVE")))
+
+(defun pi-coding-agent-tu-bench--expected-semantic-hash ()
+  "Return SHA-256 of the exact expected cooling semantic projection."
+  (secure-hash 'sha256
+               (string-join
+                (pi-coding-agent-tu-bench--expected-semantic-lines) "\n")))
+
+(defun pi-coding-agent-tu-bench--tree-root-row ()
+  "Return tree-root counters from the current dynamic measurement phase."
+  (list :phase pi-coding-agent-tu-bench--tree-root-phase
+        :count pi-coding-agent-tu-bench--tree-root-count
+        :totalMs pi-coding-agent-tu-bench--tree-root-ms
+        :maxMs pi-coding-agent-tu-bench--tree-root-max-ms))
+
+(defun pi-coding-agent-tu-bench--around-tree-root (orig &rest args)
+  "Call ORIG with ARGS and record time in the active lightweight phase."
+  (if (not pi-coding-agent-tu-bench--tree-root-phase)
+      (apply orig args)
+    (let ((start (float-time))
+          value)
+      (unwind-protect
+          (setq value (apply orig args))
+        (let ((elapsed (* 1000.0 (- (float-time) start))))
+          (setq pi-coding-agent-tu-bench--tree-root-count
+                (1+ pi-coding-agent-tu-bench--tree-root-count)
+                pi-coding-agent-tu-bench--tree-root-ms
+                (+ pi-coding-agent-tu-bench--tree-root-ms elapsed)
+                pi-coding-agent-tu-bench--tree-root-max-ms
+                (max pi-coding-agent-tu-bench--tree-root-max-ms elapsed))))
+      value)))
+
+(defun pi-coding-agent-tu-bench--around-process-filter (orig proc output)
+  "Call process filter ORIG for PROC and OUTPUT while timing the real path."
+  (let* ((id (cl-incf pi-coding-agent-tu-bench--filter-sequence))
+         (start (float-time))
+         (pi-coding-agent-tu-bench--current-filter-id id)
+         value)
+    (setq value (funcall orig proc output))
+    (let* ((elapsed (* 1000.0 (- (float-time) start)))
+           (agent-end
+            (and pi-coding-agent-tu-bench--agent-end-observation
+                 (= id (plist-get pi-coding-agent-tu-bench--agent-end-observation
+                                  :filterId))))
+           (row (list :id id
+                      :wallMs elapsed
+                      :bytes (string-bytes output)
+                      :lines (cl-count ?\n output)
+                      :agentEnd (and agent-end t))))
+      (push row pi-coding-agent-tu-bench--filter-log)
+      (when agent-end
+        (setq pi-coding-agent-tu-bench--agent-end-filter row)))
+    value))
+
 (defun pi-coding-agent-tu-bench--around-handle-event (orig event)
   "Around advice recording handling time for display EVENT.
 Calls ORIG with EVENT and appends to the benchmark event log."
-  (let ((start (float-time)))
-    (prog1 (funcall orig event)
-      (let ((type (or (plist-get event :type) "unknown")))
-        (push (cons type (* 1000.0 (- (float-time) start)))
-              pi-coding-agent-tu-bench--event-log)
-        (when (equal type "agent_end")
-          (setq pi-coding-agent-tu-bench--agent-end-time (float-time)))))))
+  (let ((type (or (plist-get event :type) "unknown")))
+    (if (and (equal type "agent_end")
+             (pi-coding-agent-tu-bench--cooling-scenario-p))
+        (let* ((boundary-before
+                (and (markerp pi-coding-agent--hot-tail-start)
+                     (marker-position pi-coding-agent--hot-tail-start)))
+               (queue-before (length pi-coding-agent--tool-cooling-queue))
+               (timer-before (and pi-coding-agent--tool-cooling-timer t))
+               (cold-before
+                (length (pi-coding-agent-tu-bench--cold-tool-metadata)))
+               (overlays-before
+                (length (pi-coding-agent-tu-bench--tool-overlays)))
+               (collapsed-before
+                (pi-coding-agent-tu-bench--collapsed-tool-count))
+               (live-before
+                (if (hash-table-p pi-coding-agent--live-tool-blocks)
+                    (hash-table-count pi-coding-agent--live-tool-blocks)
+                  0))
+               (current-before
+                (pi-coding-agent-tu-bench--overlay-count-for-id
+                 pi-coding-agent-tu-bench-cooling-live-id))
+               (gc-before gcs-done)
+               (gc-time-before gc-elapsed)
+               (start (float-time))
+               (pi-coding-agent-tu-bench--tree-root-phase "agent_end")
+               (pi-coding-agent-tu-bench--tree-root-count 0)
+               (pi-coding-agent-tu-bench--tree-root-ms 0.0)
+               (pi-coding-agent-tu-bench--tree-root-max-ms 0.0)
+               value end elapsed tree-row)
+          (setq value (funcall orig event)
+                end (float-time)
+                elapsed (* 1000.0 (- end start))
+                tree-row (pi-coding-agent-tu-bench--tree-root-row))
+          (push (cons type elapsed) pi-coding-agent-tu-bench--event-log)
+          (setq pi-coding-agent-tu-bench--agent-end-time end
+                pi-coding-agent-tu-bench--drain-start-time end
+                pi-coding-agent-tu-bench--agent-end-observation
+                (list
+                 :wallMs elapsed
+                 :filterId pi-coding-agent-tu-bench--current-filter-id
+                 :boundaryBefore boundary-before
+                 :boundaryAfter
+                 (and (markerp pi-coding-agent--hot-tail-start)
+                      (marker-position pi-coding-agent--hot-tail-start))
+                 :queueBefore queue-before
+                 :queueAfter (length pi-coding-agent--tool-cooling-queue)
+                 :timerBefore timer-before
+                 :timerAfter (and pi-coding-agent--tool-cooling-timer t)
+                 :coldBefore cold-before
+                 :coldAfter
+                 (length (pi-coding-agent-tu-bench--cold-tool-metadata))
+                 :toolOverlaysBefore overlays-before
+                 :toolOverlaysAfter
+                 (length (pi-coding-agent-tu-bench--tool-overlays))
+                 :collapsedToolOverlaysBefore collapsed-before
+                 :liveRegistryBefore live-before
+                 :liveRegistryAfter
+                 (if (hash-table-p pi-coding-agent--live-tool-blocks)
+                     (hash-table-count pi-coding-agent--live-tool-blocks)
+                   0)
+                 :currentOverlayBefore current-before
+                 :currentOverlayAfter
+                 (pi-coding-agent-tu-bench--overlay-count-for-id
+                  pi-coding-agent-tu-bench-cooling-live-id)
+                 :semanticLinesAfter
+                 (length (pi-coding-agent-tu-bench--semantic-lines))
+                 :semanticHashAfter
+                 (pi-coding-agent-tu-bench--semantic-hash)
+                 :gcs (- gcs-done gc-before)
+                 :gcMs (* 1000.0 (- gc-elapsed gc-time-before))
+                 :treeRoots tree-row))
+          value)
+      (let ((start (float-time)))
+        (prog1 (funcall orig event)
+          (let ((end (float-time)))
+            (push (cons type (* 1000.0 (- end start)))
+                  pi-coding-agent-tu-bench--event-log)
+            (when (equal type "agent_end")
+              (setq pi-coding-agent-tu-bench--agent-end-time end))))))))
+
+(defun pi-coding-agent-tu-bench--around-cooling-slice
+    (orig buffer generation)
+  "Call cooling worker ORIG for BUFFER and GENERATION and record one slice."
+  (if (not (pi-coding-agent-tu-bench--cooling-scenario-p))
+      (funcall orig buffer generation)
+    (let* ((index (cl-incf pi-coding-agent-tu-bench--cooling-slice-sequence))
+           (buffer-live-before (buffer-live-p buffer))
+           (queue-before
+            (if buffer-live-before
+                (with-current-buffer buffer
+                  (length pi-coding-agent--tool-cooling-queue))
+              -1))
+           (candidate
+            (and buffer-live-before
+                 (with-current-buffer buffer
+                   (car pi-coding-agent--tool-cooling-queue))))
+           (candidate-id
+            (and candidate
+                 (pi-coding-agent-tu-bench--overlay-tool-call-id candidate)))
+           (candidate-eligible
+            (and candidate buffer-live-before
+                 (with-current-buffer buffer
+                   (when-let* ((boundary
+                                (pi-coding-agent--tool-cooling-boundary)))
+                     (pi-coding-agent--completed-tool-overlay-before-p
+                      candidate boundary)))))
+           (timer-before
+            (and buffer-live-before
+                 (with-current-buffer buffer
+                   (and pi-coding-agent--tool-cooling-timer t))))
+           (gc-before gcs-done)
+           (gc-time-before gc-elapsed)
+           (start (float-time))
+           (pi-coding-agent-tu-bench--tree-root-phase "cooling_slice")
+           (pi-coding-agent-tu-bench--tree-root-count 0)
+           (pi-coding-agent-tu-bench--tree-root-ms 0.0)
+           (pi-coding-agent-tu-bench--tree-root-max-ms 0.0)
+           value end)
+      (unwind-protect
+          (setq value (funcall orig buffer generation))
+        (setq end (float-time))
+        (let* ((buffer-live-after (buffer-live-p buffer))
+               (queue-after
+                (if buffer-live-after
+                    (with-current-buffer buffer
+                      (length pi-coding-agent--tool-cooling-queue))
+                  -1))
+               (timer-after
+                (and buffer-live-after
+                     (with-current-buffer buffer
+                       (and pi-coding-agent--tool-cooling-timer t))))
+               (delta (and (>= queue-before 0) (>= queue-after 0)
+                           (- queue-before queue-after)))
+               (row
+                (list
+                 :index index
+                 :queueBefore queue-before
+                 :queueAfter queue-after
+                 :queueDelta delta
+                 :candidateId (or candidate-id :json-null)
+                 :candidateEligible
+                 (pi-coding-agent-tu-bench--json-bool candidate-eligible)
+                 :candidateOverlayAliveAfter
+                 (pi-coding-agent-tu-bench--json-bool
+                  (and candidate (overlay-buffer candidate)))
+                 :timerBefore
+                 (pi-coding-agent-tu-bench--json-bool timer-before)
+                 :timerAfter
+                 (pi-coding-agent-tu-bench--json-bool timer-after)
+                 :wallMs (* 1000.0 (- end start))
+                 :gcs (- gcs-done gc-before)
+                 :gcMs (* 1000.0 (- gc-elapsed gc-time-before))
+                 :treeRoots (pi-coding-agent-tu-bench--tree-root-row)
+                 :window (pi-coding-agent-tu-bench--capture-window-state))))
+          (push row pi-coding-agent-tu-bench--cooling-slice-log)))
+      value)))
+
+(defun pi-coding-agent-tu-bench--around-display-warning (orig &rest args)
+  "Call `display-warning' ORIG with ARGS and record scheduler errors."
+  (let ((text (format "%s" (nth 1 args))))
+    (when (and (pi-coding-agent-tu-bench--cooling-scenario-p)
+               (string-match-p "Deferred tool block cooling failed" text))
+      (push text pi-coding-agent-tu-bench--scheduler-errors)))
+  (apply orig args))
 
 (defun pi-coding-agent-tu-bench--install-advice ()
-  "Install the per-event timing and render counting advice."
+  "Install event, render, and scenario-specific cooling measurement advice."
   (advice-add 'pi-coding-agent--handle-display-event
               :around #'pi-coding-agent-tu-bench--around-handle-event)
   (advice-add 'pi-coding-agent--tool-block-replace-body
               :around #'pi-coding-agent-tu-bench--around-replace-body)
   (advice-add 'pi-coding-agent--display-tool-end
-              :around #'pi-coding-agent-tu-bench--around-display-tool-end))
+              :around #'pi-coding-agent-tu-bench--around-display-tool-end)
+  (when (pi-coding-agent-tu-bench--cooling-scenario-p)
+    (advice-add 'pi-coding-agent--process-filter
+                :around #'pi-coding-agent-tu-bench--around-process-filter)
+    (advice-add 'pi-coding-agent--run-tool-cooling-slice
+                :around #'pi-coding-agent-tu-bench--around-cooling-slice)
+    (advice-add 'display-warning
+                :around #'pi-coding-agent-tu-bench--around-display-warning)
+    (when (fboundp 'treesit-parser-root-node)
+      (advice-add 'treesit-parser-root-node
+                  :around #'pi-coding-agent-tu-bench--around-tree-root))))
 
 (defun pi-coding-agent-tu-bench--remove-advice ()
   "Remove all benchmark advice."
+  (advice-remove 'pi-coding-agent--process-filter
+                 #'pi-coding-agent-tu-bench--around-process-filter)
   (advice-remove 'pi-coding-agent--handle-display-event
                  #'pi-coding-agent-tu-bench--around-handle-event)
   (advice-remove 'pi-coding-agent--tool-block-replace-body
                  #'pi-coding-agent-tu-bench--around-replace-body)
   (advice-remove 'pi-coding-agent--display-tool-end
-                 #'pi-coding-agent-tu-bench--around-display-tool-end))
+                 #'pi-coding-agent-tu-bench--around-display-tool-end)
+  (advice-remove 'pi-coding-agent--run-tool-cooling-slice
+                 #'pi-coding-agent-tu-bench--around-cooling-slice)
+  (advice-remove 'display-warning
+                 #'pi-coding-agent-tu-bench--around-display-warning)
+  (when (fboundp 'treesit-parser-root-node)
+    (advice-remove 'treesit-parser-root-node
+                   #'pi-coding-agent-tu-bench--around-tree-root)))
 
 (defun pi-coding-agent-tu-bench--record-render (operation tool-call-id
                                                           elapsed-ms)
@@ -383,6 +800,298 @@ Each row is a plist with :type :count :totalMs :meanMs and :maxMs."
           :over100Ms (cl-count-if (lambda (x) (> x 0.1)) lateness)
           :over250Ms (cl-count-if (lambda (x) (> x 0.25)) lateness))))
 
+(defun pi-coding-agent-tu-bench--window-line-at (buffer position)
+  "Return BUFFER's source line at POSITION without text properties."
+  (with-current-buffer buffer
+    (save-excursion
+      (goto-char (min (max (point-min) position) (point-max)))
+      (buffer-substring-no-properties
+       (line-beginning-position) (line-end-position)))))
+
+(defun pi-coding-agent-tu-bench--capture-window-state ()
+  "Return the cooling chat window's current logical sentinel/follow state."
+  (let* ((buffer pi-coding-agent-tu-bench--cooling-chat-buffer)
+         (window (and (buffer-live-p buffer)
+                      (get-buffer-window buffer t))))
+    (if (not (and (buffer-live-p buffer) (window-live-p window)))
+        (list :available :json-false
+              :expectedRoute pi-coding-agent-tu-bench--command-last-route
+              :viewOk t)
+      (with-current-buffer buffer
+        (let* ((start (window-start window))
+               (window-point-position (window-point window))
+               (start-line
+                (pi-coding-agent-tu-bench--window-line-at buffer start))
+               (point-line
+                (pi-coding-agent-tu-bench--window-line-at
+                 buffer window-point-position))
+               (following (pi-coding-agent--window-following-p window))
+               (sentinel-p
+                (and (string-prefix-p "COOLING-WINDOW-SENTINEL" start-line)
+                     (string-prefix-p "COOLING-WINDOW-SENTINEL" point-line)))
+               (view-ok
+                (if (equal pi-coding-agent-tu-bench--command-last-route
+                           "sentinel")
+                    sentinel-p
+                  following)))
+          (list :available t
+                :expectedRoute pi-coding-agent-tu-bench--command-last-route
+                :windowStart start
+                :windowPoint window-point-position
+                :pointMax (point-max)
+                :startLine start-line
+                :pointLine point-line
+                :following
+                (pi-coding-agent-tu-bench--json-bool following)
+                :sentinel
+                (pi-coding-agent-tu-bench--json-bool sentinel-p)
+                :viewOk
+                (pi-coding-agent-tu-bench--json-bool view-ok)))))))
+
+(defun pi-coding-agent-tu-bench--command-pre-hook ()
+  "Record entry through the benchmark command's pre-command hook."
+  (when (eq this-command
+            'pi-coding-agent-tu-bench--scroll-heartbeat-command)
+    (setq pi-coding-agent-tu-bench--command-current-job
+          (plist-put pi-coding-agent-tu-bench--command-current-job
+                     :preHookAt (float-time)))))
+
+(defun pi-coding-agent-tu-bench--command-post-hook ()
+  "Record exit through the benchmark command's post-command hook."
+  (when (eq this-command
+            'pi-coding-agent-tu-bench--scroll-heartbeat-command)
+    (setq pi-coding-agent-tu-bench--command-current-job
+          (plist-put pi-coding-agent-tu-bench--command-current-job
+                     :postHookAt (float-time)))))
+
+(defun pi-coding-agent-tu-bench--scroll-heartbeat-command ()
+  "Route one deterministic sentinel/follow scroll heartbeat."
+  (interactive)
+  (let* ((job pi-coding-agent-tu-bench--command-current-job)
+         (route (plist-get job :route))
+         (buffer pi-coding-agent-tu-bench--cooling-chat-buffer)
+         (window (and (buffer-live-p buffer)
+                      (get-buffer-window buffer t))))
+    (unless (buffer-live-p buffer)
+      (error "Cooling command route lost its chat buffer"))
+    (with-current-buffer buffer
+      (let ((sentinel
+             (and (markerp pi-coding-agent-tu-bench--window-sentinel-marker)
+                  (marker-position
+                   pi-coding-agent-tu-bench--window-sentinel-marker))))
+        (unless sentinel
+          (error "Cooling command route lost its logical sentinel"))
+        (if (window-live-p window)
+            (with-selected-window window
+              (if (equal route "sentinel")
+                  (progn
+                    (goto-char sentinel)
+                    (set-window-start window sentinel t)
+                    (set-window-point window sentinel))
+                (goto-char (point-max))
+                (set-window-point window (point-max))))
+          ;; Batch is a secondary lane without a window, but still traverses
+          ;; the same unread-event/key-binding/command-hook route.
+          (goto-char (if (equal route "sentinel")
+                         sentinel
+                       (point-max))))))
+    (setq pi-coding-agent-tu-bench--command-last-route route)))
+
+(defun pi-coding-agent-tu-bench--enqueue-command-event
+    (sequence due route)
+  "Enqueue scroll command SEQUENCE for DUE using logical ROUTE."
+  (setq pi-coding-agent-tu-bench--command-timer nil)
+  (when pi-coding-agent-tu-bench--command-drain-active
+    (setq pi-coding-agent-tu-bench--command-pending
+          (nconc pi-coding-agent-tu-bench--command-pending
+                 (list (list :sequence sequence
+                             :dueAt due
+                             :enqueuedAt (float-time)
+                             :route route))))
+    (setq unread-command-events
+          (append unread-command-events
+                  (list pi-coding-agent-tu-bench-command-event)))))
+
+(defun pi-coding-agent-tu-bench--schedule-command-event ()
+  "Arm one benchmark command event when the cooling drain is active."
+  (when (and pi-coding-agent-tu-bench--command-drain-active
+             (not pi-coding-agent-tu-bench--command-timer)
+             (null pi-coding-agent-tu-bench--command-pending))
+    (let* ((sequence
+            (cl-incf pi-coding-agent-tu-bench--command-sequence))
+           (route (if (cl-oddp sequence) "sentinel" "follow"))
+           (due (+ (float-time)
+                   pi-coding-agent-tu-bench-command-interval)))
+      (setq pi-coding-agent-tu-bench--command-timer
+            (run-at-time pi-coding-agent-tu-bench-command-interval nil
+                         #'pi-coding-agent-tu-bench--enqueue-command-event
+                         sequence due route)))))
+
+(defun pi-coding-agent-tu-bench--route-command-event (event)
+  "Route unread EVENT through key lookup, hooks, and `command-execute'."
+  (when (eq event pi-coding-agent-tu-bench-command-event)
+    (let* ((job (pop pi-coding-agent-tu-bench--command-pending))
+           (buffer pi-coding-agent-tu-bench--cooling-chat-buffer)
+           (command
+            (and (buffer-live-p buffer)
+                 (with-current-buffer buffer
+                   (key-binding (vector event) t))))
+           (started (float-time))
+           error-text)
+      (if (not job)
+          (setq error-text "Command event had no scheduled job")
+        (setq job (plist-put job :startedAt started)
+              pi-coding-agent-tu-bench--command-current-job job)
+        (condition-case error-data
+            (if (not (eq command
+                         'pi-coding-agent-tu-bench--scroll-heartbeat-command))
+                (error "Command event resolved to %S" command)
+              (with-current-buffer buffer
+                (let ((this-command command)
+                      (real-this-command command))
+                  (run-hooks 'pre-command-hook)
+                  (unwind-protect
+                      (command-execute command)
+                    (run-hooks 'post-command-hook)))))
+          (error
+           (setq error-text (error-message-string error-data))))
+        (setq job pi-coding-agent-tu-bench--command-current-job))
+      (let* ((ended (float-time))
+             (row
+              (append
+               job
+               (list
+                :command (and command (symbol-name command))
+                :endedAt ended
+                :latenessMs
+                (if-let* ((due (plist-get job :dueAt)))
+                    (* 1000.0 (max 0.0 (- started due)))
+                  0.0)
+                :queueDelayMs
+                (if-let* ((enqueued (plist-get job :enqueuedAt)))
+                    (* 1000.0 (max 0.0 (- started enqueued)))
+                  0.0)
+                :durationMs (* 1000.0 (- ended started))
+                :preHook
+                (pi-coding-agent-tu-bench--json-bool
+                 (plist-get job :preHookAt))
+                :postHook
+                (pi-coding-agent-tu-bench--json-bool
+                 (plist-get job :postHookAt))
+                :error (or error-text :json-null)
+                :window (pi-coding-agent-tu-bench--capture-window-state)))))
+        (push row pi-coding-agent-tu-bench--command-log))
+      (setq pi-coding-agent-tu-bench--command-current-job nil)
+      (pi-coding-agent-tu-bench--schedule-command-event))
+    t))
+
+(defun pi-coding-agent-tu-bench--install-command-route (chat-buf)
+  "Install the benchmark-safe unread command route in CHAT-BUF."
+  (setq pi-coding-agent-tu-bench--cooling-chat-buffer chat-buf
+        pi-coding-agent-tu-bench--command-last-route "follow")
+  (with-current-buffer chat-buf
+    (use-local-map (copy-keymap (current-local-map)))
+    (define-key (current-local-map)
+                (vector pi-coding-agent-tu-bench-command-event)
+                #'pi-coding-agent-tu-bench--scroll-heartbeat-command)
+    (add-hook 'pre-command-hook
+              #'pi-coding-agent-tu-bench--command-pre-hook nil t)
+    (add-hook 'post-command-hook
+              #'pi-coding-agent-tu-bench--command-post-hook nil t)
+    (save-excursion
+      (goto-char (point-min))
+      (unless (search-forward "COOLING-WINDOW-SENTINEL" nil t)
+        (error "Cooling fixture did not render its window sentinel"))
+      (setq pi-coding-agent-tu-bench--window-sentinel-marker
+            (copy-marker (line-beginning-position) nil)))
+    (goto-char (point-max)))
+  (when-let* ((window (get-buffer-window chat-buf t)))
+    (select-window window)
+    (set-window-point window
+                      (with-current-buffer chat-buf (point-max)))))
+
+(defun pi-coding-agent-tu-bench--start-command-route ()
+  "Start one-shot command scheduling for a natural cooling drain."
+  (setq pi-coding-agent-tu-bench--command-drain-active t)
+  (pi-coding-agent-tu-bench--schedule-command-event))
+
+(defun pi-coding-agent-tu-bench--stop-command-route ()
+  "Stop command scheduling and remove unread benchmark events."
+  (setq pi-coding-agent-tu-bench--command-drain-active nil)
+  (when (timerp pi-coding-agent-tu-bench--command-timer)
+    (cancel-timer pi-coding-agent-tu-bench--command-timer))
+  (setq pi-coding-agent-tu-bench--command-timer nil
+        pi-coding-agent-tu-bench--command-pending nil
+        unread-command-events
+        (delq pi-coding-agent-tu-bench-command-event
+              unread-command-events)))
+
+(defun pi-coding-agent-tu-bench--cooling-drained-p (chat-buf)
+  "Return non-nil when CHAT-BUF owns no cooling queue or timer."
+  (and (buffer-live-p chat-buf)
+       (with-current-buffer chat-buf
+         (and (null pi-coding-agent--tool-cooling-queue)
+              (null pi-coding-agent--tool-cooling-timer)))))
+
+(defun pi-coding-agent-tu-bench--wait-for-natural-cooling
+    (chat-buf timeout)
+  "Wait up to TIMEOUT for CHAT-BUF's real one-shot cooling timers to drain."
+  (let ((start (or pi-coding-agent-tu-bench--drain-start-time
+                   (float-time)))
+        (gc-before gcs-done)
+        (gc-time-before gc-elapsed)
+        (deadline (+ (float-time) timeout))
+        settled end)
+    (pi-coding-agent-tu-bench--install-command-route chat-buf)
+    (pi-coding-agent-tu-bench--start-probe)
+    (pi-coding-agent-tu-bench--start-command-route)
+    (unwind-protect
+        (while (and (not settled) (< (float-time) deadline))
+          ;; `read-event' gives Emacs its ordinary timer/redisplay opportunity;
+          ;; no explicit redisplay is forced in this timed interval.
+          (when-let* ((event (read-event nil nil 0.01)))
+            (pi-coding-agent-tu-bench--route-command-event event))
+          (accept-process-output nil 0.005)
+          (when (and (pi-coding-agent-tu-bench--cooling-drained-p chat-buf)
+                     (null pi-coding-agent-tu-bench--command-pending))
+            (setq settled t)))
+      (setq end (float-time))
+      (pi-coding-agent-tu-bench--stop-command-route)
+      (pi-coding-agent-tu-bench--stop-probe))
+    (list :settled (pi-coding-agent-tu-bench--json-bool settled)
+          :timeoutSeconds timeout
+          :wallMs (* 1000.0 (- end start))
+          :activeMs
+          (cl-loop for row in pi-coding-agent-tu-bench--cooling-slice-log
+                   sum (plist-get row :wallMs))
+          :callbacks (length pi-coding-agent-tu-bench--cooling-slice-log)
+          :gcs (- gcs-done gc-before)
+          :gcMs (* 1000.0 (- gc-elapsed gc-time-before))
+          :finalWindow (pi-coding-agent-tu-bench--capture-window-state))))
+
+(defun pi-coding-agent-tu-bench--command-stats ()
+  "Return command scheduling and duration summary statistics."
+  (let* ((rows pi-coding-agent-tu-bench--command-log)
+         (lateness (mapcar (lambda (row) (plist-get row :latenessMs)) rows))
+         (durations (mapcar (lambda (row) (plist-get row :durationMs)) rows)))
+    (list :count (length rows)
+          :sentinelRoutes
+          (cl-count "sentinel" rows :key (lambda (row) (plist-get row :route))
+                    :test #'equal)
+          :followRoutes
+          (cl-count "follow" rows :key (lambda (row) (plist-get row :route))
+                    :test #'equal)
+          :latenessP50Ms
+          (pi-coding-agent-tu-bench--percentile lateness 0.50)
+          :latenessP95Ms
+          (pi-coding-agent-tu-bench--percentile lateness 0.95)
+          :latenessMaxMs (if lateness (apply #'max lateness) 0.0)
+          :durationP50Ms
+          (pi-coding-agent-tu-bench--percentile durations 0.50)
+          :durationP95Ms
+          (pi-coding-agent-tu-bench--percentile durations 0.95)
+          :durationMaxMs (if durations (apply #'max durations) 0.0))))
+
 (defun pi-coding-agent-tu-bench--storm-tool-ids ()
   "Return the expected storm phase subagent tool call IDs."
   (cl-loop for index below pi-coding-agent-tu-bench-parallel-tools
@@ -446,6 +1155,189 @@ Each row is a plist with :type :count :totalMs :meanMs and :maxMs."
       (if (hash-table-p pi-coding-agent--live-tool-blocks)
           (hash-table-count pi-coding-agent--live-tool-blocks)
         0))))
+
+(defun pi-coding-agent-tu-bench--parser-font-lock-state (chat-buf)
+  "Return final parser-root and font-lock usability metrics for CHAT-BUF."
+  (if (not (buffer-live-p chat-buf))
+      (list :parserOk :json-false
+            :fontLockOk :json-false
+            :error "chat buffer is not live")
+    (with-current-buffer chat-buf
+      (let ((pi-coding-agent-tu-bench--tree-root-phase "final_check")
+            (pi-coding-agent-tu-bench--tree-root-count 0)
+            (pi-coding-agent-tu-bench--tree-root-ms 0.0)
+            (pi-coding-agent-tu-bench--tree-root-max-ms 0.0)
+            parser root root-start root-end root-type
+            parser-error font-lock-error
+            (font-lock-start (float-time))
+            font-lock-ms)
+        (condition-case error-data
+            (progn
+              (setq parser (pi-coding-agent--markdown-parser))
+              (unless parser
+                (error "No Markdown tree-sitter parser"))
+              (setq root (treesit-parser-root-node parser)
+                    root-start (treesit-node-start root)
+                    root-end (treesit-node-end root)
+                    root-type (treesit-node-type root)))
+          (error
+           (setq parser-error (error-message-string error-data))))
+        (setq font-lock-start (float-time))
+        (condition-case error-data
+            (font-lock-ensure (point-min) (point-max))
+          (error
+           (setq font-lock-error (error-message-string error-data))))
+        (setq font-lock-ms (* 1000.0 (- (float-time) font-lock-start)))
+        (list
+         :parserOk
+         (pi-coding-agent-tu-bench--json-bool
+          (and root
+               (<= root-start (point-min))
+               (>= root-end (1- (point-max)))))
+         :fontLockOk
+         (pi-coding-agent-tu-bench--json-bool (null font-lock-error))
+         :parserCount (length (treesit-parser-list))
+         :rootType (or root-type :json-null)
+         :rootStart (or root-start :json-null)
+         :rootEnd (or root-end :json-null)
+         :fontLockMs font-lock-ms
+         :parserError (or parser-error :json-null)
+         :fontLockError (or font-lock-error :json-null)
+         :treeRoots (pi-coding-agent-tu-bench--tree-root-row))))))
+
+(defun pi-coding-agent-tu-bench--tool-name-counts (metadata)
+  "Return cooling tool-name counts from cold target METADATA."
+  (list :bash (cl-count "bash" metadata
+                        :key (lambda (entry) (plist-get entry :tool-name))
+                        :test #'equal)
+        :read (cl-count "read" metadata
+                        :key (lambda (entry) (plist-get entry :tool-name))
+                        :test #'equal)
+        :write (cl-count "write" metadata
+                         :key (lambda (entry) (plist-get entry :tool-name))
+                         :test #'equal)
+        :edit (cl-count "edit" metadata
+                        :key (lambda (entry) (plist-get entry :tool-name))
+                        :test #'equal)))
+
+(defun pi-coding-agent-tu-bench--cooling-final-state (chat-buf parser-state)
+  "Return exact settled cooling state for CHAT-BUF and PARSER-STATE."
+  (if (not (buffer-live-p chat-buf))
+      (list :bufferLive :json-false :parser parser-state)
+    (with-current-buffer chat-buf
+      (let* ((metadata (pi-coding-agent-tu-bench--cold-tool-metadata))
+             (tool-overlays (pi-coding-agent-tu-bench--tool-overlays))
+             (current
+              (seq-find
+               (lambda (overlay)
+                 (equal (pi-coding-agent-tu-bench--overlay-tool-call-id
+                         overlay)
+                        pi-coding-agent-tu-bench-cooling-live-id))
+               tool-overlays))
+             (boundary
+              (and (markerp pi-coding-agent--hot-tail-start)
+                   (marker-position pi-coding-agent--hot-tail-start)))
+             (semantic-lines
+              (pi-coding-agent-tu-bench--semantic-lines))
+             (window (get-buffer-window chat-buf t)))
+        (list
+         :bufferLive t
+         :coldTools (length metadata)
+         :coldToolNames
+         (pi-coding-agent-tu-bench--tool-name-counts metadata)
+         :pathBearingColdTools
+         (cl-count-if (lambda (entry) (plist-get entry :path)) metadata)
+         :toolOverlays (length tool-overlays)
+         :toolOverlayIds
+         (vconcat
+          (sort (delq nil
+                      (mapcar
+                       #'pi-coding-agent-tu-bench--overlay-tool-call-id
+                       tool-overlays))
+                #'string<))
+         :currentOverlayStart
+         (if current (overlay-start current) :json-null)
+         :currentOverlayEnd
+         (if current (overlay-end current) :json-null)
+         :currentInsideHotTail
+         (pi-coding-agent-tu-bench--json-bool
+          (and current boundary (>= (overlay-start current) boundary)))
+         :currentColdProperty
+         (pi-coding-agent-tu-bench--json-bool
+          (and current
+               (get-text-property
+                (overlay-start current)
+                'pi-coding-agent-cold-tool-block)))
+         :hotTailBoundary (or boundary :json-null)
+         :buttons (pi-coding-agent-tu-bench--button-count)
+         :diffOverlays
+         (cl-count-if
+          (lambda (overlay)
+            (overlay-get overlay 'pi-coding-agent-diff-overlay))
+          (overlays-in (point-min) (point-max)))
+         :tableOverlays
+         (cl-count-if
+          (lambda (overlay)
+            (overlay-get overlay 'pi-coding-agent-table-display))
+          (overlays-in (point-min) (point-max)))
+         :liveToolRegistry
+         (if (hash-table-p pi-coding-agent--live-tool-blocks)
+             (hash-table-count pi-coding-agent--live-tool-blocks)
+           0)
+         :pendingToolOverlay
+         (pi-coding-agent-tu-bench--json-bool
+          pi-coding-agent--pending-tool-overlay)
+         :queueLength (length pi-coding-agent--tool-cooling-queue)
+         :timerOwned
+         (pi-coding-agent-tu-bench--json-bool
+          pi-coding-agent--tool-cooling-timer)
+         :semanticLineCount (length semantic-lines)
+         :semanticHash (pi-coding-agent-tu-bench--semantic-hash)
+         :expectedSemanticHash
+         (pi-coding-agent-tu-bench--expected-semantic-hash)
+         :window (pi-coding-agent-tu-bench--capture-window-state)
+         :geometry
+         (if (and pi-coding-agent-tu-bench-display-buffers
+                  (not noninteractive)
+                  (window-live-p window))
+             (list :frameColumns (frame-width (window-frame window))
+                   :frameLines (frame-height (window-frame window))
+                   :chatColumns (window-width window)
+                   :chatLines (window-height window))
+           :json-null)
+         :parser parser-state)))))
+
+(defun pi-coding-agent-tu-bench--cooling-slices-in-order ()
+  "Return cooling slice rows in callback order."
+  (nreverse (copy-sequence pi-coding-agent-tu-bench--cooling-slice-log)))
+
+(defun pi-coding-agent-tu-bench--commands-in-order ()
+  "Return command rows in scheduling order."
+  (nreverse (copy-sequence pi-coding-agent-tu-bench--command-log)))
+
+(defun pi-coding-agent-tu-bench--tree-root-summary ()
+  "Return lightweight tree-root metrics split across agent_end and slices."
+  (let* ((agent-row
+          (plist-get pi-coding-agent-tu-bench--agent-end-observation
+                     :treeRoots))
+         (slice-rows (pi-coding-agent-tu-bench--cooling-slices-in-order)))
+    (list
+     :agentEnd (or agent-row
+                   (list :phase "agent_end" :count 0
+                         :totalMs 0.0 :maxMs 0.0))
+     :coolingSlices
+     (list
+      :count (cl-loop for row in slice-rows
+                      sum (plist-get (plist-get row :treeRoots) :count))
+      :totalMs (cl-loop for row in slice-rows
+                        sum (plist-get (plist-get row :treeRoots) :totalMs))
+      :maxMs (if slice-rows
+                 (apply #'max
+                        (mapcar
+                         (lambda (row)
+                           (plist-get (plist-get row :treeRoots) :maxMs))
+                         slice-rows))
+               0.0)))))
 
 (defun pi-coding-agent-tu-bench--check (name ok detail)
   "Return a correctness check entry for NAME with OK flag and DETAIL text."
@@ -526,32 +1418,336 @@ Every entry must have a true :ok for the benchmark run to pass."
             checks))
     (nreverse checks)))
 
-(defun pi-coding-agent-tu-bench--cleanup-session (chat-buf)
-  "Kill CHAT-BUF, its input buffer, and their fake pi process."
-  (when (buffer-live-p chat-buf)
-    (let ((input-buf (buffer-local-value 'pi-coding-agent--input-buffer
-                                         chat-buf)))
-      (with-current-buffer chat-buf
-        (when (and (boundp 'pi-coding-agent--process)
-                   (processp pi-coding-agent--process)
-                   (process-live-p pi-coding-agent--process))
-          (set-process-query-on-exit-flag pi-coding-agent--process nil)
-          (delete-process pi-coding-agent--process)))
-      (kill-buffer chat-buf)
-      (when (buffer-live-p input-buf)
-        (kill-buffer input-buf)))))
+(defun pi-coding-agent-tu-bench--collect-cooling-checks
+    (chat-buf drain final-state)
+  "Build structural check rows for CHAT-BUF cooling DRAIN and FINAL-STATE."
+  (let* ((expected (pi-coding-agent-tu-bench--fill-tool-count))
+         (observation pi-coding-agent-tu-bench--agent-end-observation)
+         (slices (pi-coding-agent-tu-bench--cooling-slices-in-order))
+         (commands (pi-coding-agent-tu-bench--commands-in-order))
+         (names (plist-get final-state :coldToolNames))
+         (parser (plist-get final-state :parser))
+         (expected-paths (+ pi-coding-agent-tu-bench-fill-read
+                            pi-coding-agent-tu-bench-fill-write
+                            pi-coding-agent-tu-bench-fill-edit))
+         (expected-semantic-lines (+ expected 2))
+         (expected-hash (pi-coding-agent-tu-bench--expected-semantic-hash))
+         (slice-deltas
+          (mapcar (lambda (row) (plist-get row :queueDelta)) slices))
+         (progress-slices
+          (seq-filter (lambda (row)
+                        (= 1 (or (plist-get row :queueDelta) -1)))
+                      slices))
+         checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "agent-end-real-process-filter-path"
+      (and pi-coding-agent-tu-bench--agent-end-time
+           observation
+           pi-coding-agent-tu-bench--agent-end-filter)
+      (if pi-coding-agent-tu-bench--agent-end-filter
+          (format "agent_end event %.3f ms inside filter %d (%.3f ms)"
+                  (plist-get observation :wallMs)
+                  (plist-get pi-coding-agent-tu-bench--agent-end-filter :id)
+                  (plist-get pi-coding-agent-tu-bench--agent-end-filter :wallMs))
+        "agent_end had no enclosing real process-filter observation"))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "hot-tail-boundary-advances-only-at-agent-end"
+      (and (= (or (plist-get observation :boundaryBefore) -1) 1)
+           (> (or (plist-get observation :boundaryAfter) 0) 1))
+      (format "boundary %s -> %s"
+              (plist-get observation :boundaryBefore)
+              (plist-get observation :boundaryAfter)))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "current-tool-live-on-agent-end-entry"
+      (and (= (or (plist-get observation :liveRegistryBefore) -1) 1)
+           (= (or (plist-get observation :currentOverlayBefore) -1) 1))
+      (format "live registry %s; current overlays %s"
+              (plist-get observation :liveRegistryBefore)
+              (plist-get observation :currentOverlayBefore)))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "agent-end-returns-with-whole-cohort-deferred"
+      (and (= (or (plist-get observation :queueAfter) -1) expected)
+           (eq (plist-get observation :timerAfter) t)
+           (= (or (plist-get observation :coldAfter) -1) 0)
+           (= (or (plist-get observation :toolOverlaysAfter) -1)
+              (1+ expected)))
+      (format "queue=%s timer=%s cold=%s hot-overlays=%s expected cohort=%d"
+              (plist-get observation :queueAfter)
+              (plist-get observation :timerAfter)
+              (plist-get observation :coldAfter)
+              (plist-get observation :toolOverlaysAfter)
+              expected))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "cohort-has-collapsed-and-short-tools"
+      (let ((collapsed
+             (or (plist-get observation :collapsedToolOverlaysBefore) 0)))
+        (and (> collapsed 0) (< collapsed expected)))
+      (format "%s collapsed overlays among %d completed fixture tools"
+              (plist-get observation :collapsedToolOverlaysBefore) expected))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "one-candidate-maximum-per-natural-callback"
+      (and (>= (length slices) expected)
+           (cl-every (lambda (delta)
+                       (and (integerp delta) (memq delta '(0 1))))
+                     slice-deltas)
+           (= expected (apply #'+ (or slice-deltas '(0))))
+           (= expected (length progress-slices))
+           (seq-every-p
+            (lambda (row)
+              (and (eq (plist-get row :candidateEligible) t)
+                   (eq (plist-get row :candidateOverlayAliveAfter)
+                       :json-false)))
+            progress-slices))
+      (format "%d callbacks, %d one-overlay progress slices, deltas in [0,1]"
+              (length slices) (length progress-slices)))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "natural-drain-settles-before-timeout"
+      (eq (plist-get drain :settled) t)
+      (format "wall %.3f ms, active %.3f ms, timeout %s s"
+              (or (plist-get drain :wallMs) 0.0)
+              (or (plist-get drain :activeMs) 0.0)
+              (plist-get drain :timeoutSeconds)))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "exact-final-cold-hot-counts"
+      (and (= (or (plist-get final-state :coldTools) -1) expected)
+           (= (or (plist-get final-state :toolOverlays) -1) 1)
+           (equal (plist-get final-state :toolOverlayIds)
+                  (vector pi-coding-agent-tu-bench-cooling-live-id)))
+      (format "cold=%s hot-overlays=%s ids=%S"
+              (plist-get final-state :coldTools)
+              (plist-get final-state :toolOverlays)
+              (plist-get final-state :toolOverlayIds)))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "exact-cold-tool-cohort-composition"
+      (and (= (or (plist-get names :bash) -1)
+              pi-coding-agent-tu-bench-fill-bash)
+           (= (or (plist-get names :read) -1)
+              pi-coding-agent-tu-bench-fill-read)
+           (= (or (plist-get names :write) -1)
+              pi-coding-agent-tu-bench-fill-write)
+           (= (or (plist-get names :edit) -1)
+              pi-coding-agent-tu-bench-fill-edit)
+           (= (or (plist-get final-state :pathBearingColdTools) -1)
+              expected-paths))
+      (format "names=%S path-bearing=%s/%d"
+              names (plist-get final-state :pathBearingColdTools)
+              expected-paths))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "current-inside-hot-tail-stays-hot"
+      (and (eq (plist-get final-state :currentInsideHotTail) t)
+           (eq (plist-get final-state :currentColdProperty) :json-false)
+           (= 1 (pi-coding-agent-tu-bench--count-occurrences
+                 chat-buf "COOLING-SEMANTIC-LIVE")))
+      (format "inside=%s cold-property=%s live sentinel occurrences=%d"
+              (plist-get final-state :currentInsideHotTail)
+              (plist-get final-state :currentColdProperty)
+              (pi-coding-agent-tu-bench--count-occurrences
+               chat-buf "COOLING-SEMANTIC-LIVE")))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "semantic-sentinel-projection-hash-holds"
+      (and (= (or (plist-get observation :semanticLinesAfter) -1)
+              expected-semantic-lines)
+           (= (or (plist-get final-state :semanticLineCount) -1)
+              expected-semantic-lines)
+           (equal (plist-get observation :semanticHashAfter) expected-hash)
+           (equal (plist-get final-state :semanticHash) expected-hash))
+      (format "agent_end=%s final=%s expected=%s lines=%s/%d"
+              (plist-get observation :semanticHashAfter)
+              (plist-get final-state :semanticHash)
+              expected-hash
+              (plist-get final-state :semanticLineCount)
+              expected-semantic-lines))
+     checks)
+    (let ((table-pos nil)
+          (current-pos (plist-get final-state :currentOverlayStart)))
+      (when (buffer-live-p chat-buf)
+        (with-current-buffer chat-buf
+          (save-excursion
+            (goto-char (point-min))
+            (when (search-forward "COOLING-SEMANTIC-HOT-TABLE" nil t)
+              (setq table-pos (match-beginning 0))))))
+      (push
+       (pi-coding-agent-tu-bench--check
+        "adjacent-hot-tail-table-remains-usable"
+        (and table-pos
+             (integerp current-pos)
+             (< table-pos current-pos)
+             (or (not pi-coding-agent-tu-bench-display-buffers)
+                 (> (or (plist-get final-state :tableOverlays) 0) 0)))
+        (format "table-pos=%s current-pos=%s display-overlays=%s"
+                table-pos current-pos
+                (plist-get final-state :tableOverlays)))
+       checks))
+    (push
+     (pi-coding-agent-tu-bench--check
+      "no-stale-buttons-diffs-or-tool-overlays"
+      (and (= (or (plist-get final-state :buttons) -1) 0)
+           (= (or (plist-get final-state :diffOverlays) -1) 0)
+           (= (or (plist-get final-state :toolOverlays) -1) 1))
+      (format "buttons=%s diffs=%s tool-overlays=%s"
+              (plist-get final-state :buttons)
+              (plist-get final-state :diffOverlays)
+              (plist-get final-state :toolOverlays)))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "cooling-scheduler-and-live-registry-clean"
+      (and (= (or (plist-get final-state :queueLength) -1) 0)
+           (eq (plist-get final-state :timerOwned) :json-false)
+           (= (or (plist-get final-state :liveToolRegistry) -1) 0)
+           (eq (plist-get final-state :pendingToolOverlay) :json-false)
+           (null pi-coding-agent-tu-bench--scheduler-errors))
+      (format "queue=%s timer=%s live=%s pending=%s scheduler-errors=%S"
+              (plist-get final-state :queueLength)
+              (plist-get final-state :timerOwned)
+              (plist-get final-state :liveToolRegistry)
+              (plist-get final-state :pendingToolOverlay)
+              pi-coding-agent-tu-bench--scheduler-errors))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "parser-root-and-font-lock-usable"
+      (and (eq (plist-get parser :parserOk) t)
+           (eq (plist-get parser :fontLockOk) t))
+      (format "parser=%s font-lock=%s root=%s parser-error=%s font-lock-error=%s"
+              (plist-get parser :parserOk)
+              (plist-get parser :fontLockOk)
+              (plist-get parser :rootType)
+              (plist-get parser :parserError)
+              (plist-get parser :fontLockError)))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "command-loop-scroll-heartbeats-routed"
+      (and (>= (length commands) 2)
+           (seq-some (lambda (row)
+                       (equal (plist-get row :route) "sentinel"))
+                     commands)
+           (seq-some (lambda (row)
+                       (equal (plist-get row :route) "follow"))
+                     commands)
+           (seq-every-p
+            (lambda (row)
+              (and (eq (plist-get row :preHook) t)
+                   (eq (plist-get row :postHook) t)
+                   (eq (plist-get row :error) :json-null)
+                   (eq (plist-get (plist-get row :window) :viewOk) t)))
+            commands)
+           (seq-every-p
+            (lambda (row)
+              (eq (plist-get (plist-get row :window) :viewOk) t))
+            slices)
+           (eq (plist-get (plist-get drain :finalWindow) :viewOk) t))
+      (format "%d commands (%d sentinel/%d follow); final route=%s view-ok=%s"
+              (length commands)
+              (cl-count "sentinel" commands
+                        :key (lambda (row) (plist-get row :route))
+                        :test #'equal)
+              (cl-count "follow" commands
+                        :key (lambda (row) (plist-get row :route))
+                        :test #'equal)
+              (plist-get (plist-get drain :finalWindow) :expectedRoute)
+              (plist-get (plist-get drain :finalWindow) :viewOk)))
+     checks)
+    (push
+     (pi-coding-agent-tu-bench--check
+      "cooling-wire-event-counts"
+      (and (= (pi-coding-agent-tu-bench--event-count
+               "tool_execution_start")
+              (1+ expected))
+           (= (pi-coding-agent-tu-bench--event-count
+               "tool_execution_end")
+              expected)
+           (= (pi-coding-agent-tu-bench--event-count
+               "tool_execution_update")
+              0)
+           (= (pi-coding-agent-tu-bench--event-count "agent_end") 1))
+      (format "starts=%d ends=%d updates=%d agent_end=%d"
+              (pi-coding-agent-tu-bench--event-count
+               "tool_execution_start")
+              (pi-coding-agent-tu-bench--event-count
+               "tool_execution_end")
+              (pi-coding-agent-tu-bench--event-count
+               "tool_execution_update")
+              (pi-coding-agent-tu-bench--event-count "agent_end")))
+     checks)
+    (when (and pi-coding-agent-tu-bench-display-buffers
+               (not noninteractive))
+      (let ((geometry (plist-get final-state :geometry)))
+        (push
+         (pi-coding-agent-tu-bench--check
+          "gui-frame-is-120x40"
+          (and (= (or (plist-get geometry :frameColumns) -1) 120)
+               (= (or (plist-get geometry :frameLines) -1) 40))
+          (format "frame=%sx%s chat=%sx%s"
+                  (plist-get geometry :frameColumns)
+                  (plist-get geometry :frameLines)
+                  (plist-get geometry :chatColumns)
+                  (plist-get geometry :chatLines)))
+         checks)))
+    (nreverse checks)))
+
+(defun pi-coding-agent-tu-bench--cleanup-session-directory (session-dir)
+  "Delete generated SESSION-DIR when it belongs to this iteration output."
+  (when (and (stringp session-dir)
+             (file-directory-p session-dir)
+             (file-in-directory-p session-dir
+                                  pi-coding-agent-tu-bench-out-dir))
+    (delete-directory session-dir t)))
+
+(defun pi-coding-agent-tu-bench--cleanup-session (chat-buf session-dir)
+  "Kill CHAT-BUF and its fake process, then delete generated SESSION-DIR."
+  (unwind-protect
+      (when (buffer-live-p chat-buf)
+        (let ((input-buf (buffer-local-value 'pi-coding-agent--input-buffer
+                                             chat-buf)))
+          (with-current-buffer chat-buf
+            (when (and (boundp 'pi-coding-agent--process)
+                       (processp pi-coding-agent--process)
+                       (process-live-p pi-coding-agent--process))
+              (set-process-query-on-exit-flag pi-coding-agent--process nil)
+              (delete-process pi-coding-agent--process)))
+          (kill-buffer chat-buf)
+          (when (buffer-live-p input-buf)
+            (kill-buffer input-buf))))
+    (pi-coding-agent-tu-bench--cleanup-session-directory session-dir)))
 
 (defun pi-coding-agent-tu-bench--run-session ()
-  "Run one storm session and return a metrics plist.
-Sets up a fake-backed session in a temporary directory, sends one prompt,
-waits for agent_end, then collects buffer metrics and correctness checks."
+  "Run one fake-backed tool benchmark session and return a metrics plist.
+The cooling scenario waits for production one-shot timers to drain naturally;
+the storm scenarios retain their existing prompt-to-agent_end settle path."
   (let* ((session-dir (make-temp-file
                        (expand-file-name "session-"
                                          pi-coding-agent-tu-bench-out-dir)
                        t))
+         (cooling (pi-coding-agent-tu-bench--cooling-scenario-p))
          (chat-buf nil)
          (ok nil)
          (error-text nil)
+         (drain nil)
+         (parser-state nil)
+         (final-state nil)
          (gc-before nil)
          (gc-time-before nil)
          (start nil))
@@ -562,6 +1758,9 @@ waits for agent_end, then collects buffer metrics and correctness checks."
           (list "--log-file" pi-coding-agent-tu-bench-fake-log))
     ;; Never prompt about grammars or versions from a benchmark run.
     (setq pi-coding-agent-essential-grammar-action 'warn)
+    (when cooling
+      (setq pi-coding-agent-hot-tail-turn-count
+            pi-coding-agent-tu-bench-hot-tail-turns))
     (unwind-protect
         (condition-case err
             (progn
@@ -574,52 +1773,124 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                 (pi-coding-agent--show-session-buffers
                  chat-buf
                  (buffer-local-value 'pi-coding-agent--input-buffer chat-buf))
+                ;; This setup redisplay is deliberately before the timed drain.
                 (redisplay t))
               (garbage-collect)
               (setq gc-before gcs-done
                     gc-time-before gc-elapsed
                     start (float-time))
-              (pi-coding-agent-tu-bench--start-probe)
+              (unless cooling
+                (pi-coding-agent-tu-bench--start-probe))
               (setq pi-coding-agent-tu-bench--prompt-time (float-time))
               (with-current-buffer chat-buf
                 (pi-coding-agent--prepare-and-send
-                 "run the synthetic tool update storm"))
-              (setq ok
-                    (pi-coding-agent-tu-bench--wait-until
-                     (lambda ()
-                       (let ((proc (and (buffer-live-p chat-buf)
-                                        (with-current-buffer chat-buf
-                                          pi-coding-agent--process))))
-                         (unless (and (processp proc) (process-live-p proc))
-                           (error "Fake pi process exited before the storm settled"))
-                         (and pi-coding-agent-tu-bench--agent-end-time
-                              (= 0 (pi-coding-agent-tu-bench--pending-requests-count
+                 (if cooling
+                     "run the synthetic deferred agent-end cooling cohort"
+                   "run the synthetic tool update storm")))
+              (if cooling
+                  (progn
+                    ;; Suppress the legacy benchmark's explicit redisplay while
+                    ;; receiving the final event.  The drain below uses ordinary
+                    ;; read-event opportunities and production timers only.
+                    (unless
+                        (let ((pi-coding-agent-tu-bench-display-buffers nil))
+                          (pi-coding-agent-tu-bench--wait-until
+                           (lambda ()
+                             (let ((proc
+                                    (and (buffer-live-p chat-buf)
+                                         (with-current-buffer chat-buf
+                                           pi-coding-agent--process))))
+                               (unless (and (processp proc)
+                                            (process-live-p proc))
+                                 (error
+                                  "Fake pi exited before agent_end cooling"))
+                               pi-coding-agent-tu-bench--agent-end-time))
+                           pi-coding-agent-tu-bench-timeout-seconds))
+                      (error "Timed out waiting for cooling agent_end after %d seconds"
+                             pi-coding-agent-tu-bench-timeout-seconds))
+                    (setq drain
+                          (pi-coding-agent-tu-bench--wait-for-natural-cooling
+                           chat-buf pi-coding-agent-tu-bench-timeout-seconds))
+                    (let ((proc (with-current-buffer chat-buf
+                                  pi-coding-agent--process)))
+                      (setq ok
+                            (and (eq (plist-get drain :settled) t)
+                                 (= 0
+                                    (pi-coding-agent-tu-bench--pending-requests-count
+                                     proc)))))
+                    (unless ok
+                      (error "Cooling drain did not settle cleanly within %d seconds"
+                             pi-coding-agent-tu-bench-timeout-seconds)))
+                (setq ok
+                      (pi-coding-agent-tu-bench--wait-until
+                       (lambda ()
+                         (let ((proc (and (buffer-live-p chat-buf)
+                                          (with-current-buffer chat-buf
+                                            pi-coding-agent--process))))
+                           (unless (and (processp proc) (process-live-p proc))
+                             (error
+                              "Fake pi process exited before the storm settled"))
+                           (and pi-coding-agent-tu-bench--agent-end-time
+                                (= 0
+                                   (pi-coding-agent-tu-bench--pending-requests-count
                                     proc)))))
-                     pi-coding-agent-tu-bench-timeout-seconds))
-              (unless ok
-                (error "Timed out waiting for agent_end after %d seconds"
-                       pi-coding-agent-tu-bench-timeout-seconds)))
+                       pi-coding-agent-tu-bench-timeout-seconds))
+                (unless ok
+                  (error "Timed out waiting for agent_end after %d seconds"
+                         pi-coding-agent-tu-bench-timeout-seconds))))
           (error (setq error-text (error-message-string err))))
-      (pi-coding-agent-tu-bench--stop-probe))
-    (prog1
-        (list :ok (pi-coding-agent-tu-bench--json-bool ok)
-              :error error-text
-              :wallMs (when pi-coding-agent-tu-bench--agent-end-time
-                        (* 1000.0 (- pi-coding-agent-tu-bench--agent-end-time
-                                     pi-coding-agent-tu-bench--prompt-time)))
-              :seconds (and start (- (float-time) start))
-              :gcs (and gc-before (- gcs-done gc-before))
-              :gcSeconds (and gc-time-before (- gc-elapsed gc-time-before))
-              :bufferBytes (and (buffer-live-p chat-buf)
-                                (with-current-buffer chat-buf (buffer-size)))
-              :bufferLines (and (buffer-live-p chat-buf)
-                                (with-current-buffer chat-buf
-                                  (count-lines (point-min) (point-max))))
-              :overlays (and (buffer-live-p chat-buf)
-                             (with-current-buffer chat-buf
-                               (length (overlays-in (point-min) (point-max)))))
-              :checks (pi-coding-agent-tu-bench--collect-checks chat-buf))
-      (pi-coding-agent-tu-bench--cleanup-session chat-buf))))
+      (pi-coding-agent-tu-bench--stop-command-route)
+      (pi-coding-agent-tu-bench--stop-probe)
+      ;; The synthetic cwd is not an advertised artifact.  Delete it in this
+      ;; unwind path even when event handling quits or errors.
+      (pi-coding-agent-tu-bench--cleanup-session-directory session-dir))
+    (when cooling
+      (when (and ok (buffer-live-p chat-buf))
+        (setq parser-state
+              (pi-coding-agent-tu-bench--parser-font-lock-state chat-buf)
+              final-state
+              (pi-coding-agent-tu-bench--cooling-final-state
+               chat-buf parser-state)))
+      (unless parser-state
+        (setq parser-state
+              (list :parserOk :json-false
+                    :fontLockOk :json-false
+                    :error (or error-text "cooling did not settle"))))
+      (unless final-state
+        (setq final-state
+              (pi-coding-agent-tu-bench--cooling-final-state
+               chat-buf parser-state))))
+    (unwind-protect
+        (let ((checks
+               (if cooling
+                   (pi-coding-agent-tu-bench--collect-cooling-checks
+                    chat-buf drain final-state)
+                 (pi-coding-agent-tu-bench--collect-checks chat-buf))))
+          (list :settled (pi-coding-agent-tu-bench--json-bool ok)
+                :error error-text
+                :wallMs (when pi-coding-agent-tu-bench--agent-end-time
+                          (* 1000.0
+                             (- pi-coding-agent-tu-bench--agent-end-time
+                                pi-coding-agent-tu-bench--prompt-time)))
+                :seconds (and start (- (float-time) start))
+                :gcs (and gc-before (- gcs-done gc-before))
+                :gcSeconds
+                (and gc-time-before (- gc-elapsed gc-time-before))
+                :bufferBytes
+                (and (buffer-live-p chat-buf)
+                     (with-current-buffer chat-buf (buffer-size)))
+                :bufferLines
+                (and (buffer-live-p chat-buf)
+                     (with-current-buffer chat-buf
+                       (count-lines (point-min) (point-max))))
+                :overlays
+                (and (buffer-live-p chat-buf)
+                     (with-current-buffer chat-buf
+                       (length (overlays-in (point-min) (point-max)))))
+                :drain drain
+                :final final-state
+                :checks checks))
+      (pi-coding-agent-tu-bench--cleanup-session chat-buf session-dir))))
 
 (defun pi-coding-agent-tu-bench--git-string (&rest args)
   "Run git with ARGS in the repository root and return trimmed output."
@@ -640,7 +1911,14 @@ waits for agent_end, then collects buffer metrics and correctness checks."
         :updates pi-coding-agent-tu-bench-updates
         :parallelTools pi-coding-agent-tu-bench-parallel-tools
         :gapScale pi-coding-agent-tu-bench-gap-scale
-        :seed pi-coding-agent-tu-bench-seed))
+        :seed pi-coding-agent-tu-bench-seed
+        :hotTailTurns pi-coding-agent-tu-bench-hot-tail-turns
+        :commandIntervalMs
+        (* 1000.0 pi-coding-agent-tu-bench-command-interval)
+        :expectedCoolingCohort
+        (if (pi-coding-agent-tu-bench--cooling-scenario-p)
+            (pi-coding-agent-tu-bench--fill-tool-count)
+          0)))
 
 (defun pi-coding-agent-tu-bench--write-times-tsv ()
   "Write event timing and render rows to `pi-coding-agent-tu-bench-times-file'."
@@ -662,6 +1940,61 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                       (plist-get row :meanMs)
                       (plist-get row :maxMs))))))
 
+(defun pi-coding-agent-tu-bench--write-cooling-tsv ()
+  "Write detailed cooling callback and command TSV artifacts."
+  (when (pi-coding-agent-tu-bench--cooling-scenario-p)
+    (with-temp-file pi-coding-agent-tu-bench-cooling-slices-file
+      (insert (concat
+               "index\tqueue_before\tqueue_after\tqueue_delta\t"
+               "candidate_id\teligible\toverlay_alive_after\twall_ms\t"
+               "tree_root_count\ttree_root_ms\tgcs\tgc_ms\ttimer_after\t"
+               "window_route\twindow_ok\n"))
+      (dolist (row (pi-coding-agent-tu-bench--cooling-slices-in-order))
+        (let ((tree (plist-get row :treeRoots))
+              (window (plist-get row :window)))
+          (insert
+           (format "%d\t%d\t%d\t%d\t%s\t%s\t%s\t%.3f\t%d\t%.3f\t%d\t%.3f\t%s\t%s\t%s\n"
+                   (plist-get row :index)
+                   (plist-get row :queueBefore)
+                   (plist-get row :queueAfter)
+                   (plist-get row :queueDelta)
+                   (plist-get row :candidateId)
+                   (if (eq (plist-get row :candidateEligible) t) 1 0)
+                   (if (eq (plist-get row :candidateOverlayAliveAfter) t) 1 0)
+                   (plist-get row :wallMs)
+                   (plist-get tree :count)
+                   (plist-get tree :totalMs)
+                   (plist-get row :gcs)
+                   (plist-get row :gcMs)
+                   (if (eq (plist-get row :timerAfter) t) 1 0)
+                   (plist-get window :expectedRoute)
+                   (if (eq (plist-get window :viewOk) t) 1 0))))))
+    (with-temp-file pi-coding-agent-tu-bench-commands-file
+      (insert (concat
+               "sequence\troute\tdue_at\tenqueued_at\tstarted_at\tended_at\t"
+               "lateness_ms\tqueue_delay_ms\tduration_ms\tpre_hook\tpost_hook\t"
+               "window_route\twindow_ok\terror\n"))
+      (dolist (row (pi-coding-agent-tu-bench--commands-in-order))
+        (let ((window (plist-get row :window)))
+          (insert
+           (format "%d\t%s\t%.6f\t%.6f\t%.6f\t%.6f\t%.3f\t%.3f\t%.3f\t%s\t%s\t%s\t%s\t%s\n"
+                   (plist-get row :sequence)
+                   (plist-get row :route)
+                   (plist-get row :dueAt)
+                   (plist-get row :enqueuedAt)
+                   (plist-get row :startedAt)
+                   (plist-get row :endedAt)
+                   (plist-get row :latenessMs)
+                   (plist-get row :queueDelayMs)
+                   (plist-get row :durationMs)
+                   (if (eq (plist-get row :preHook) t) 1 0)
+                   (if (eq (plist-get row :postHook) t) 1 0)
+                   (plist-get window :expectedRoute)
+                   (if (eq (plist-get window :viewOk) t) 1 0)
+                   (if (eq (plist-get row :error) :json-null)
+                       ""
+                     (plist-get row :error)))))))))
+
 (defun pi-coding-agent-tu-bench--checks-json (entries)
   "Encode correctness check ENTRIES as a JSON vector."
   (vconcat
@@ -677,6 +2010,10 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                       (pi-coding-agent-tu-bench--git-string
                        "status" "--porcelain" "--untracked-files=no"))))
          (probe (pi-coding-agent-tu-bench--probe-stats))
+         (cooling (pi-coding-agent-tu-bench--cooling-scenario-p))
+         (filters (nreverse
+                   (copy-sequence pi-coding-agent-tu-bench--filter-log)))
+         (command-stats (pi-coding-agent-tu-bench--command-stats))
          (object
           (list :scenario pi-coding-agent-tu-bench-scenario
                 :iteration pi-coding-agent-tu-bench-iteration
@@ -690,7 +2027,14 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                 (pi-coding-agent-tu-bench--json-bool
                  (treesit-language-available-p 'markdown))
                 :workload (pi-coding-agent-tu-bench--workload-json)
+                :timingGuidance
+                (list :policy "diagnostic-only"
+                      :targetUnderMs 100
+                      :concernOverMs 250
+                      :severeOverMs 1000
+                      :hardFailure :json-false)
                 :ok (plist-get metrics :ok)
+                :settled (plist-get metrics :settled)
                 :error (or (plist-get metrics :error) :json-null)
                 :wallMs (or (plist-get metrics :wallMs) :json-null)
                 :seconds (plist-get metrics :seconds)
@@ -699,6 +2043,21 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                 :bufferBytes (plist-get metrics :bufferBytes)
                 :bufferLines (plist-get metrics :bufferLines)
                 :overlays (plist-get metrics :overlays)
+                :agentEnd
+                (or pi-coding-agent-tu-bench--agent-end-observation
+                    :json-null)
+                :processFilters
+                (list :count (length filters)
+                      :maxMs
+                      (if filters
+                          (apply #'max
+                                 (mapcar (lambda (row)
+                                           (plist-get row :wallMs))
+                                         filters))
+                        0.0)
+                      :agentEnd
+                      (or pi-coding-agent-tu-bench--agent-end-filter
+                          :json-null))
                 :eventStats
                 (vconcat
                  (mapcar (lambda (row)
@@ -727,6 +2086,32 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                                :displayToolEnd
                                (pi-coding-agent-tu-bench--render-operation-json
                                 "display-tool-end"))
+                :cooling
+                (if cooling
+                    (list
+                     :drain (or (plist-get metrics :drain) :json-null)
+                     :slices
+                     (vconcat
+                      (pi-coding-agent-tu-bench--cooling-slices-in-order))
+                     :commands
+                     (list :stats command-stats
+                           :rows
+                           (vconcat
+                            (pi-coding-agent-tu-bench--commands-in-order)))
+                     :treeRoots
+                     (pi-coding-agent-tu-bench--tree-root-summary)
+                     :schedulerErrors
+                     (vconcat
+                      (nreverse
+                       (copy-sequence
+                        pi-coding-agent-tu-bench--scheduler-errors)))
+                     :final (plist-get metrics :final)
+                     :artifacts
+                     (list :slicesTsv
+                           pi-coding-agent-tu-bench-cooling-slices-file
+                           :commandsTsv
+                           pi-coding-agent-tu-bench-commands-file))
+                  :json-null)
                 :checks (pi-coding-agent-tu-bench--checks-json
                          (plist-get metrics :checks)))))
     (with-temp-file pi-coding-agent-tu-bench-result-file
@@ -737,11 +2122,17 @@ waits for agent_end, then collects buffer metrics and correctness checks."
   (let ((dirty (not (string-empty-p
                      (pi-coding-agent-tu-bench--git-string
                       "status" "--porcelain" "--untracked-files=no"))))
-        (probe (pi-coding-agent-tu-bench--probe-stats)))
+        (probe (pi-coding-agent-tu-bench--probe-stats))
+        (cooling (pi-coding-agent-tu-bench--cooling-scenario-p)))
     (with-temp-file pi-coding-agent-tu-bench-report-file
-      (insert "# Tool-update storm benchmark\n\n")
+      (insert (if cooling
+                  "# Deferred agent_end cooling benchmark\n\n"
+                "# Tool-update storm benchmark\n\n"))
       (insert "Synthetic deterministic workload only; no private session content is read or stored.\n\n")
-      (insert (format "- Verdict: `%s`\n" (if run-ok "pass" "FAIL")))
+      (insert (format "- Verdict: `%s`\n"
+                      (pi-coding-agent-tu-bench--verdict-label run-ok)))
+      (insert (format "- Session/drain settled: `%s`\n"
+                      (if (eq (plist-get metrics :settled) t) "yes" "no")))
       (insert (format "- Scenario: `%s`\n" pi-coding-agent-tu-bench-scenario))
       (insert (format "- Iteration: `%d`\n" pi-coding-agent-tu-bench-iteration))
       (insert (format "- Commit: `%s`%s\n"
@@ -770,11 +2161,17 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                       pi-coding-agent-tu-bench-fill-write
                       pi-coding-agent-tu-bench-fill-edit
                       pi-coding-agent-tu-bench-fill-output-lines))
-      (insert (format "- Storm: `%d` updates across `%d` parallel subagent tools, gap scale `%.2f`, seed `%d`\n\n"
-                      pi-coding-agent-tu-bench-updates
-                      pi-coding-agent-tu-bench-parallel-tools
-                      pi-coding-agent-tu-bench-gap-scale
-                      pi-coding-agent-tu-bench-seed))
+      (if cooling
+          (insert (format "- Cooling: `%d` completed overlays cross at final agent_end; `%d` hot-tail turn; command interval `%.0f` ms\n\n"
+                          (pi-coding-agent-tu-bench--fill-tool-count)
+                          pi-coding-agent-tu-bench-hot-tail-turns
+                          (* 1000.0
+                             pi-coding-agent-tu-bench-command-interval)))
+        (insert (format "- Storm: `%d` updates across `%d` parallel subagent tools, gap scale `%.2f`, seed `%d`\n\n"
+                        pi-coding-agent-tu-bench-updates
+                        pi-coding-agent-tu-bench-parallel-tools
+                        pi-coding-agent-tu-bench-gap-scale
+                        pi-coding-agent-tu-bench-seed)))
       (insert "## Wall-clock and buffer metrics\n\n")
       (insert (format "- Prompt to agent_end: `%s` ms\n"
                       (if-let* ((wall (plist-get metrics :wallMs)))
@@ -788,6 +2185,59 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                       (or (plist-get metrics :bufferBytes) "n/a")
                       (or (plist-get metrics :bufferLines) "n/a")
                       (or (plist-get metrics :overlays) "n/a")))
+      (insert "Timing guidance is diagnostic only: `<100 ms` target, `>250 ms` concern, `>1 s` severe.  No timing threshold fails the run.\n\n")
+      (when cooling
+        (insert "## Measurement-fidelity caveat\n\n")
+        (insert "This runner uses `-Q`.  Slice and tree-root timings are structural diagnostics, and zero root calls is valid.  Do not cite this benchmark as evidence that md-ts root cost was reduced; an exact normal-init GUI replay is the performance-fidelity evidence.\n\n")
+        (let* ((agent-end pi-coding-agent-tu-bench--agent-end-observation)
+               (filter pi-coding-agent-tu-bench--agent-end-filter)
+               (drain (plist-get metrics :drain))
+               (final (plist-get metrics :final))
+               (commands (pi-coding-agent-tu-bench--command-stats))
+               (slices (pi-coding-agent-tu-bench--cooling-slices-in-order))
+               (slice-max (if slices
+                              (apply #'max
+                                     (mapcar (lambda (row)
+                                               (plist-get row :wallMs))
+                                             slices))
+                            0.0))
+               (tree (pi-coding-agent-tu-bench--tree-root-summary)))
+          (insert "## Deferred cooling metrics\n\n")
+          (insert (format "- agent_end event: `%.3f` ms; enclosing filter: `%s` ms\n"
+                          (or (plist-get agent-end :wallMs) 0.0)
+                          (if filter
+                              (format "%.3f" (plist-get filter :wallMs))
+                            "n/a")))
+          (insert (format "- Return state: queue `%s`, timer `%s`, cold `%s`; boundary `%s` → `%s`\n"
+                          (plist-get agent-end :queueAfter)
+                          (plist-get agent-end :timerAfter)
+                          (plist-get agent-end :coldAfter)
+                          (plist-get agent-end :boundaryBefore)
+                          (plist-get agent-end :boundaryAfter)))
+          (insert (format "- Natural drain: `%.3f` ms wall, `%.3f` ms callback-active, `%d` callbacks, max slice `%.3f` ms\n"
+                          (or (plist-get drain :wallMs) 0.0)
+                          (or (plist-get drain :activeMs) 0.0)
+                          (length slices) slice-max))
+          (insert (format "- Drain GC: `%s` collections, `%.3f` ms; final cold/hot: `%s`/`%s`\n"
+                          (plist-get drain :gcs)
+                          (or (plist-get drain :gcMs) 0.0)
+                          (plist-get final :coldTools)
+                          (plist-get final :toolOverlays)))
+          (insert (format "- Commands: `%d` (`%d` sentinel / `%d` follow); lateness p95/max `%.3f`/`%.3f` ms; duration p95/max `%.3f`/`%.3f` ms\n"
+                          (plist-get commands :count)
+                          (plist-get commands :sentinelRoutes)
+                          (plist-get commands :followRoutes)
+                          (plist-get commands :latenessP95Ms)
+                          (plist-get commands :latenessMaxMs)
+                          (plist-get commands :durationP95Ms)
+                          (plist-get commands :durationMaxMs)))
+          (insert (format "- Tree roots: agent_end `%s` calls / `%.3f` ms; slices `%s` calls / `%.3f` ms\n"
+                          (plist-get (plist-get tree :agentEnd) :count)
+                          (plist-get (plist-get tree :agentEnd) :totalMs)
+                          (plist-get (plist-get tree :coolingSlices) :count)
+                          (plist-get (plist-get tree :coolingSlices) :totalMs)))
+          (insert (format "- Semantic SHA-256: `%s`\n\n"
+                          (plist-get final :semanticHash)))))
       (insert "## Probe timer (main-thread blocking)\n\n")
       (insert (format "- Interval: `%.0f` ms; fires: `%d`\n"
                       (plist-get probe :intervalMs) (plist-get probe :fires)))
@@ -809,8 +2259,10 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                         (plist-get row :meanMs)
                         (plist-get row :maxMs))))
       (insert "\n## Tool block render counts\n\n")
-      (insert "Environment-independent coalescing metric: how often the frontend re-renders tool block bodies.  ")
-      (insert "The WP2 coalescing renderer should drop `replace-body` calls towards (storm seconds / 0.25) x parallel tools.\n\n")
+      (insert "Environment-independent metric: how often the frontend re-renders tool block bodies.  ")
+      (unless cooling
+        (insert "The WP2 coalescing renderer should drop `replace-body` calls towards (storm seconds / 0.25) x parallel tools."))
+      (insert "\n\n")
       (insert "| operation | total calls | total ms | mean ms | max ms |\n")
       (insert "|---|---:|---:|---:|---:|\n")
       (dolist (operation '("replace-body" "display-tool-end"))
@@ -829,16 +2281,17 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                                  (plist-get aggregate :total))
                             0.0)
                           (plist-get aggregate :maxMs)))))
-      (insert "\nPer storm tool call ID:\n\n")
-      (insert "| tool call id | replace-body calls | display-tool-end calls |\n")
-      (insert "|---|---:|---:|\n")
-      (dolist (tool-call-id (pi-coding-agent-tu-bench--storm-tool-ids))
-        (insert (format "| `%s` | %d | %d |\n"
-                        tool-call-id
-                        (pi-coding-agent-tu-bench--render-count
-                         "replace-body" tool-call-id)
-                        (pi-coding-agent-tu-bench--render-count
-                         "display-tool-end" tool-call-id))))
+      (unless cooling
+        (insert "\nPer storm tool call ID:\n\n")
+        (insert "| tool call id | replace-body calls | display-tool-end calls |\n")
+        (insert "|---|---:|---:|\n")
+        (dolist (tool-call-id (pi-coding-agent-tu-bench--storm-tool-ids))
+          (insert (format "| `%s` | %d | %d |\n"
+                          tool-call-id
+                          (pi-coding-agent-tu-bench--render-count
+                           "replace-body" tool-call-id)
+                          (pi-coding-agent-tu-bench--render-count
+                           "display-tool-end" tool-call-id)))))
       (insert "\nThe full per-tool-call-id breakdown (including fill phase ids) is in `result.json` and `times.tsv`.\n")
       (insert "\n## Correctness checks\n\n")
       (insert "| check | ok | detail |\n")
@@ -853,20 +2306,61 @@ waits for agent_end, then collects buffer metrics and correctness checks."
                       pi-coding-agent-tu-bench-result-file))
       (insert (format "- Timing TSV: `%s`\n"
                       pi-coding-agent-tu-bench-times-file))
+      (when cooling
+        (insert (format "- Cooling slices TSV: `%s`\n"
+                        pi-coding-agent-tu-bench-cooling-slices-file))
+        (insert (format "- Command route TSV: `%s`\n"
+                        pi-coding-agent-tu-bench-commands-file)))
       (insert (format "- Fake RPC log without content: `%s`\n"
                       pi-coding-agent-tu-bench-fake-log)))))
 
 (defun pi-coding-agent-tu-bench--metrics-ok-p (metrics)
-  "Return non-nil when METRICS report a settled run with every check green."
-  (and (eq (plist-get metrics :ok) t)
+  "Return non-nil when METRICS settled with every structural check green."
+  (and (eq (plist-get metrics :settled) t)
        (seq-every-p (lambda (check) (eq (plist-get check :ok) t))
                     (plist-get metrics :checks))))
+
+(defun pi-coding-agent-tu-bench--metrics-with-verdict (metrics)
+  "Return METRICS with :ok set from its complete structural verdict."
+  (plist-put metrics :ok
+             (pi-coding-agent-tu-bench--json-bool
+              (pi-coding-agent-tu-bench--metrics-ok-p metrics))))
+
+(defun pi-coding-agent-tu-bench--verdict-label (run-ok)
+  "Return the report verdict label for RUN-OK."
+  (if run-ok "pass" "FAIL"))
+
+(defun pi-coding-agent-tu-bench--exit-status (run-ok)
+  "Return the benchmark process exit status for RUN-OK."
+  (if run-ok 0 1))
+
+(defun pi-coding-agent-tu-bench--validate-verdict-contract ()
+  "Smoke-check failed assertions across JSON, report, and exit verdicts.
+This intentionally uses an in-memory failed check rather than a fault-injected
+benchmark scenario.  It prevents settled-only JSON success from regressing."
+  (let* ((metrics
+          (pi-coding-agent-tu-bench--metrics-with-verdict
+           (list :settled t
+                 :checks
+                 (list (list :name "synthetic-failed-cooling-check"
+                             :ok :json-false)))))
+         (run-ok (eq (plist-get metrics :ok) t))
+         (encoded (json-encode
+                   (list :ok (plist-get metrics :ok)
+                         :settled (plist-get metrics :settled)))))
+    (unless (and (eq (plist-get metrics :ok) :json-false)
+                 (string-match-p "\\\"ok\\\":false" encoded)
+                 (equal (pi-coding-agent-tu-bench--verdict-label run-ok)
+                        "FAIL")
+                 (= (pi-coding-agent-tu-bench--exit-status run-ok) 1))
+      (error "Benchmark verdict contract self-check failed: %s" encoded))))
 
 ;;;###autoload
 (defun pi-coding-agent-tu-bench-run ()
   "Run one tool-update benchmark iteration and write artifacts.
-Return non-nil when the storm settled and all correctness checks passed.
-Timing thresholds are not enforced."
+Return non-nil when the scenario settled and all correctness checks passed.
+Timing thresholds are diagnostic only and are never enforced."
+  (pi-coding-agent-tu-bench--validate-verdict-contract)
   (when (and pi-coding-agent-tu-bench-display-buffers
              (not noninteractive)
              (not (display-graphic-p)))
@@ -878,16 +2372,42 @@ Timing thresholds are not enforced."
         pi-coding-agent-tu-bench--agent-end-time nil
         pi-coding-agent-tu-bench--probe-expected nil
         pi-coding-agent-tu-bench--probe-lateness nil
-        pi-coding-agent-tu-bench--render-log (make-hash-table :test 'equal))
+        pi-coding-agent-tu-bench--render-log (make-hash-table :test 'equal)
+        pi-coding-agent-tu-bench--current-filter-id nil
+        pi-coding-agent-tu-bench--filter-sequence 0
+        pi-coding-agent-tu-bench--filter-log nil
+        pi-coding-agent-tu-bench--agent-end-observation nil
+        pi-coding-agent-tu-bench--agent-end-filter nil
+        pi-coding-agent-tu-bench--drain-start-time nil
+        pi-coding-agent-tu-bench--cooling-slice-log nil
+        pi-coding-agent-tu-bench--cooling-slice-sequence 0
+        pi-coding-agent-tu-bench--scheduler-errors nil
+        pi-coding-agent-tu-bench--cooling-chat-buffer nil
+        pi-coding-agent-tu-bench--command-timer nil
+        pi-coding-agent-tu-bench--command-pending nil
+        pi-coding-agent-tu-bench--command-log nil
+        pi-coding-agent-tu-bench--command-sequence 0
+        pi-coding-agent-tu-bench--command-current-job nil
+        pi-coding-agent-tu-bench--command-drain-active nil
+        pi-coding-agent-tu-bench--command-last-route "follow"
+        pi-coding-agent-tu-bench--window-sentinel-marker nil)
   (pi-coding-agent-tu-bench--install-advice)
   (unwind-protect
-      (let* ((metrics (pi-coding-agent-tu-bench--run-session))
-             (run-ok (pi-coding-agent-tu-bench--metrics-ok-p metrics)))
+      (let* ((metrics
+              (pi-coding-agent-tu-bench--metrics-with-verdict
+               (pi-coding-agent-tu-bench--run-session)))
+             (run-ok (eq (plist-get metrics :ok) t)))
         (pi-coding-agent-tu-bench--write-times-tsv)
+        (pi-coding-agent-tu-bench--write-cooling-tsv)
         (pi-coding-agent-tu-bench--write-result-json metrics)
         (pi-coding-agent-tu-bench--write-report metrics run-ok)
         (princ (format "Wrote %s\n" pi-coding-agent-tu-bench-result-file))
         (princ (format "Wrote %s\n" pi-coding-agent-tu-bench-times-file))
+        (when (pi-coding-agent-tu-bench--cooling-scenario-p)
+          (princ (format "Wrote %s\n"
+                         pi-coding-agent-tu-bench-cooling-slices-file))
+          (princ (format "Wrote %s\n"
+                         pi-coding-agent-tu-bench-commands-file)))
         (princ (format "Wrote %s\n" pi-coding-agent-tu-bench-report-file))
         run-ok)
     (pi-coding-agent-tu-bench--remove-advice)))
@@ -895,7 +2415,9 @@ Timing thresholds are not enforced."
 (defun pi-coding-agent-tu-bench-run-batch ()
   "Run one tool-update benchmark iteration in batch mode and exit."
   (let ((standard-output #'external-debugging-output))
-    (kill-emacs (if (pi-coding-agent-tu-bench-run) 0 1))))
+    (kill-emacs
+     (pi-coding-agent-tu-bench--exit-status
+      (pi-coding-agent-tu-bench-run)))))
 
 (provide 'pi-coding-agent-tool-update-bench)
 ;;; pi-coding-agent-tool-update-bench.el ends here

--- a/bench/run-tool-update-bench.sh
+++ b/bench/run-tool-update-bench.sh
@@ -10,6 +10,10 @@
 #   ./bench/run-tool-update-bench.sh --scenarios storm,smoke # comma-separated scenarios
 #   ./bench/run-tool-update-bench.sh --out-dir tmp/tu-bench  # write artifacts elsewhere
 #
+# Default out-dir: tmp/tool-update-bench, or tmp/agent-end-cooling-bench/<lane>
+# (gui|batch) when every selected scenario starts with agent-end-cooling;
+# relative --out-dir paths anchor at the project root.
+#
 # The primary lane uses xvfb-run for GUI Emacs: the measured cost is buffer
 # mutation plus redisplay/fontification, which batch mode cannot reproduce.
 # Batch numbers are a faster secondary lane and CI artifact generator.
@@ -22,11 +26,11 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 BATCH=0
 REPS=3
-OUT_DIR="$PROJECT_DIR/tmp/tool-update-bench"
+OUT_DIR=""
 SCENARIOS=()
 
 usage() {
-    sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+    awk 'NR > 1 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
 }
 
 require_arg() {
@@ -75,9 +79,25 @@ if [[ ${#SCENARIOS[@]} -eq 0 ]]; then
     SCENARIOS=(storm)
 fi
 
+if [[ -z "$OUT_DIR" ]]; then
+    all_cooling=1
+    for scenario in "${SCENARIOS[@]}"; do
+        if [[ "$scenario" != agent-end-cooling* ]]; then
+            all_cooling=0
+            break
+        fi
+    done
+    if [[ "$all_cooling" = 1 ]]; then
+        if [[ "$BATCH" = "1" ]]; then lane="batch"; else lane="gui"; fi
+        OUT_DIR="$PROJECT_DIR/tmp/agent-end-cooling-bench/$lane"
+    else
+        OUT_DIR="$PROJECT_DIR/tmp/tool-update-bench"
+    fi
+fi
+
 case "$OUT_DIR" in
     /*) ;;
-    *) OUT_DIR="$PWD/$OUT_DIR" ;;
+    *) OUT_DIR="$PROJECT_DIR/$OUT_DIR" ;;
 esac
 while [[ "$OUT_DIR" != "/" && "$OUT_DIR" == */ ]]; do
     OUT_DIR="${OUT_DIR%/}"
@@ -398,8 +418,11 @@ if cooling_rows:
             print(f"{scenario:<24} no successful runs")
             summary_lines.append(f"| {scenario} | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0/{len(subset_all)} |")
             continue
-        median = lambda key: statistics.median(float(row[key]) for row in subset)
-        maximum = lambda key: max(float(row[key]) for row in subset)
+        def median(key: str) -> float:
+            return statistics.median(float(row[key]) for row in subset)
+
+        def maximum(key: str) -> float:
+            return max(float(row[key]) for row in subset)
         callbacks = int(maximum("drainCallbacks"))
         gcs = int(maximum("drainGcs"))
         cold = int(maximum("coldTools"))

--- a/bench/run-tool-update-bench.sh
+++ b/bench/run-tool-update-bench.sh
@@ -6,6 +6,7 @@
 #   ./bench/run-tool-update-bench.sh --batch                 # batch mode (secondary lane)
 #   ./bench/run-tool-update-bench.sh -c 3                    # 3 repetitions per scenario
 #   ./bench/run-tool-update-bench.sh --scenario smoke -c 1   # cheap correctness smoke
+#   ./bench/run-tool-update-bench.sh --scenario agent-end-cooling -c 1
 #   ./bench/run-tool-update-bench.sh --scenarios storm,smoke # comma-separated scenarios
 #   ./bench/run-tool-update-bench.sh --out-dir tmp/tu-bench  # write artifacts elsewhere
 #
@@ -130,6 +131,38 @@ PI_TU_BENCH_SEED=20240817
 PI_TU_BENCH_TIMEOUT_SECONDS=240
 EOF
             ;;
+        agent-end-cooling-smoke)
+            cat <<'EOF'
+PI_TU_BENCH_FILL_BASH=6
+PI_TU_BENCH_FILL_READ=2
+PI_TU_BENCH_FILL_WRITE=1
+PI_TU_BENCH_FILL_EDIT=1
+PI_TU_BENCH_FILL_OUTPUT_LINES=12
+PI_TU_BENCH_UPDATES=0
+PI_TU_BENCH_PARALLEL_TOOLS=0
+PI_TU_BENCH_GAP_SCALE=0.0
+PI_TU_BENCH_SEED=20240817
+PI_TU_BENCH_HOT_TAIL_TURNS=1
+PI_TU_BENCH_COMMAND_INTERVAL_MS=100
+PI_TU_BENCH_TIMEOUT_SECONDS=30
+EOF
+            ;;
+        agent-end-cooling)
+            cat <<'EOF'
+PI_TU_BENCH_FILL_BASH=72
+PI_TU_BENCH_FILL_READ=10
+PI_TU_BENCH_FILL_WRITE=4
+PI_TU_BENCH_FILL_EDIT=4
+PI_TU_BENCH_FILL_OUTPUT_LINES=18
+PI_TU_BENCH_UPDATES=0
+PI_TU_BENCH_PARALLEL_TOOLS=0
+PI_TU_BENCH_GAP_SCALE=0.0
+PI_TU_BENCH_SEED=20240817
+PI_TU_BENCH_HOT_TAIL_TURNS=1
+PI_TU_BENCH_COMMAND_INTERVAL_MS=100
+PI_TU_BENCH_TIMEOUT_SECONDS=90
+EOF
+            ;;
         *) echo "Unknown scenario: $1" >&2; exit 1 ;;
     esac
 }
@@ -138,16 +171,17 @@ for scenario in "${SCENARIOS[@]}"; do
     scenario_env "$scenario" >/dev/null
 done
 
+export PI_TU_BENCH_PROJECT_DIR="$PROJECT_DIR"
 EMACS_INIT=(
     -Q -L "$PROJECT_DIR"
-    --eval "(setq inhibit-startup-screen t)"
-    --eval "(require 'package)"
-    --eval "(package-initialize)"
-    --eval "(setq load-path (cons (expand-file-name \"$PROJECT_DIR\") load-path))"
+    --eval '(setq inhibit-startup-screen t)'
+    --eval '(require (quote package))'
+    --eval '(package-initialize)'
+    --eval '(let ((project (getenv "PI_TU_BENCH_PROJECT_DIR"))) (unless project (error "PI_TU_BENCH_PROJECT_DIR is unset")) (setq load-path (cons (expand-file-name project) load-path)))'
     -l "$SCRIPT_DIR/pi-coding-agent-tool-update-bench.el"
 )
 
-printf '=== pi-coding-agent Tool-Update Storm Benchmarks ===\n'
+printf '=== pi-coding-agent Tool-Update Benchmarks ===\n'
 printf 'Project: %s\n' "$PROJECT_DIR"
 if [[ "$BATCH" = "1" ]]; then
     MODE="batch"
@@ -194,7 +228,7 @@ for scenario in "${SCENARIOS[@]}"; do
         else
             if ! xvfb-run -a env GDK_BACKEND=x11 PATH="$PATH" \
                 emacs --geometry 120x40 "${EMACS_INIT[@]}" \
-                --eval "(let ((standard-output #'external-debugging-output)) (kill-emacs (if (pi-coding-agent-tu-bench-run) 0 1)))" \
+                --eval '(let ((standard-output (function external-debugging-output))) (kill-emacs (pi-coding-agent-tu-bench--exit-status (pi-coding-agent-tu-bench-run))))' \
                 </dev/null > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
                 cat "$run_dir/stdout.log"
                 cat "$run_dir/stderr.log" >&2
@@ -220,11 +254,26 @@ reps = sys.argv[3]
 scenarios_arg = sys.argv[4]
 rows: list[dict[str, Any]] = []
 
+
+def as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 for result_path in sorted(out.glob("*/iter-*/result.json")):
     with result_path.open(encoding="utf-8") as handle:
         result = json.load(handle)
-    probe = result.get("probe", {})
-    renders = result.get("renders", {})
+    probe = as_dict(result.get("probe"))
+    renders = as_dict(result.get("renders"))
+    cooling = as_dict(result.get("cooling"))
+    drain = as_dict(cooling.get("drain"))
+    final = as_dict(cooling.get("final"))
+    command_stats = as_dict(as_dict(cooling.get("commands")).get("stats"))
+    slices_value = cooling.get("slices")
+    slices = slices_value if isinstance(slices_value, list) else []
+    agent_end = as_dict(result.get("agentEnd"))
+    agent_end_filter = as_dict(
+        as_dict(result.get("processFilters")).get("agentEnd")
+    )
     update_stats = next(
         (row for row in result.get("eventStats", [])
          if row.get("type") == "tool_execution_update"),
@@ -235,19 +284,36 @@ for result_path in sorted(out.glob("*/iter-*/result.json")):
         for check in result.get("checks", [])
         if check.get("ok") is not True
     ]
+    derived_ok = result.get("settled") is True and not failed_checks
+    if result.get("ok") is not derived_ok:
+        failed_checks.append("result-ok-verdict-mismatch")
     rows.append({
         "scenario": result.get("scenario"),
         "iteration": result.get("iteration"),
-        "ok": result.get("ok") is True and not failed_checks,
-        "wallMs": result.get("wallMs"),
-        "updateMeanMs": update_stats.get("meanMs"),
-        "updateMaxMs": update_stats.get("maxMs"),
-        "replaceBodyCalls": renders.get("replaceBody", {}).get("total"),
-        "displayToolEndCalls": renders.get("displayToolEnd", {}).get("total"),
-        "probeP95Ms": probe.get("p95Ms"),
-        "probeMaxMs": probe.get("maxMs"),
-        "probeOver100Ms": probe.get("over100Ms"),
-        "probeOver250Ms": probe.get("over250Ms"),
+        "ok": result.get("ok") is True and derived_ok and not failed_checks,
+        "settled": result.get("settled") is True,
+        "coolingScenario": str(result.get("scenario", "")).startswith("agent-end-cooling"),
+        "wallMs": result.get("wallMs") or 0,
+        "agentEndMs": agent_end.get("wallMs") or 0,
+        "agentEndFilterMs": agent_end_filter.get("wallMs") or 0,
+        "drainWallMs": drain.get("wallMs") or 0,
+        "drainActiveMs": drain.get("activeMs") or 0,
+        "drainCallbacks": drain.get("callbacks") or 0,
+        "sliceMaxMs": max((float(row.get("wallMs") or 0) for row in slices), default=0),
+        "drainGcs": drain.get("gcs") or 0,
+        "updateMeanMs": update_stats.get("meanMs") or 0,
+        "updateMaxMs": update_stats.get("maxMs") or 0,
+        "replaceBodyCalls": renders.get("replaceBody", {}).get("total") or 0,
+        "displayToolEndCalls": renders.get("displayToolEnd", {}).get("total") or 0,
+        "probeP95Ms": probe.get("p95Ms") or 0,
+        "probeMaxMs": probe.get("maxMs") or 0,
+        "probeOver100Ms": probe.get("over100Ms") or 0,
+        "probeOver250Ms": probe.get("over250Ms") or 0,
+        "commandLatenessP95Ms": command_stats.get("latenessP95Ms") or 0,
+        "commandLatenessMaxMs": command_stats.get("latenessMaxMs") or 0,
+        "commandDurationMaxMs": command_stats.get("durationMaxMs") or 0,
+        "coldTools": final.get("coldTools") or 0,
+        "hotToolOverlays": final.get("toolOverlays") or 0,
         "bufferBytes": result.get("bufferBytes"),
         "overlays": result.get("overlays"),
         "seconds": result.get("seconds"),
@@ -264,48 +330,95 @@ if rows:
         writer.writerows(rows)
 
 summary_lines: list[str] = []
-summary_lines.append("# pi-coding-agent tool-update storm benchmark summary")
+summary_lines.append("# pi-coding-agent tool-update benchmark summary")
 summary_lines.append("")
 summary_lines.append("Synthetic deterministic workload only; no private session content is used.")
 summary_lines.append("")
 summary_lines.append(f"- Mode: `{mode}`")
 summary_lines.append(f"- Repetitions per scenario: `{reps}`")
 summary_lines.append(f"- Scenarios: `{scenarios_arg}`")
-summary_lines.append("- Timing thresholds: `none` (correctness failures still fail the run)")
-summary_lines.append("")
-summary_lines.append("| scenario | wall ms (median) | update mean ms | update max ms | replace-body calls | tool-end renders | probe p95 ms | probe max ms | >100 ms late | >250 ms late | successful runs |")
-summary_lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+summary_lines.append(
+    "- Timing policy: diagnostics only (`<100 ms` target, `>250 ms` concern, "
+    "`>1 s` severe); correctness failures alone fail the run"
+)
 
 print("\nsummary")
-print("scenario    wall-med  upd-mean  upd-max  replace-body  tool-end  probe-p95  probe-max  >100ms  >250ms  ok")
-print("--------    --------  --------  -------  ------------  --------  ---------  ---------  ------  ------  --")
-
 failed = [row for row in rows if not row["ok"]]
-for scenario in sorted({str(row["scenario"]) for row in rows}):
-    subset_all = [row for row in rows if str(row["scenario"]) == scenario]
-    subset = [row for row in subset_all if row["ok"]]
-    if not subset:
-        print(f"{scenario:<11} no successful runs")
-        summary_lines.append(f"| {scenario} | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0/{len(subset_all)} |")
-        continue
-    walls = sorted(float(row["wallMs"]) for row in subset)
-    upd_mean = statistics.median(float(row["updateMeanMs"]) for row in subset)
-    upd_max = max(float(row["updateMaxMs"]) for row in subset)
-    replace_body = max(int(row["replaceBodyCalls"]) for row in subset)
-    tool_end = max(int(row["displayToolEndCalls"]) for row in subset)
-    p95 = statistics.median(float(row["probeP95Ms"]) for row in subset)
-    pmax = max(float(row["probeMaxMs"]) for row in subset)
-    over100 = max(int(row["probeOver100Ms"]) for row in subset)
-    over250 = max(int(row["probeOver250Ms"]) for row in subset)
-    ok_count = f"{len(subset)}/{len(subset_all)}"
-    print(
-        f"{scenario:<11} {walls[len(walls)//2]:8.0f}  {upd_mean:8.2f}  {upd_max:7.1f}  "
-        f"{replace_body:12d}  {tool_end:8d}  {p95:9.1f}  {pmax:9.1f}  {over100:6d}  {over250:6d}  {ok_count}"
-    )
-    summary_lines.append(
-        f"| {scenario} | {statistics.median(walls):.0f} | {upd_mean:.2f} | {upd_max:.1f} | "
-        f"{replace_body} | {tool_end} | {p95:.1f} | {pmax:.1f} | {over100} | {over250} | {ok_count} |"
-    )
+storm_rows = [row for row in rows if not row["coolingScenario"]]
+cooling_rows = [row for row in rows if row["coolingScenario"]]
+
+if storm_rows:
+    summary_lines.append("")
+    summary_lines.append("## Tool-update storm")
+    summary_lines.append("")
+    summary_lines.append("| scenario | wall ms (median) | update mean ms | update max ms | replace-body calls | tool-end renders | probe p95 ms | probe max ms | >100 ms late | >250 ms late | successful runs |")
+    summary_lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    print("\ntool-update storm")
+    print("scenario    wall-med  upd-mean  upd-max  replace-body  tool-end  probe-p95  probe-max  >100ms  >250ms  ok")
+    print("--------    --------  --------  -------  ------------  --------  ---------  ---------  ------  ------  --")
+    for scenario in sorted({str(row["scenario"]) for row in storm_rows}):
+        subset_all = [row for row in storm_rows if str(row["scenario"]) == scenario]
+        subset = [row for row in subset_all if row["ok"]]
+        if not subset:
+            print(f"{scenario:<11} no successful runs")
+            summary_lines.append(f"| {scenario} | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0/{len(subset_all)} |")
+            continue
+        walls = [float(row["wallMs"]) for row in subset]
+        upd_mean = statistics.median(float(row["updateMeanMs"]) for row in subset)
+        upd_max = max(float(row["updateMaxMs"]) for row in subset)
+        replace_body = max(int(row["replaceBodyCalls"]) for row in subset)
+        tool_end = max(int(row["displayToolEndCalls"]) for row in subset)
+        p95 = statistics.median(float(row["probeP95Ms"]) for row in subset)
+        pmax = max(float(row["probeMaxMs"]) for row in subset)
+        over100 = max(int(row["probeOver100Ms"]) for row in subset)
+        over250 = max(int(row["probeOver250Ms"]) for row in subset)
+        ok_count = f"{len(subset)}/{len(subset_all)}"
+        print(
+            f"{scenario:<11} {statistics.median(walls):8.0f}  {upd_mean:8.2f}  {upd_max:7.1f}  "
+            f"{replace_body:12d}  {tool_end:8d}  {p95:9.1f}  {pmax:9.1f}  {over100:6d}  {over250:6d}  {ok_count}"
+        )
+        summary_lines.append(
+            f"| {scenario} | {statistics.median(walls):.0f} | {upd_mean:.2f} | {upd_max:.1f} | "
+            f"{replace_body} | {tool_end} | {p95:.1f} | {pmax:.1f} | {over100} | {over250} | {ok_count} |"
+        )
+
+if cooling_rows:
+    summary_lines.append("")
+    summary_lines.append("## Deferred agent_end cooling")
+    summary_lines.append("")
+    summary_lines.append("| scenario | agent_end ms | enclosing filter ms | drain wall ms | drain active ms | callbacks | max slice ms | probe p95/max ms | command late p95/max ms | command max ms | GC | cold/hot | successful runs |")
+    summary_lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    print("\ndeferred agent_end cooling")
+    print("scenario                  end-ms  filter-ms  drain-ms  active-ms  callbacks  slice-max  probe-p95/max  cmd-late-p95/max  cmd-max  GC  cold/hot  ok")
+    print("------------------------  ------  ---------  --------  ---------  ---------  ---------  -------------  ----------------  -------  --  --------  --")
+    for scenario in sorted({str(row["scenario"]) for row in cooling_rows}):
+        subset_all = [row for row in cooling_rows if str(row["scenario"]) == scenario]
+        subset = [row for row in subset_all if row["ok"]]
+        if not subset:
+            print(f"{scenario:<24} no successful runs")
+            summary_lines.append(f"| {scenario} | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0/{len(subset_all)} |")
+            continue
+        median = lambda key: statistics.median(float(row[key]) for row in subset)
+        maximum = lambda key: max(float(row[key]) for row in subset)
+        callbacks = int(maximum("drainCallbacks"))
+        gcs = int(maximum("drainGcs"))
+        cold = int(maximum("coldTools"))
+        hot = int(maximum("hotToolOverlays"))
+        ok_count = f"{len(subset)}/{len(subset_all)}"
+        print(
+            f"{scenario:<24} {median('agentEndMs'):7.2f}  {median('agentEndFilterMs'):9.2f}  "
+            f"{median('drainWallMs'):8.1f}  {median('drainActiveMs'):9.1f}  {callbacks:9d}  "
+            f"{maximum('sliceMaxMs'):9.2f}  {median('probeP95Ms'):5.1f}/{maximum('probeMaxMs'):5.1f}  "
+            f"{median('commandLatenessP95Ms'):7.2f}/{maximum('commandLatenessMaxMs'):7.2f}  "
+            f"{maximum('commandDurationMaxMs'):7.2f}  {gcs:2d}  {cold}/{hot}  {ok_count}"
+        )
+        summary_lines.append(
+            f"| {scenario} | {median('agentEndMs'):.2f} | {median('agentEndFilterMs'):.2f} | "
+            f"{median('drainWallMs'):.1f} | {median('drainActiveMs'):.1f} | {callbacks} | "
+            f"{maximum('sliceMaxMs'):.2f} | {median('probeP95Ms'):.1f}/{maximum('probeMaxMs'):.1f} | "
+            f"{median('commandLatenessP95Ms'):.2f}/{maximum('commandLatenessMaxMs'):.2f} | "
+            f"{maximum('commandDurationMaxMs'):.2f} | {gcs} | {cold}/{hot} | {ok_count} |"
+        )
 
 summary_lines.append("")
 summary_lines.append("## Artifacts")
@@ -314,6 +427,9 @@ summary_lines.append(f"- CSV: `{csv_path}`")
 summary_lines.append("- Per-run reports: `SCENARIO/iter-NN/report.md`")
 summary_lines.append("- Per-run JSON: `SCENARIO/iter-NN/result.json`")
 summary_lines.append("- Per-run timing TSV: `SCENARIO/iter-NN/times.tsv`")
+if cooling_rows:
+    summary_lines.append("- Per-callback cooling TSV: `SCENARIO/iter-NN/cooling-slices.tsv`")
+    summary_lines.append("- Per-command heartbeat TSV: `SCENARIO/iter-NN/commands.tsv`")
 
 if failed:
     summary_lines.append("")

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -3333,10 +3333,8 @@ Live tool blocks that are still executing are excluded."
        (overlay-get overlay 'pi-coding-agent-header-end)))
 
 (defun pi-coding-agent--completed-tool-overlay-before-p (overlay boundary)
-  "Return non-nil when tool OVERLAY is completed and before BOUNDARY.
-OVERLAY must still belong to the current buffer."
+  "Return non-nil when tool OVERLAY is completed and before BOUNDARY."
   (and (pi-coding-agent--completed-tool-overlay-p overlay)
-       (eq (overlay-buffer overlay) (current-buffer))
        (< (overlay-start overlay) boundary)))
 
 (defun pi-coding-agent--tool-overlays-in-reverse-order (overlays)
@@ -3514,14 +3512,11 @@ from leaving a retry loop or wedged timer slot."
   "Arm one deferred tool-cooling slice when work lacks an owner."
   (when (and pi-coding-agent--tool-cooling-queue
              (not pi-coding-agent--tool-cooling-timer))
-    (condition-case error-data
-        (setq pi-coding-agent--tool-cooling-timer
-              (run-at-time pi-coding-agent--tool-cooling-delay nil
-                           #'pi-coding-agent--run-tool-cooling-slice
-                           (current-buffer)
-                           pi-coding-agent--tool-cooling-generation))
-      (error
-       (pi-coding-agent--fail-tool-cooling error-data)))))
+    (setq pi-coding-agent--tool-cooling-timer
+          (run-at-time pi-coding-agent--tool-cooling-delay nil
+                       #'pi-coding-agent--run-tool-cooling-slice
+                       (current-buffer)
+                       pi-coding-agent--tool-cooling-generation))))
 
 (defun pi-coding-agent--queue-tool-cooling-outside-hot-tail ()
   "Merge the current outside-hot-tail cohort into deferred cooling.
@@ -3550,12 +3545,16 @@ new body end.  Positions at or after OLD-END shift by the actual length delta."
    ((< position old-end)
     (+ old-start
        (min (- position old-start)
-            (max 0 (- new-end old-start)))))
+            (- new-end old-start))))
    (t
     (+ position (- new-end old-end)))))
 
 (defun pi-coding-agent--capture-tool-cooling-view ()
-  "Capture buffer point and visible-window positions before tool cooling."
+  "Capture buffer point and visible-window positions before tool cooling.
+Unlike `pi-coding-agent--with-scroll-preservation', which restores unmapped
+`window-point' and is valid for append-only inserts, cooling rewrites
+mid-buffer ranges, so positions and window starts must be mapped through
+the replacement."
   (list
    :point (point)
    :windows
@@ -3641,6 +3640,8 @@ Timer ownership is cleared before input checks, mutation, or rearming."
                      overlay)))
                 (pi-coding-agent--schedule-tool-cooling)))
           (quit
+           ;; C-g is user intent: pending cooling is discarded silently and
+           ;; the quit resignals; errors, by contrast, fail loudly below.
            (pi-coding-agent--cancel-tool-cooling)
            (signal (car error-data) (cdr error-data)))
           (error

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1098,6 +1098,7 @@ which asks upfront before any buffers are touched."
   (when (derived-mode-p 'pi-coding-agent-chat-mode)
     (pi-coding-agent--cancel-followup-drain-timer)
     (pi-coding-agent--cancel-tool-update-flush)
+    (pi-coding-agent--cancel-tool-cooling)
     (pi-coding-agent--invalidate-prompt-start-wait)
     (pi-coding-agent--set-activity-phase "idle" 'teardown t)
     (dolist (proc (delete-dups (delq nil (list pi-coding-agent--process
@@ -1349,7 +1350,7 @@ Updates buffer-local state and renders display updates."
       (plist-get pi-coding-agent--state :messages))
      (pi-coding-agent--display-agent-end)
      (pi-coding-agent--update-hot-tail-boundary)
-     (pi-coding-agent--cool-completed-tool-blocks-outside-hot-tail))
+     (pi-coding-agent--queue-tool-cooling-outside-hot-tail))
     ("auto_retry_start"
      (pi-coding-agent--cancel-followup-drain-timer)
      (pi-coding-agent--display-retry-start event))
@@ -1448,8 +1449,10 @@ This removes completed/pending tool overlays, diff overlays, and lightweight
 cold-tool metadata before buffer reset or history rebuild, then clears keyed
 live-tool state, cached execution args, pending coalesced tool updates, and
 the compatibility pending overlay slot so buffer and render state stay
-consistent.  Tree-sitter overlays are left alone."
+consistent.  Pending deferred cooling is invalidated first.  Tree-sitter
+overlays are left alone."
   (pi-coding-agent--cancel-tool-update-flush)
+  (pi-coding-agent--cancel-tool-cooling)
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-tool-block t)
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-diff-overlay t)
   (let ((inhibit-read-only t))
@@ -3279,9 +3282,29 @@ command falls back to `outline-cycle' for turn folding."
 ;;
 ;; Completed tool blocks outside the hot tail (older than the most
 ;; recent `pi-coding-agent-hot-tail-turn-count' headed turns) are
-;; cooled into plain text.  The cold form keeps the header, visible
-;; preview, and lightweight authoritative target metadata, but drops
-;; overlays, buttons, full-content payloads, and syntax-tagged rendering.
+;; cooled into plain text.  Live agent-end handling queues one block per
+;; timer turn; history replay keeps synchronous cooling after invalidating
+;; stale queued work.  The cold form keeps the header, visible preview, and
+;; lightweight authoritative target metadata, but drops overlays, buttons,
+;; full-content payloads, and syntax-tagged rendering.
+
+(defconst pi-coding-agent--tool-cooling-delay 0.05
+  "Seconds between deferred rewrites of completed tool blocks.
+A small nonzero delay gives input and redisplay a chance to run between
+expensive Markdown-changing rewrites.  Internal constant, not a user option.")
+
+(defvar-local pi-coding-agent--tool-cooling-queue nil
+  "Completed tool overlays awaiting deferred cold-history rewrites.
+Candidates are ordered from the end of the buffer backward and are
+revalidated immediately before each rewrite.")
+
+(defvar-local pi-coding-agent--tool-cooling-timer nil
+  "The one owned one-shot timer for deferred tool cooling, or nil.")
+
+(defvar-local pi-coding-agent--tool-cooling-generation 0
+  "Generation owning the current deferred tool-cooling queue.
+Cancellation increments this value so already-dispatched callbacks cannot
+act on rebuilt history or a newer queue.")
 
 (defun pi-coding-agent--ensure-cold-tool-property-nonsticky ()
   "Keep cold tool authority from spreading across insertion boundaries."
@@ -3308,6 +3331,38 @@ Live tool blocks that are still executing are excluded."
        (not (eq overlay pi-coding-agent--pending-tool-overlay))
        (not (pi-coding-agent--tool-overlay-live-p overlay))
        (overlay-get overlay 'pi-coding-agent-header-end)))
+
+(defun pi-coding-agent--completed-tool-overlay-before-p (overlay boundary)
+  "Return non-nil when tool OVERLAY is completed and before BOUNDARY.
+OVERLAY must still belong to the current buffer."
+  (and (pi-coding-agent--completed-tool-overlay-p overlay)
+       (eq (overlay-buffer overlay) (current-buffer))
+       (< (overlay-start overlay) boundary)))
+
+(defun pi-coding-agent--tool-overlays-in-reverse-order (overlays)
+  "Return a copy of tool OVERLAYS ordered from buffer end backward."
+  (sort (copy-sequence overlays)
+        (lambda (a b)
+          (> (overlay-start a) (overlay-start b)))))
+
+(defun pi-coding-agent--tool-cooling-boundary ()
+  "Return the current usable hot-tail boundary, or nil.
+A boundary at `point-min' leaves the whole buffer hot."
+  (when (and (markerp pi-coding-agent--hot-tail-start)
+             (eq (marker-buffer pi-coding-agent--hot-tail-start)
+                 (current-buffer))
+             (> (marker-position pi-coding-agent--hot-tail-start) (point-min)))
+    (marker-position pi-coding-agent--hot-tail-start)))
+
+(defun pi-coding-agent--completed-tool-overlays-outside-hot-tail ()
+  "Return completed tool overlays before the current hot-tail boundary.
+The result is ordered from the end of the buffer backward."
+  (when-let* ((boundary (pi-coding-agent--tool-cooling-boundary)))
+    (pi-coding-agent--tool-overlays-in-reverse-order
+     (seq-filter
+      (lambda (overlay)
+        (pi-coding-agent--completed-tool-overlay-before-p overlay boundary))
+      (overlays-in (point-min) boundary)))))
 
 (defun pi-coding-agent--tool-overlay-visible-body (overlay)
   "Return the currently visible body text for completed tool OVERLAY.
@@ -3416,30 +3471,180 @@ diff annotations."
   "Cool the given completed tool OVERLAYS.
 Blocks are processed from the end of the buffer backward so region
 rewrites do not disturb remaining candidates."
-  (let* ((candidates (seq-filter #'pi-coding-agent--completed-tool-overlay-p
-                                 overlays))
-         (sorted (sort (copy-sequence candidates)
-                       (lambda (a b)
-                         (> (overlay-start a) (overlay-start b))))))
+  (let ((sorted
+         (pi-coding-agent--tool-overlays-in-reverse-order
+          (seq-filter #'pi-coding-agent--completed-tool-overlay-p overlays))))
     (pi-coding-agent--with-scroll-preservation
       (save-excursion
         (dolist (overlay sorted)
           (pi-coding-agent--cool-tool-overlay overlay))))))
 
 (defun pi-coding-agent--cool-completed-tool-blocks-outside-hot-tail ()
-  "Cool completed tool blocks that fall before the hot-tail boundary.
-Uses the same `pi-coding-agent--hot-tail-start' marker that tables
-use for resize scope, so there is one unified hot-tail concept."
-  (when (and (markerp pi-coding-agent--hot-tail-start)
-             (> (marker-position pi-coding-agent--hot-tail-start) (point-min)))
-    (let* ((boundary (marker-position pi-coding-agent--hot-tail-start))
-           (cold-overlays
-            (seq-filter (lambda (ov)
-                          (and (pi-coding-agent--completed-tool-overlay-p ov)
-                               (< (overlay-start ov) boundary)))
-                        (overlays-in (point-min) boundary))))
-      (when cold-overlays
-        (pi-coding-agent--cool-completed-tool-blocks cold-overlays)))))
+  "Synchronously cool completed tool blocks before the hot-tail boundary.
+Uses the same `pi-coding-agent--hot-tail-start' marker that tables use for
+resize scope.  History replay uses this synchronous path after cancelling
+stale deferred work; live agent_end handling uses the deferred queue."
+  (when-let* ((cold-overlays
+              (pi-coding-agent--completed-tool-overlays-outside-hot-tail)))
+    (pi-coding-agent--cool-completed-tool-blocks cold-overlays)))
+
+(defun pi-coding-agent--cancel-tool-cooling ()
+  "Cancel and invalidate deferred completed-tool cooling.
+The operation is idempotent with respect to owned work.  Its generation
+always advances so a callback already dispatched by Emacs becomes stale."
+  (when (timerp pi-coding-agent--tool-cooling-timer)
+    (cancel-timer pi-coding-agent--tool-cooling-timer))
+  (setq pi-coding-agent--tool-cooling-timer nil
+        pi-coding-agent--tool-cooling-queue nil
+        pi-coding-agent--tool-cooling-generation
+        (1+ pi-coding-agent--tool-cooling-generation)))
+
+(defun pi-coding-agent--fail-tool-cooling (error-data)
+  "Fail closed after deferred cooling ERROR-DATA.
+Owned work is invalidated before reporting the failure, preventing an error
+from leaving a retry loop or wedged timer slot."
+  (pi-coding-agent--cancel-tool-cooling)
+  (display-warning
+   'pi-coding-agent
+   (format "Deferred tool block cooling failed: %s"
+           (error-message-string error-data))
+   :error))
+
+(defun pi-coding-agent--schedule-tool-cooling ()
+  "Arm one deferred tool-cooling slice when work lacks an owner."
+  (when (and pi-coding-agent--tool-cooling-queue
+             (not pi-coding-agent--tool-cooling-timer))
+    (condition-case error-data
+        (setq pi-coding-agent--tool-cooling-timer
+              (run-at-time pi-coding-agent--tool-cooling-delay nil
+                           #'pi-coding-agent--run-tool-cooling-slice
+                           (current-buffer)
+                           pi-coding-agent--tool-cooling-generation))
+      (error
+       (pi-coding-agent--fail-tool-cooling error-data)))))
+
+(defun pi-coding-agent--queue-tool-cooling-outside-hot-tail ()
+  "Merge the current outside-hot-tail cohort into deferred cooling.
+Existing candidates are deduplicated and retain one buffer-local timer owner.
+Newly eligible overlays take their normal reverse-buffer order; stale queued
+entries remain at the end for execution-time revalidation."
+  (let ((candidates
+         (pi-coding-agent--completed-tool-overlays-outside-hot-tail))
+        merged)
+    (dolist (overlay (append candidates pi-coding-agent--tool-cooling-queue))
+      (unless (memq overlay merged)
+        (push overlay merged)))
+    (setq pi-coding-agent--tool-cooling-queue (nreverse merged))
+    (pi-coding-agent--schedule-tool-cooling)))
+
+(defun pi-coding-agent--map-tool-cooling-position
+    (position old-start old-end new-end)
+  "Map POSITION through one tool-body replacement.
+OLD-START and OLD-END delimit the old half-open body range; NEW-END is the
+new body end and the body start is unchanged.  Positions before the body stay
+fixed.  Positions in the old body retain their relative offset, clamped to the
+new body end.  Positions at or after OLD-END shift by the actual length delta."
+  (cond
+   ((< position old-start)
+    position)
+   ((< position old-end)
+    (+ old-start
+       (min (- position old-start)
+            (max 0 (- new-end old-start)))))
+   (t
+    (+ position (- new-end old-end)))))
+
+(defun pi-coding-agent--capture-tool-cooling-view ()
+  "Capture buffer point and visible-window positions before tool cooling."
+  (list
+   :point (point)
+   :windows
+   (mapcar
+    (lambda (window)
+      (list :window window
+            :following (pi-coding-agent--window-following-p window)
+            :start (window-start window)
+            :point (window-point window)))
+    (get-buffer-window-list (current-buffer) nil t))))
+
+(defun pi-coding-agent--restore-tool-cooling-view
+    (view old-start old-end new-end)
+  "Restore cooling VIEW through the body replacement bounds.
+OLD-START and OLD-END are the old body bounds and NEW-END is its new end.
+Every live window still showing the current buffer gets mapped start and point;
+a window that was following the tail instead gets point at the new buffer end.
+The buffer's own point is mapped too."
+  (let ((map-position
+         (lambda (position)
+           (pi-coding-agent--map-tool-cooling-position
+            position old-start old-end new-end))))
+    ;; Restore buffer point first.  A selected chat window restored below then
+    ;; establishes the same mapped point, or point-max when it was following.
+    (goto-char (funcall map-position (plist-get view :point)))
+    (dolist (window-state (plist-get view :windows))
+      (let ((window (plist-get window-state :window)))
+        (when (and (window-live-p window)
+                   (eq (window-buffer window) (current-buffer)))
+          (set-window-start
+           window
+           (funcall map-position (plist-get window-state :start))
+           t)
+          (set-window-point
+           window
+           (if (plist-get window-state :following)
+               (point-max)
+             (funcall map-position
+                      (plist-get window-state :point)))))))))
+
+(defun pi-coding-agent--cool-tool-overlay-preserving-view (overlay)
+  "Cool completed tool OVERLAY while mapping visible view positions.
+The header stays in place, so only the replaced body bounds participate in the
+mapping.  Return the result of `pi-coding-agent--cool-tool-overlay'."
+  (let* ((header-end-marker
+          (overlay-get overlay 'pi-coding-agent-header-end))
+         (old-start (and (markerp header-end-marker)
+                         (marker-position header-end-marker)))
+         (old-end (overlay-end overlay)))
+    (if (not (and old-start old-end (<= old-start old-end)))
+        (pi-coding-agent--cool-tool-overlay overlay)
+      (let ((view (pi-coding-agent--capture-tool-cooling-view))
+            ;; The primitive deletes at OLD-START, then inserts there.  This
+            ;; rear-advancing marker stays at the deletion boundary and moves
+            ;; across exactly the newly inserted body.
+            (new-end-marker (copy-marker old-start t)))
+        (unwind-protect
+            (when (pi-coding-agent--cool-tool-overlay overlay)
+              (pi-coding-agent--restore-tool-cooling-view
+               view old-start old-end (marker-position new-end-marker))
+              t)
+          (set-marker new-end-marker nil))))))
+
+(defun pi-coding-agent--run-tool-cooling-slice (buffer generation)
+  "Cool at most one queued tool overlay in BUFFER for GENERATION.
+This is the ordinary one-shot timer callback.  Current input wins without
+queue progress.  Otherwise one candidate is removed, revalidated as completed,
+current-buffer-owned, and still outside the live hot-tail boundary, then passed
+to the unchanged cold rewrite primitive with cooling-specific view mapping.
+Timer ownership is cleared before input checks, mutation, or rearming."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (when (= generation pi-coding-agent--tool-cooling-generation)
+        (setq pi-coding-agent--tool-cooling-timer nil)
+        (condition-case error-data
+            (if (input-pending-p)
+                (pi-coding-agent--schedule-tool-cooling)
+              (when-let* ((overlay (pop pi-coding-agent--tool-cooling-queue)))
+                (when-let* ((boundary (pi-coding-agent--tool-cooling-boundary)))
+                  (when (pi-coding-agent--completed-tool-overlay-before-p
+                         overlay boundary)
+                    (pi-coding-agent--cool-tool-overlay-preserving-view
+                     overlay)))
+                (pi-coding-agent--schedule-tool-cooling)))
+          (quit
+           (pi-coding-agent--cancel-tool-cooling)
+           (signal (car error-data) (cdr error-data)))
+          (error
+           (pi-coding-agent--fail-tool-cooling error-data)))))))
 
 ;;;; File Navigation
 

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -1834,7 +1834,9 @@ larger window when the selected one cannot be split."
 (defmacro pi-coding-agent--with-scroll-preservation (&rest body)
   "Execute BODY preserving scroll for windows not following output.
 Windows at buffer end will scroll to show new content.
-Windows where user scrolled up stay in place."
+Windows where user scrolled up stay in place.
+Valid for append-only inserts; for mid-buffer rewrites like tool cooling, see
+`pi-coding-agent--capture-tool-cooling-view' in pi-coding-agent-render.el."
   (declare (indent 0) (debug t))
   `(let* ((windows (get-buffer-window-list (current-buffer) nil t))
           (following (cl-remove-if-not #'pi-coding-agent--window-following-p windows))

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -2881,6 +2881,21 @@ Call inside `with-temp-buffer' after `pi-coding-agent-chat-mode'."
       (pi-coding-agent--run-tool-cooling-slice
        (current-buffer) pi-coding-agent--tool-cooling-generation))))
 
+(defun pi-coding-agent-test--drain-tool-cooling-via-real-timers ()
+  "Deliver real cooling timers until the current buffer's queue empties.
+Each wait lasts long enough for one more one-shot slice; `sit-for' runs
+pending timers in batch and interactive Emacs alike.  Input is forced idle
+so every slice makes progress, and the loop is bounded so a broken rearm
+fails the caller instead of hanging the suite.  Return non-nil when the
+queue drained before the deadline."
+  (cl-letf (((symbol-function 'input-pending-p)
+             (lambda (&rest _) nil)))
+    (let ((deadline (+ (float-time) 3)))
+      (while (and pi-coding-agent--tool-cooling-queue
+                  (< (float-time) deadline))
+        (sit-for 0.05))
+      (not pi-coding-agent--tool-cooling-queue))))
+
 (defun pi-coding-agent-test--render-completed-tool-turn
     (tool-call-id tool-name args content &optional details)
   "Render one completed assistant turn with a single tool result.
@@ -3599,6 +3614,90 @@ When EXPANDED is non-nil, expand its preview before returning the overlay."
             (should-not pi-coding-agent--tool-cooling-queue)
             (should-not pi-coding-agent--tool-cooling-timer)
             (should-not (pi-coding-agent-test--all-tool-overlays))))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-real-timers-drain-cohort ()
+  "Real one-shot timer delivery cools the queued cohort and keeps the newest turn hot."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 1))
+      (let ((oldest
+             (pi-coding-agent-test--render-headed-completed-read-block "drain-old-1"))
+            (middle
+             (pi-coding-agent-test--render-headed-completed-read-block "drain-old-2"))
+            (third
+             (pi-coding-agent-test--render-headed-completed-read-block "drain-old-3"))
+            (newest
+             (pi-coding-agent-test--render-headed-completed-read-block "drain-new")))
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (should (equal pi-coding-agent--tool-cooling-queue
+                       (list third middle oldest)))
+        (should pi-coding-agent--tool-cooling-timer)
+        (should (pi-coding-agent-test--drain-tool-cooling-via-real-timers))
+        (should-not pi-coding-agent--tool-cooling-queue)
+        (should-not pi-coding-agent--tool-cooling-timer)
+        (dolist (cooled (list oldest middle third))
+          (should-not (overlay-buffer cooled)))
+        (should (overlay-buffer newest))
+        (should (equal (pi-coding-agent-test--all-tool-overlays) (list newest)))
+        (goto-char (point-min))
+        (dolist (id '("drain-old-1" "drain-old-2" "drain-old-3"))
+          (search-forward (format "result %s" id))
+          (should (get-text-property
+                   (1- (point)) 'pi-coding-agent-cold-tool-block)))
+        (search-forward "result drain-new")
+        (should-not (get-text-property
+                     (1- (point)) 'pi-coding-agent-cold-tool-block))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-nil-boundary-drain-keeps-block-hot ()
+  "Real timer slices skip cooling once the hot tail covers the whole buffer."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 1))
+      (let ((older
+             (pi-coding-agent-test--render-headed-completed-read-block "cover-old"))
+            (newest
+             (pi-coding-agent-test--render-headed-completed-read-block "cover-new")))
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (should (equal pi-coding-agent--tool-cooling-queue (list older)))
+        (should pi-coding-agent--tool-cooling-timer)
+        (set-marker pi-coding-agent--hot-tail-start (point-min))
+        (should (pi-coding-agent-test--drain-tool-cooling-via-real-timers))
+        (should-not pi-coding-agent--tool-cooling-queue)
+        (should-not pi-coding-agent--tool-cooling-timer)
+        (let ((live (pi-coding-agent-test--all-tool-overlays)))
+          (should (memq older live))
+          (should (memq newest live)))
+        (goto-char (point-min))
+        (search-forward "result cover-old")
+        (should-not (get-text-property
+                     (1- (point)) 'pi-coding-agent-cold-tool-block))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-real-timer-error-fails-closed ()
+  "A cooling error surfacing from real timer delivery fails closed with one warning."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 1)
+          warning)
+      (dotimes (index 3)
+        (pi-coding-agent-test--render-headed-completed-read-block
+         (format "fail-%d" index)))
+      (pi-coding-agent--handle-display-event '(:type "agent_end"))
+      (should pi-coding-agent--tool-cooling-queue)
+      (should pi-coding-agent--tool-cooling-timer)
+      (let ((generation pi-coding-agent--tool-cooling-generation))
+        (cl-letf (((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                   (lambda (&rest _)
+                     (error "synthetic real-timer cooling failure")))
+                  ((symbol-function 'display-warning)
+                   (lambda (&rest args)
+                     (setq warning args))))
+          (should (pi-coding-agent-test--drain-tool-cooling-via-real-timers)))
+        (should (> pi-coding-agent--tool-cooling-generation generation))
+        (should-not pi-coding-agent--tool-cooling-queue)
+        (should-not pi-coding-agent--tool-cooling-timer)
+        (should (string-match-p
+                 "synthetic real-timer cooling failure"
+                 (format "%s" (nth 1 warning))))))))
 
 (ert-deftest pi-coding-agent-test-cooled-file-target-preserves-local-authority-and-line-map ()
   "Cooling keeps a local tool path authoritative and maps only content lines."

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -2871,6 +2871,16 @@ Call inside `with-temp-buffer' after `pi-coding-agent-chat-mode'."
   (seq-filter (lambda (ov) (overlay-get ov 'pi-coding-agent-tool-block))
               (overlays-in (point-min) (point-max))))
 
+(defun pi-coding-agent-test--drain-tool-cooling ()
+  "Run all deferred tool-cooling slices deterministically in this buffer."
+  (cl-letf (((symbol-function 'input-pending-p)
+             (lambda (&rest _) nil)))
+    (while pi-coding-agent--tool-cooling-queue
+      (when (timerp pi-coding-agent--tool-cooling-timer)
+        (cancel-timer pi-coding-agent--tool-cooling-timer))
+      (pi-coding-agent--run-tool-cooling-slice
+       (current-buffer) pi-coding-agent--tool-cooling-generation))))
+
 (defun pi-coding-agent-test--render-completed-tool-turn
     (tool-call-id tool-name args content &optional details)
   "Render one completed assistant turn with a single tool result.
@@ -2879,7 +2889,9 @@ TOOL-NAME and ARGS are passed through the normal tool execution path.
 CONTENT is the tool result content list, and DETAILS is optional result
 metadata such as an edit diff.
 Synthetic turns also reset `pi-coding-agent--assistant-header-shown' so
-repeated helper calls model new prompts rather than retry attempts."
+repeated helper calls model new prompts rather than retry attempts.  Deferred
+cooling is drained explicitly so existing cold-render semantic tests observe a
+settled event loop without wall-clock timing."
   (setq pi-coding-agent--assistant-header-shown nil)
   (pi-coding-agent--handle-display-event '(:type "agent_start"))
   (pi-coding-agent--handle-display-event
@@ -2893,7 +2905,700 @@ repeated helper calls model new prompts rather than retry attempts."
          :toolName tool-name
          :result (list :content content :details details)
          :isError nil))
-  (pi-coding-agent--handle-display-event '(:type "agent_end")))
+  (pi-coding-agent--handle-display-event '(:type "agent_end"))
+  (pi-coding-agent-test--drain-tool-cooling))
+
+(defmacro pi-coding-agent-test--with-recorded-cooling-timers
+    (jobs &rest body)
+  "Run BODY with cooling timer requests appended to JOBS.
+Each recorded job carries the requested delay, callback, arguments, returned
+fake timer, and the cooling timer owner observed while `run-at-time' ran.
+Unrelated timer requests pass through to the real `run-at-time'."
+  (declare (indent 1) (debug (symbolp body)))
+  (let ((original (make-symbol "original-run-at-time")))
+    `(let ((,jobs nil)
+           (,original (symbol-function 'run-at-time)))
+       (cl-letf (((symbol-function 'run-at-time)
+                  (lambda (delay repeat function &rest args)
+                    (if (eq function
+                            'pi-coding-agent--run-tool-cooling-slice)
+                        (let ((timer (timer-create)))
+                          (setq ,jobs
+                                (nconc ,jobs
+                                       (list
+                                        (list :delay delay
+                                              :repeat repeat
+                                              :function function
+                                              :args args
+                                              :timer timer
+                                              :owner
+                                              pi-coding-agent--tool-cooling-timer))))
+                          timer)
+                      (apply ,original delay repeat function args)))))
+         ,@body))))
+
+(defun pi-coding-agent-test--invoke-recorded-cooling-timer (job)
+  "Invoke recorded cooling timer JOB synchronously."
+  (apply (plist-get job :function) (plist-get job :args)))
+
+(defun pi-coding-agent-test--render-completed-read-block (tool-call-id)
+  "Render and return a completed read overlay for TOOL-CALL-ID."
+  (let* ((path (format "/tmp/%s.py" tool-call-id))
+         (args (list :path path))
+         (block (pi-coding-agent--display-tool-start
+                 "read" args tool-call-id)))
+    (pi-coding-agent--display-tool-end
+     "read" args
+     (list (list :type "text" :text (format "result %s" tool-call-id)))
+     nil nil block)
+    (pi-coding-agent--tool-block-overlay block)))
+
+(defun pi-coding-agent-test--render-headed-completed-read-block (tool-call-id)
+  "Render and return a headed completed read overlay for TOOL-CALL-ID."
+  (setq pi-coding-agent--assistant-header-shown nil)
+  (pi-coding-agent--display-agent-start)
+  (pi-coding-agent-test--render-completed-read-block tool-call-id))
+
+(defun pi-coding-agent-test--render-long-cooling-read-block
+    (tool-call-id &optional expanded)
+  "Render a long completed read block for TOOL-CALL-ID.
+When EXPANDED is non-nil, expand its preview before returning the overlay."
+  (let* ((pi-coding-agent-tool-preview-lines 3)
+         (path (format "/tmp/%s.py" tool-call-id))
+         (args (list :path path))
+         (content
+          (mapconcat (lambda (index)
+                       (format "read body line %02d" index))
+                     (number-sequence 1 20) "\n"))
+         (block (pi-coding-agent--display-tool-start
+                 "read" args tool-call-id)))
+    (pi-coding-agent--display-tool-end
+     "read" args (list (list :type "text" :text content))
+     nil nil block)
+    (let ((overlay (pi-coding-agent--tool-block-overlay block)))
+      (when expanded
+        (let ((button (pi-coding-agent--find-toggle-button-in-region
+                       (overlay-start overlay) (overlay-end overlay))))
+          (should button)
+          (pi-coding-agent--toggle-tool-output button)))
+      overlay)))
+
+(defun pi-coding-agent-test--render-collapsed-cooling-bash-block (tool-call-id)
+  "Render a collapsed completed bash block for TOOL-CALL-ID."
+  (let* ((pi-coding-agent-bash-preview-lines 3)
+         (args '(:command "produce output"))
+         (content
+          (mapconcat (lambda (index)
+                       (format "bash body line %02d" index))
+                     (number-sequence 1 12) "\n"))
+         (block (pi-coding-agent--display-tool-start
+                 "bash" args tool-call-id)))
+    (pi-coding-agent--display-tool-end
+     "bash" args (list (list :type "text" :text content))
+     nil nil block)
+    (pi-coding-agent--tool-block-overlay block)))
+
+(defun pi-coding-agent-test--window-point-text-p (window text)
+  "Return non-nil when WINDOW point begins with TEXT."
+  (with-current-buffer (window-buffer window)
+    (save-excursion
+      (goto-char (window-point window))
+      (looking-at-p (regexp-quote text)))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-agent-end-schedules-cohort ()
+  "agent_end queues the cold cohort without synchronously rewriting it."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 1)
+          cooled)
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (let ((older
+               (pi-coding-agent-test--render-headed-completed-read-block "old"))
+              (newer
+               (pi-coding-agent-test--render-headed-completed-read-block "new")))
+          (cl-letf (((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                     (lambda (overlay)
+                       (push overlay cooled))))
+            (pi-coding-agent--handle-display-event '(:type "agent_end")))
+          (should-not cooled)
+          (should (overlay-buffer older))
+          (should (overlay-buffer newer))
+          (should (equal pi-coding-agent--tool-cooling-queue (list older)))
+          (should (eq pi-coding-agent--tool-cooling-timer
+                      (plist-get (car jobs) :timer)))
+          (should (= 1 (length jobs)))
+          (should (> (plist-get (car jobs) :delay) 0))
+          (should-not (plist-get (car jobs) :repeat))
+          (should-not (plist-get (car jobs) :owner)))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-position-map-boundaries ()
+  "Cooling position mapping is continuous at replacement boundaries."
+  ;; Shrinking [10, 20) to [10, 15).
+  (should (= 9 (pi-coding-agent--map-tool-cooling-position 9 10 20 15)))
+  (should (= 10 (pi-coding-agent--map-tool-cooling-position 10 10 20 15)))
+  (should (= 12 (pi-coding-agent--map-tool-cooling-position 12 10 20 15)))
+  (should (= 15 (pi-coding-agent--map-tool-cooling-position 19 10 20 15)))
+  (should (= 15 (pi-coding-agent--map-tool-cooling-position 20 10 20 15)))
+  (should (= 20 (pi-coding-agent--map-tool-cooling-position 25 10 20 15)))
+  ;; Expanding preserves inside offsets and shifts the old end and suffix.
+  (should (= 19 (pi-coding-agent--map-tool-cooling-position 19 10 20 25)))
+  (should (= 25 (pi-coding-agent--map-tool-cooling-position 20 10 20 25)))
+  (should (= 30 (pi-coding-agent--map-tool-cooling-position 25 10 20 25))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-view-after-body-stays-logical ()
+  "One slice keeps selected and other windows on sentinels after the body."
+  (let ((buffer (generate-new-buffer " *pi-cooling-view-after*"))
+        (pi-coding-agent-quit-without-confirmation t))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent-test--render-long-cooling-read-block
+             "view-after" t)
+            (let ((inhibit-read-only t))
+              (goto-char (point-max))
+              (dotimes (index 10)
+                (insert (format "before A filler %02d\n" index)))
+              (insert "VIEW-A-START context\n")
+              (dotimes (index 3)
+                (insert (format "inside A filler %02d\n" index)))
+              (insert "VIEW-A-POINT sentinel\n")
+              (dotimes (index 10)
+                (insert (format "between filler %02d\n" index)))
+              (insert "VIEW-B-START context\n")
+              (dotimes (index 3)
+                (insert (format "inside B filler %02d\n" index)))
+              (insert "VIEW-B-POINT sentinel\n")
+              (dotimes (index 60)
+                (insert (format "tail filler %02d\n" index)))))
+          (pi-coding-agent-test--with-recorded-cooling-timers jobs
+            (with-current-buffer buffer
+              (let ((pi-coding-agent-hot-tail-turn-count 0))
+                (pi-coding-agent--handle-display-event '(:type "agent_end"))))
+            (should (= 1 (length jobs)))
+            (save-window-excursion
+              (delete-other-windows)
+              (switch-to-buffer buffer)
+              (let* ((selected (selected-window))
+                     (other (split-window-right))
+                     start-a point-a start-b point-b old-point-a)
+                (set-window-buffer other buffer)
+                (with-current-buffer buffer
+                  (save-excursion
+                    (goto-char (point-min))
+                    (search-forward "VIEW-A-START context")
+                    (setq start-a (line-beginning-position))
+                    (search-forward "VIEW-A-POINT sentinel")
+                    (setq point-a (match-beginning 0))
+                    (search-forward "VIEW-B-START context")
+                    (setq start-b (line-beginning-position))
+                    (search-forward "VIEW-B-POINT sentinel")
+                    (setq point-b (match-beginning 0))))
+                (select-window selected)
+                (goto-char point-a)
+                (set-window-start selected start-a t)
+                (set-window-point other point-b)
+                (set-window-start other start-b t)
+                (setq old-point-a (window-point selected))
+                (cl-letf (((symbol-function 'input-pending-p)
+                           (lambda (&rest _) nil)))
+                  (pi-coding-agent-test--invoke-recorded-cooling-timer
+                   (pop jobs)))
+                (should-not jobs)
+                (should (equal "VIEW-A-START context"
+                               (pi-coding-agent-test--window-start-line
+                                selected)))
+                (should (pi-coding-agent-test--window-point-text-p
+                         selected "VIEW-A-POINT sentinel"))
+                (should (equal "VIEW-B-START context"
+                               (pi-coding-agent-test--window-start-line other)))
+                (should (pi-coding-agent-test--window-point-text-p
+                         other "VIEW-B-POINT sentinel"))
+                (should (/= old-point-a (window-point selected)))
+                (with-current-buffer buffer
+                  (should (= (point) (window-point selected)))
+                  (should (looking-at-p "VIEW-A-POINT sentinel")))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-view-inside-body-maps-and-clamps ()
+  "One slice maps an inside start relatively and clamps an inside point."
+  (let ((buffer (generate-new-buffer " *pi-cooling-view-inside*"))
+        (pi-coding-agent-quit-without-confirmation t))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (pi-coding-agent-chat-mode)
+            (let* ((overlay
+                    (pi-coding-agent-test--render-collapsed-cooling-bash-block
+                     "view-inside"))
+                   (button (pi-coding-agent--find-toggle-button-in-region
+                            (overlay-start overlay) (overlay-end overlay))))
+              (should button)
+              (pi-coding-agent--toggle-tool-output button))
+            (let ((inhibit-read-only t))
+              (goto-char (point-max))
+              (dotimes (index 60)
+                (insert (format "after body filler %02d\n" index)))))
+          (pi-coding-agent-test--with-recorded-cooling-timers jobs
+            (with-current-buffer buffer
+              (let ((pi-coding-agent-hot-tail-turn-count 0))
+                (pi-coding-agent--handle-display-event '(:type "agent_end"))))
+            (save-window-excursion
+              (delete-other-windows)
+              (switch-to-buffer buffer)
+              (let* ((window (selected-window))
+                     (overlay
+                      (car (pi-coding-agent-test--all-tool-overlays)))
+                     (body-start
+                      (marker-position
+                       (overlay-get overlay 'pi-coding-agent-header-end)))
+                     (old-body-end (overlay-end overlay))
+                     (old-point (1- old-body-end))
+                     start-inside start-offset point-offset)
+                (goto-char body-start)
+                (search-forward "bash body line 02")
+                (setq start-inside (match-beginning 0)
+                      start-offset (- start-inside body-start)
+                      point-offset (- old-point body-start))
+                (goto-char old-point)
+                (set-window-start window start-inside t)
+                (cl-letf (((symbol-function 'input-pending-p)
+                           (lambda (&rest _) nil)))
+                  (pi-coding-agent-test--invoke-recorded-cooling-timer
+                   (pop jobs)))
+                (let* ((new-body-end
+                        (next-single-property-change
+                         body-start 'pi-coding-agent-cold-tool-block
+                         nil (point-max)))
+                       (new-body-length (- new-body-end body-start))
+                       (expected-start
+                        (+ body-start (min start-offset new-body-length)))
+                       (expected-point
+                        (+ body-start (min point-offset new-body-length))))
+                  (should (= expected-point new-body-end))
+                  (should (= expected-start (window-start window)))
+                  (should (= expected-point (window-point window)))
+                  (should (= expected-point (point)))
+                  (goto-char expected-start)
+                  (should (looking-at-p "bash body line 02")))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-view-tail-keeps-following ()
+  "A tail-following window remains pinned to point-max after one slice."
+  (let ((buffer (generate-new-buffer " *pi-cooling-view-tail*"))
+        (pi-coding-agent-quit-without-confirmation t))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent-test--render-long-cooling-read-block
+             "view-tail" t)
+            (let ((inhibit-read-only t))
+              (goto-char (point-max))
+              (dotimes (index 80)
+                (insert (format "tail context %02d\n" index)))))
+          (pi-coding-agent-test--with-recorded-cooling-timers jobs
+            (with-current-buffer buffer
+              (let ((pi-coding-agent-hot-tail-turn-count 0))
+                (pi-coding-agent--handle-display-event '(:type "agent_end"))))
+            (save-window-excursion
+              (delete-other-windows)
+              (switch-to-buffer buffer)
+              (let ((window (selected-window))
+                    (old-point-max (point-max)))
+                (goto-char (point-max))
+                (recenter -1)
+                (should (pi-coding-agent--window-following-p window))
+                (cl-letf (((symbol-function 'input-pending-p)
+                           (lambda (&rest _) nil)))
+                  (pi-coding-agent-test--invoke-recorded-cooling-timer
+                   (pop jobs)))
+                (should (< (point-max) old-point-max))
+                (should (= (window-point window) (point-max)))
+                (should (= (point) (point-max)))
+                (should (pi-coding-agent-test--window-shows-tail-p window))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-worker-does-one-and-rearms ()
+  "Each cooling slice rewrites one queued overlay and rearms if needed."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0)
+          mutations)
+      (dotimes (index 3)
+        (pi-coding-agent-test--render-completed-read-block
+         (format "call-%d" index)))
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (should (= 3 (length pi-coding-agent--tool-cooling-queue)))
+        (let ((original (symbol-function 'pi-coding-agent--cool-tool-overlay)))
+          (cl-letf (((symbol-function 'input-pending-p)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                     (lambda (overlay)
+                       (push (cons overlay pi-coding-agent--tool-cooling-timer)
+                             mutations)
+                       (funcall original overlay))))
+            (dotimes (index 3)
+              (should (= 1 (length jobs)))
+              (let ((before (length (pi-coding-agent-test--all-tool-overlays)))
+                    (job (pop jobs)))
+                (should (eq pi-coding-agent--tool-cooling-timer
+                            (plist-get job :timer)))
+                (should-not (plist-get job :owner))
+                (pi-coding-agent-test--invoke-recorded-cooling-timer job)
+                (should (= (1- before)
+                           (length (pi-coding-agent-test--all-tool-overlays))))
+                (if (< index 2)
+                    (progn
+                      (should (= 1 (length jobs)))
+                      (should pi-coding-agent--tool-cooling-timer))
+                  (should-not jobs)
+                  (should-not pi-coding-agent--tool-cooling-queue)
+                  (should-not pi-coding-agent--tool-cooling-timer))))))
+        (should (= 3 (length mutations)))
+        (should (cl-every (lambda (entry) (null (cdr entry))) mutations))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-input-yields-without-progress ()
+  "Pending input leaves the cooling queue untouched and rearms one timer."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0)
+          (cool-calls 0))
+      (dotimes (index 2)
+        (pi-coding-agent-test--render-completed-read-block
+         (format "call-%d" index)))
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (let ((queue-before (copy-sequence pi-coding-agent--tool-cooling-queue))
+              (text-before (buffer-string))
+              (timer-before pi-coding-agent--tool-cooling-timer)
+              (job (pop jobs)))
+          (cl-letf (((symbol-function 'input-pending-p)
+                     (lambda (&rest _) t))
+                    ((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                     (lambda (&rest _)
+                       (setq cool-calls (1+ cool-calls)))))
+            (pi-coding-agent-test--invoke-recorded-cooling-timer job))
+          (should (= 0 cool-calls))
+          (should (equal queue-before pi-coding-agent--tool-cooling-queue))
+          (should (equal text-before (buffer-string)))
+          (should (= 1 (length jobs)))
+          (should pi-coding-agent--tool-cooling-timer)
+          (should-not (eq timer-before pi-coding-agent--tool-cooling-timer))
+          (should-not (plist-get (car jobs) :owner))
+          (pi-coding-agent--cancel-tool-cooling))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-revalidates-each-candidate ()
+  "Cooling skips candidates that became unsafe before their timer slice."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0)
+          mutations)
+      (dotimes (index 6)
+        (pi-coding-agent-test--render-completed-read-block
+         (format "call-%d" index)))
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (let* ((candidates (copy-sequence pi-coding-agent--tool-cooling-queue))
+               (inside (nth 0 candidates))
+               (pending (nth 1 candidates))
+               (live (nth 2 candidates))
+               (incomplete (nth 3 candidates))
+               (deleted (nth 4 candidates))
+               (eligible (nth 5 candidates))
+               (original (symbol-function 'pi-coding-agent--cool-tool-overlay)))
+          (should (= 6 (length candidates)))
+          (cl-labels
+              ((run-next
+                ()
+                (should (= 1 (length jobs)))
+                (pi-coding-agent-test--invoke-recorded-cooling-timer
+                 (pop jobs))))
+            (cl-letf (((symbol-function 'input-pending-p)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                       (lambda (overlay)
+                         (push overlay mutations)
+                         (funcall original overlay))))
+              ;; The boundary moved behind this queued overlay.
+              (move-marker pi-coding-agent--hot-tail-start
+                           (overlay-start inside) (current-buffer))
+              (run-next)
+              (should (overlay-buffer inside))
+              ;; The compatibility/current slot reclaimed this overlay.
+              (setq pi-coding-agent--pending-tool-overlay pending)
+              (run-next)
+              (setq pi-coding-agent--pending-tool-overlay nil)
+              (should (overlay-buffer pending))
+              ;; A keyed execution reclaimed this finalized block.
+              (let* ((record (overlay-get live
+                                          'pi-coding-agent-tool-block-record))
+                     (tool-call-id
+                      (pi-coding-agent--tool-block-tool-call-id record)))
+                (puthash tool-call-id record pi-coding-agent--live-tool-blocks)
+                (run-next)
+                (remhash tool-call-id pi-coding-agent--live-tool-blocks))
+              (should (overlay-buffer live))
+              ;; Completion metadata disappeared before this slice.
+              (overlay-put incomplete 'pi-coding-agent-header-end nil)
+              (run-next)
+              (should (overlay-buffer incomplete))
+              ;; A history rewrite may already have deleted a queued overlay.
+              (delete-overlay deleted)
+              (run-next)
+              ;; One still-valid candidate is rewritten normally.
+              (run-next)
+              (should-not (overlay-buffer eligible))
+              (should (equal mutations (list eligible)))
+              (should-not jobs)
+              (should-not pi-coding-agent--tool-cooling-queue)
+              (should-not pi-coding-agent--tool-cooling-timer))))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-cancel-invalidates-clear-and-history ()
+  "Clear and history rebuild make already-recorded cooling callbacks stale."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0)
+          (cool-calls 0))
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (dotimes (index 2)
+          (pi-coding-agent-test--render-completed-read-block
+           (format "clear-%d" index)))
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (let ((job (pop jobs))
+              (generation pi-coding-agent--tool-cooling-generation))
+          (pi-coding-agent--clear-render-artifacts)
+          (should (> pi-coding-agent--tool-cooling-generation generation))
+          (cl-letf (((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                     (lambda (&rest _)
+                       (setq cool-calls (1+ cool-calls)))))
+            (pi-coding-agent-test--invoke-recorded-cooling-timer job))
+          (should (= 0 cool-calls))
+          (should-not pi-coding-agent--tool-cooling-queue)
+          (should-not pi-coding-agent--tool-cooling-timer))
+        (dotimes (index 2)
+          (pi-coding-agent-test--render-completed-read-block
+           (format "history-%d" index)))
+        (pi-coding-agent--update-hot-tail-boundary)
+        (pi-coding-agent--queue-tool-cooling-outside-hot-tail)
+        (let ((job (pop jobs))
+              (generation pi-coding-agent--tool-cooling-generation))
+          (pi-coding-agent--display-session-history
+           [(:role "assistant" :content [(:type "text" :text "replacement")])]
+           (current-buffer))
+          (let ((history-text (buffer-string)))
+            (should (> pi-coding-agent--tool-cooling-generation generation))
+            (cl-letf (((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                       (lambda (&rest _)
+                         (setq cool-calls (1+ cool-calls)))))
+              (pi-coding-agent-test--invoke-recorded-cooling-timer job))
+            (should (equal history-text (buffer-string))))
+          (should (= 0 cool-calls))
+          (should-not jobs)
+          (should-not pi-coding-agent--tool-cooling-queue)
+          (should-not pi-coding-agent--tool-cooling-timer))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-cancel-invalidates-buffer-kill ()
+  "Killing a chat cancels cooling and makes its recorded callback harmless."
+  (let ((buffer (generate-new-buffer "*pi-coding-agent-test-cooling-kill*"))
+        (pi-coding-agent-quit-without-confirmation t)
+        cancelled
+        cool-calls)
+    (unwind-protect
+        (pi-coding-agent-test--with-recorded-cooling-timers jobs
+          (with-current-buffer buffer
+            (pi-coding-agent-chat-mode)
+            (let ((pi-coding-agent-hot-tail-turn-count 0))
+              (pi-coding-agent-test--render-completed-read-block "kill")
+              (pi-coding-agent--handle-display-event '(:type "agent_end")))
+            (let ((job (car jobs))
+                  (timer pi-coding-agent--tool-cooling-timer))
+              (cl-letf (((symbol-function 'cancel-timer)
+                         (lambda (owned-timer)
+                           (push owned-timer cancelled)))
+                        ((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                         (lambda (&rest _)
+                           (setq cool-calls (1+ (or cool-calls 0))))))
+                (kill-buffer buffer)
+                (should (memq timer cancelled))
+                (pi-coding-agent-test--invoke-recorded-cooling-timer job))
+              (should-not cool-calls))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-error-fails-closed ()
+  "A cooling error clears ownership, warns, and does not retry itself."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0)
+          warning)
+      (dotimes (index 2)
+        (pi-coding-agent-test--render-completed-read-block
+         (format "call-%d" index)))
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (let ((generation pi-coding-agent--tool-cooling-generation)
+              (job (pop jobs)))
+          (cl-letf (((symbol-function 'input-pending-p)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                     (lambda (&rest _)
+                       (error "synthetic cooling failure")))
+                    ((symbol-function 'display-warning)
+                     (lambda (&rest args)
+                       (setq warning args))))
+            (pi-coding-agent-test--invoke-recorded-cooling-timer job))
+          (should (> pi-coding-agent--tool-cooling-generation generation))
+          (should-not pi-coding-agent--tool-cooling-queue)
+          (should-not pi-coding-agent--tool-cooling-timer)
+          (should-not jobs)
+          (should (string-match-p
+                   "synthetic cooling failure"
+                   (format "%s" (nth 1 warning)))))
+        ;; A later explicit enqueue can own a fresh generation normally.
+        (pi-coding-agent--queue-tool-cooling-outside-hot-tail)
+        (should (= 2 (length pi-coding-agent--tool-cooling-queue)))
+        (should (= 1 (length jobs)))
+        (should pi-coding-agent--tool-cooling-timer)
+        (pi-coding-agent--cancel-tool-cooling)))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-quit-cancels-and-resignals ()
+  "A quit invalidates cooling without warning or retry, then propagates."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0)
+          caught warning)
+      (dotimes (index 2)
+        (pi-coding-agent-test--render-completed-read-block
+         (format "quit-%d" index)))
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (let ((generation pi-coding-agent--tool-cooling-generation)
+              (job (pop jobs)))
+          (cl-letf (((symbol-function 'input-pending-p)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                     (lambda (&rest _)
+                       (signal 'quit '(synthetic-cooling-quit))))
+                    ((symbol-function 'display-warning)
+                     (lambda (&rest args)
+                       (setq warning args))))
+            (condition-case error-data
+                (pi-coding-agent-test--invoke-recorded-cooling-timer job)
+              (quit
+               (setq caught error-data))))
+          (should (equal caught '(quit synthetic-cooling-quit)))
+          (should (> pi-coding-agent--tool-cooling-generation generation))
+          (should-not pi-coding-agent--tool-cooling-queue)
+          (should-not pi-coding-agent--tool-cooling-timer)
+          (should-not jobs)
+          (should-not warning))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-stale-a-leaves-b-owned ()
+  "A cancelled generation callback cannot clear or mutate generation B."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0)
+          mutations)
+      (pi-coding-agent-test--render-completed-read-block "generation")
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (let ((stale-job (pop jobs)))
+          (pi-coding-agent--cancel-tool-cooling)
+          (pi-coding-agent--queue-tool-cooling-outside-hot-tail)
+          (let ((generation-b pi-coding-agent--tool-cooling-generation)
+                (queue-b (copy-sequence pi-coding-agent--tool-cooling-queue))
+                (timer-b pi-coding-agent--tool-cooling-timer)
+                (job-b (car jobs)))
+            (cl-letf (((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                       (lambda (overlay)
+                         (push overlay mutations))))
+              (pi-coding-agent-test--invoke-recorded-cooling-timer stale-job))
+            (should (= generation-b pi-coding-agent--tool-cooling-generation))
+            (should (equal queue-b pi-coding-agent--tool-cooling-queue))
+            (should (eq timer-b pi-coding-agent--tool-cooling-timer))
+            (should-not mutations)
+            (should (eq job-b (pop jobs)))
+            (cl-letf (((symbol-function 'input-pending-p)
+                       (lambda (&rest _) nil)))
+              (pi-coding-agent-test--invoke-recorded-cooling-timer job-b))
+            (should-not jobs)
+            (should-not pi-coding-agent--tool-cooling-queue)
+            (should-not pi-coding-agent--tool-cooling-timer)))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-uses-latest-expanded-state ()
+  "A queued collapsed block cools from its live expanded state at execution."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0))
+      (let ((overlay
+             (pi-coding-agent-test--render-long-cooling-read-block
+              "latest-state" nil)))
+        (should-not (string-match-p "read body line 20" (buffer-string)))
+        (pi-coding-agent-test--with-recorded-cooling-timers jobs
+          (pi-coding-agent--handle-display-event '(:type "agent_end"))
+          (let ((button (pi-coding-agent--find-toggle-button-in-region
+                         (overlay-start overlay) (overlay-end overlay))))
+            (should button)
+            (pi-coding-agent--toggle-tool-output button))
+          (should (string-match-p "read body line 20" (buffer-string)))
+          (cl-letf (((symbol-function 'input-pending-p)
+                     (lambda (&rest _) nil)))
+            (pi-coding-agent-test--invoke-recorded-cooling-timer (pop jobs)))
+          (should (string-match-p "read body line 20" (buffer-string)))
+          (should-not (string-match-p "more lines" (buffer-string)))
+          (should-not (pi-coding-agent-test--all-tool-overlays))
+          (goto-char (point-min))
+          (search-forward "read body line 20")
+          (should (get-text-property
+                   (1- (point)) 'pi-coding-agent-cold-tool-block)))))))
+
+(ert-deftest pi-coding-agent-test-deferred-tool-cooling-second-enqueue-deduplicates ()
+  "A merged second enqueue drains once each from newest to oldest."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 0))
+      (dotimes (index 2)
+        (pi-coding-agent-test--render-completed-read-block
+         (format "call-%d" index)))
+      (pi-coding-agent-test--with-recorded-cooling-timers jobs
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (let ((timer pi-coding-agent--tool-cooling-timer))
+          (pi-coding-agent--handle-display-event '(:type "agent_end"))
+          (should (eq timer pi-coding-agent--tool-cooling-timer))
+          (should (= 2 (length pi-coding-agent--tool-cooling-queue)))
+          (should (= 2 (length (delete-dups
+                                (copy-sequence
+                                 pi-coding-agent--tool-cooling-queue)))))
+          (should (= 1 (length jobs)))
+          (pi-coding-agent-test--render-completed-read-block "call-new")
+          (pi-coding-agent--handle-display-event '(:type "agent_end"))
+          (should (eq timer pi-coding-agent--tool-cooling-timer))
+          (should (= 3 (length pi-coding-agent--tool-cooling-queue)))
+          (should (= 3 (length (delete-dups
+                                (copy-sequence
+                                 pi-coding-agent--tool-cooling-queue)))))
+          (should (= 1 (length jobs)))
+          (let ((expected (copy-sequence pi-coding-agent--tool-cooling-queue))
+                cooled
+                (original (symbol-function 'pi-coding-agent--cool-tool-overlay)))
+            (cl-letf (((symbol-function 'input-pending-p)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'pi-coding-agent--cool-tool-overlay)
+                       (lambda (overlay)
+                         (setq cooled (append cooled (list overlay)))
+                         (funcall original overlay))))
+              (while jobs
+                (pi-coding-agent-test--invoke-recorded-cooling-timer
+                 (pop jobs))))
+            (should (equal expected cooled))
+            (should-not pi-coding-agent--tool-cooling-queue)
+            (should-not pi-coding-agent--tool-cooling-timer)
+            (should-not (pi-coding-agent-test--all-tool-overlays))))))))
 
 (ert-deftest pi-coding-agent-test-cooled-file-target-preserves-local-authority-and-line-map ()
   "Cooling keeps a local tool path authoritative and maps only content lines."
@@ -3545,6 +4250,7 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
          :result (:content ((:type "text" :text "def two():\n    return 2")))
          :isError nil))
       (pi-coding-agent--handle-display-event '(:type "agent_end"))
+      (pi-coding-agent-test--drain-tool-cooling)
       ;; Old turn cooled
       (should (string-match-p
                (regexp-quote


### PR DESCRIPTION
Finishing a turn no longer rewrites every completed tool block inside
the process filter.  Older blocks are queued and cooled one at a time
by short deferred callbacks, yielding whenever input is waiting.

Deferred cooling preserves buffer and window positions, keeps the live
hot tail interactive, and discards stale work when history is rebuilt
or a chat is closed.  A deterministic benchmark now exercises a large
completed-tool cohort through the real agent_end path and records the
natural timer drain without imposing timing thresholds.