### PR TITLE
Clean up stale session checks and stabilize test feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,15 +134,16 @@ make test-integration-real     # real only
 
 Run a filtered subset by ERT pattern:
 ```bash
-make test SELECTOR=fontify-buffer-tail
 make test SELECTOR=toolcall-delta
 make test SELECTOR='abort\|followup'
 make test-integration-fake SELECTOR=rpc-smoke
 make test-integration-real SELECTOR=steering-contract
 ```
 
-The `SELECTOR` value is an ERT selector string — a substring match
-against test names.
+The `SELECTOR` value is exported unchanged and interpreted by ERT as an
+Emacs regexp matched against test names.  For alternation, single-quote the
+shell value and use one backslash as above; `SELECTOR='abort\\|followup'`
+passes two backslashes and does not mean regexp alternation.
 
 `make test` is intentionally terse on green runs (summary-focused output).
 For full raw ERT output, use:

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ PI_PACKAGE ?= @earendil-works/pi-coding-agent
 PI_BIN ?= .cache/pi/node_modules/.bin/pi
 PI_BIN_DIR = $(abspath $(dir $(PI_BIN)))
 
-# Test selector: run a subset of tests by ERT pattern
-# Example: make test SELECTOR=fontify-buffer-tail
+# Test selector: exported unchanged and interpreted by ERT as an Emacs regexp
+# Examples: make test SELECTOR=toolcall-delta
+#           make test SELECTOR='abort\|followup'  # one regexp backslash
 SELECTOR ?=
 
 # Verbose output for tests (show full ERT output, including passed lines)

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -736,24 +736,6 @@ preflight before the agent turn has started.")
   "Current state of the pi session (buffer-local in chat buffer).
 A plist with keys like :model, :thinking-level, :messages, etc.")
 
-(defvar-local pi-coding-agent--state-timestamp nil
-  "Time when state was last updated (buffer-local in chat buffer).")
-
-(defconst pi-coding-agent--state-verify-interval 30
-  "Seconds between state verification checks.")
-
-(defun pi-coding-agent--state-needs-verification-p ()
-  "Return t if state should be verified with get_state.
-Verification is needed when:
-- State and timestamp exist
-- Session status is `idle'
-- Timestamp is older than `pi-coding-agent--state-verify-interval' seconds."
-  (and pi-coding-agent--state
-       pi-coding-agent--state-timestamp
-       (eq pi-coding-agent--status 'idle)
-       (> (- (float-time) pi-coding-agent--state-timestamp)
-          pi-coding-agent--state-verify-interval)))
-
 (defun pi-coding-agent--json-false-p (value)
   "Return t if VALUE represents JSON false.
 `json-parse-string' yields `:false', while older helpers and tests may still
@@ -810,16 +792,14 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
       ("agent_start"
        (setq pi-coding-agent--status 'streaming)
        (plist-put pi-coding-agent--state :is-retrying nil)
-       (plist-put pi-coding-agent--state :last-error nil)
-       (setq pi-coding-agent--state-timestamp (float-time)))
+       (plist-put pi-coding-agent--state :last-error nil))
       ("agent_end"
        (setq pi-coding-agent--status
              (if (pi-coding-agent--normalize-boolean (plist-get event :willRetry))
                  'sending
                'idle))
        (plist-put pi-coding-agent--state :is-retrying nil)
-       (plist-put pi-coding-agent--state :messages (plist-get event :messages))
-       (setq pi-coding-agent--state-timestamp (float-time)))
+       (plist-put pi-coding-agent--state :messages (plist-get event :messages)))
       ("message_start"
        (plist-put pi-coding-agent--state :current-message (plist-get event :message)))
       ("message_end"
@@ -834,8 +814,7 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
        (setq pi-coding-agent--pre-compaction-status
              (unless (eq pi-coding-agent--status 'compacting)
                pi-coding-agent--status))
-       (setq pi-coding-agent--status 'compacting)
-       (setq pi-coding-agent--state-timestamp (float-time)))
+       (setq pi-coding-agent--status 'compacting))
       ("compaction_end"
        (setq pi-coding-agent--status
              (cond
@@ -845,8 +824,7 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
                'sending)
               (t
                'idle)))
-       (setq pi-coding-agent--pre-compaction-status nil)
-       (setq pi-coding-agent--state-timestamp (float-time)))
+       (setq pi-coding-agent--pre-compaction-status nil))
       ("auto_retry_start"
        (setq pi-coding-agent--status 'sending)
        (plist-put pi-coding-agent--state :is-retrying t)
@@ -899,24 +877,18 @@ Only processes successful responses for state-modifying commands."
           (data (plist-get response :data)))
       (pcase command
         ("set_model"
-         (plist-put pi-coding-agent--state :model data)
-         (setq pi-coding-agent--state-timestamp (float-time)))
+         (plist-put pi-coding-agent--state :model data))
         ("cycle_model"
          (when data
            (plist-put pi-coding-agent--state :model (plist-get data :model))
-           (plist-put pi-coding-agent--state :thinking-level (plist-get data :thinkingLevel))
-           (setq pi-coding-agent--state-timestamp (float-time))))
+           (plist-put pi-coding-agent--state :thinking-level (plist-get data :thinkingLevel))))
         ("cycle_thinking_level"
          (when data
-           (plist-put pi-coding-agent--state :thinking-level (plist-get data :level))
-           (setq pi-coding-agent--state-timestamp (float-time))))
-        ("set_thinking_level"
-         (setq pi-coding-agent--state-timestamp (float-time)))
+           (plist-put pi-coding-agent--state :thinking-level (plist-get data :level))))
         ("get_state"
          (let ((new-state (pi-coding-agent--extract-state-from-response response)))
            (setq pi-coding-agent--status (plist-get new-state :status)
-                 pi-coding-agent--state new-state
-                 pi-coding-agent--state-timestamp (float-time))))))))
+                 pi-coding-agent--state new-state)))))))
 
 (defun pi-coding-agent--extract-state-from-response (response &optional anchor)
   "Extract state plist from a get_state RESPONSE.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1012,6 +1012,7 @@ Include optional STDERR in a text fence and optional DETAIL before it."
             (assoc-delete-all key pi-coding-agent--extension-status)))
     (force-mode-line-update t)))
 
+;; Pi RPC currently suppresses this method; retain client protocol support.
 (defun pi-coding-agent--extension-ui-set-working-message (event)
   "Handle setWorkingMessage method from EVENT."
   (let ((msg (plist-get event :message)))
@@ -1163,7 +1164,6 @@ which asks upfront before any buffers are touched."
   (when (eq pi-coding-agent--process process)
     (let ((error-msg (or (plist-get response :error) "Process exited")))
       (setq pi-coding-agent--status 'idle)
-      (setq pi-coding-agent--state-timestamp (float-time))
       (setq pi-coding-agent--state
             (plist-put pi-coding-agent--state :last-error error-msg))
       (unwind-protect

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -929,41 +929,6 @@ Display is handled by the display handler, not by state updates."
        :error "Model not found"))
     (should (equal (plist-get (plist-get pi-coding-agent--state :model) :id) "original"))))
 
-(ert-deftest pi-coding-agent-test-state-needs-verify-when-stale ()
-  "State needs verification when timestamp is old."
-  (let ((pi-coding-agent--status 'idle)
-        (pi-coding-agent--state (list :model "test"))
-        (pi-coding-agent--state-timestamp (- (float-time) 60)))  ;; 60 seconds ago
-    (should (pi-coding-agent--state-needs-verification-p))))
-
-(ert-deftest pi-coding-agent-test-state-no-verify-when-fresh ()
-  "State does not need verification when recently updated."
-  (let ((pi-coding-agent--status 'idle)
-        (pi-coding-agent--state (list :model "test"))
-        (pi-coding-agent--state-timestamp (float-time)))  ;; Now
-    (should (not (pi-coding-agent--state-needs-verification-p)))))
-
-(ert-deftest pi-coding-agent-test-state-no-verify-during-streaming ()
-  "State does not need verification while streaming."
-  (let ((pi-coding-agent--status 'streaming)
-        (pi-coding-agent--state (list :model "test"))
-        (pi-coding-agent--state-timestamp (- (float-time) 60)))  ;; Old, but streaming
-    (should (not (pi-coding-agent--state-needs-verification-p)))))
-
-(ert-deftest pi-coding-agent-test-state-no-verify-while-sending ()
-  "State does not need verification while waiting for agent_start."
-  (let ((pi-coding-agent--status 'sending)
-        (pi-coding-agent--state (list :model "test"))
-        (pi-coding-agent--state-timestamp (- (float-time) 60)))
-    (should (not (pi-coding-agent--state-needs-verification-p)))))
-
-(ert-deftest pi-coding-agent-test-state-no-verify-when-no-timestamp ()
-  "State does not need verification when not initialized."
-  (let ((pi-coding-agent--status 'idle)
-        (pi-coding-agent--state nil)
-        (pi-coding-agent--state-timestamp nil))
-    (should (not (pi-coding-agent--state-needs-verification-p)))))
-
 (ert-deftest pi-coding-agent-test-event-dispatch-updates-state ()
   "Events update buffer-local state via handler."
   (let ((pi-coding-agent--status 'idle)

--- a/test/pi-coding-agent-gui-tests.el
+++ b/test/pi-coding-agent-gui-tests.el
@@ -330,12 +330,14 @@ logical block and should not start following later streamed output."
       (kill-buffer buf))))
 
 (ert-deftest pi-coding-agent-gui-test-table-resize-refreshes-hot-tail-only ()
-  "Resizing the frame rewraps hot tables only and preserves scroll position."
+  "Resizing rewraps hot tables only and preserves context below the table."
   (pi-coding-agent-gui-test-with-fresh-session
     (:backend fake :fake-scenario "prompt-lifecycle")
     (let* ((chat-buf (plist-get pi-coding-agent-gui-test--session :chat-buffer))
            (frame (selected-frame))
            (orig-width (frame-width))
+           chat-win
+           initial-chat-width
            (cold-table
             "| Feature | Notes |\n|---------|-------|\n| Cold history | This older table was wrapped at the original wide width and should stay frozen after resize |\n")
            (hot-table
@@ -343,7 +345,8 @@ logical block and should not start following later streamed output."
            cold-before
            hot-before
            cold-start
-           hot-start)
+           hot-start
+           filler-start)
       (unwind-protect
           (progn
             (with-current-buffer chat-buf
@@ -353,32 +356,61 @@ logical block and should not start following later streamed output."
                 (setq cold-start (point))
                 (insert cold-table "\nAssistant\n=========\nRecent reply\n\nYou · 10:05\n===========\n")
                 (setq hot-start (point))
-                (insert hot-table)
+                ;; Terminate the Markdown table before adding scrollable context.
+                ;; Without the blank line, tree-sitter treats every filler line
+                ;; as a lazy continuation row inside one giant table.
+                (insert hot-table "\n")
+                (setq filler-start (point))
                 (dotimes (i 80)
                   (insert (format "filler line %d\n" i))))
               (font-lock-ensure)
-              (let* ((chat-win (pi-coding-agent-gui-test-chat-window))
-                     (initial-width (window-width chat-win)))
-                (pi-coding-agent--decorate-tables-in-region
-                 (point-min) (point-max) initial-width)
-                (move-marker pi-coding-agent--hot-tail-start hot-start)
-                (setq cold-before
-                      (pi-coding-agent-gui-test--table-display-strings
-                       cold-start hot-start)
-                      hot-before
-                      (pi-coding-agent-gui-test--table-display-strings
-                       hot-start (point-max)))))
+              (setq chat-win (pi-coding-agent-gui-test-chat-window)
+                    initial-chat-width (window-width chat-win))
+              (pi-coding-agent--decorate-tables-in-region
+               (point-min) (point-max) initial-chat-width)
+              (move-marker pi-coding-agent--hot-tail-start hot-start)
+              (setq cold-before
+                    (pi-coding-agent-gui-test--table-display-strings
+                     cold-start hot-start)
+                    hot-before
+                    (pi-coding-agent-gui-test--table-display-strings
+                     hot-start filler-start))
+              (should cold-before)
+              (should hot-before)
+              (should-not
+               (pi-coding-agent-gui-test--table-display-strings
+                filler-start (point-max))))
             (redisplay)
             (pi-coding-agent-gui-test-scroll-up 20)
             (let ((line-before (pi-coding-agent-gui-test-top-line-number)))
               (set-frame-size frame (- orig-width 30) (frame-height))
               (redisplay)
-              (should (pi-coding-agent-test-wait-until
+              (unless (pi-coding-agent-test-wait-until
                        (lambda ()
-                         (not (equal hot-before
-                                     (pi-coding-agent-gui-test--table-display-strings
-                                      hot-start (point-max)))))
-                       2 0.05))
+                         (< (window-width chat-win) initial-chat-width))
+                       2 0.05)
+                (ert-skip
+                 (format
+                  (concat "Window manager did not honor resize request from "
+                          "frame width %d to %d: chat window width %d is not "
+                          "narrower than its initial width %d")
+                  orig-width (- orig-width 30)
+                  (window-width chat-win) initial-chat-width)))
+              ;; X11 can report the new width while a synchronous ERT body has
+              ;; not re-entered the command-loop redisplay that delivers this
+              ;; buffer-local hook.  Exercise our registered callback in the
+              ;; same selected-window context Emacs documents for the hook.
+              (with-selected-window chat-win
+                (should
+                 (memq #'pi-coding-agent--maybe-refresh-hot-tail-tables
+                       window-configuration-change-hook))
+                (run-hooks 'window-configuration-change-hook)
+                (should (= pi-coding-agent--last-table-display-width
+                           (pi-coding-agent--chat-window-width))))
+              (should-not
+               (equal hot-before
+                      (pi-coding-agent-gui-test--table-display-strings
+                       hot-start filler-start)))
               (should (equal cold-before
                              (pi-coding-agent-gui-test--table-display-strings
                               cold-start hot-start)))

--- a/test/run-gui-tests.sh
+++ b/test/run-gui-tests.sh
@@ -99,6 +99,7 @@ cat >> "$RUNNER_FILE" << EOF
 
 (let* ((selector $SELECTOR)
        (passed 0)
+       (skipped 0)
        (failed 0)
        (total 0)
        (test-list (pi-coding-agent-gui-test--order-tests (ert-select-tests selector t))))
@@ -118,6 +119,14 @@ cat >> "$RUNNER_FILE" << EOF
             (setq passed (1+ passed))
             (pi-coding-agent-gui-test--log "  [%d/%d] PASS: %s (%s)" n total name elapsed)
             (insert (format "  PASS: %s (%s)\n" name elapsed)))
+           ((ert-test-skipped-p result)
+            (setq skipped (1+ skipped))
+            (let ((reason
+                   (error-message-string
+                    (ert-test-result-with-condition-condition result))))
+              (pi-coding-agent-gui-test--log
+               "  [%d/%d] SKIP: %s (%s): %s" n total name elapsed reason)
+              (insert (format "  SKIP: %s (%s): %s\n" name elapsed reason))))
            (t
             (setq failed (1+ failed))
             (pi-coding-agent-gui-test--log "  [%d/%d] FAIL: %s (%s)" n total name elapsed)
@@ -146,9 +155,12 @@ cat >> "$RUNNER_FILE" << EOF
                   (pi-coding-agent-gui-test--log "  --- Chat buffer content ---")
                   (pi-coding-agent-gui-test--log "%s" (with-current-buffer chat-buf (buffer-string)))
                   (pi-coding-agent-gui-test--log "  --- End chat buffer ---")))))))))
-    (insert (format "\n=== %d tests: %d passed, %d failed ===\n" total passed failed))
+    (insert (format "\n=== %d tests: %d passed, %d skipped, %d failed ===\n"
+                    total passed skipped failed))
     (write-region (point-min) (point-max) pi-coding-agent-gui-test--output-file))
-  (pi-coding-agent-gui-test--log "=== %d tests: %d passed, %d failed ===" total passed failed)
+  (pi-coding-agent-gui-test--log
+   "=== %d tests: %d passed, %d skipped, %d failed ==="
+   total passed skipped failed)
   (kill-emacs (if (> failed 0) 1 0)))
 EOF
 


### PR DESCRIPTION
## Why

A maintenance review around #253 found unused session-verification scaffolding, stale filtered-test guidance, and a malformed Markdown fixture that made a GUI resize check intermittent.

This cleanup does not implement the watchdog proposed in #253.

## Changes

- Remove the unused state-verification predicate, interval, timestamps, and isolated tests while preserving live state updates.
- Retain forward-compatible `setWorkingMessage` handling and document Pi RPC's current no-op behavior.
- Replace a stale filtered-test example and document ERT regexp escaping through Make.
- Terminate the GUI table fixture before filler text, scope overlay comparisons to the table, and verify filler receives no table overlays.
- Skip the resize assertion only when the window manager demonstrably refuses to narrow the chat window, and report ERT skips correctly in the GUI runner.

## Verification

- `make check` — 1,642 tests, 0 unexpected
- Native PGTK GUI suite — 15 passed, 1 unsupported-resize skip
- X11 and xvfb GUI suites — 16/16 passed with the resize path exercised
- Focused resize test — reproduced 1/15 on master and 1/6 on #221; 50/50 passed after fixing the fixture
- Selector check — one-backslash alternation ran 36 tests; the stale selector matched none
