### PR TITLE
Polish prose left awkward by the piem rename

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@
 #+html: <a href="#advanced-features-and-configuration">Advanced</a> ·
 #+html: <a href="#development">Development</a></p>
 
-* What is piem for Emacs? 🦬
+* What is piem? 🦬
 
 =piem= is an Emacs frontend for [[https://pi.dev][Pi]].  The Pi CLI still runs
 the agent, talks to models, and executes tools.  This package wraps Pi
@@ -132,7 +132,7 @@ session.
 
 ** Upgrading from pi-coding-agent ⬆️
 
-=piem= 3.0 is the renamed =pi-coding-agent= package (the rename was
+=piem= 3.0 is the renamed =pi-coding-agent= package (now
 [[https://github.com/dnouri/piem][dnouri/piem]] on GitHub).  Old
 configurations keep working through a compatibility stub, with one
 required step and two caveats:
@@ -276,7 +276,7 @@ the file.  Coordinates apply only to file-visiting buffers; directory targets
 retain native Dired point and marks.  A target without a location keeps the
 point, mark, and narrowing chosen by normal Emacs file visiting.
 
-By default Pi requests the native other-window opener.  Use =C-u RET= to invert
+By default piem requests the native other-window opener.  Use =C-u RET= to invert
 =piem-visit-file-other-window= for that visit; with the default
 setting this requests the same-window opener instead.  Emacs display policy may
 redirect the final placement.
@@ -712,7 +712,7 @@ C-p e=) or run =/export=.
 
 ** Extension support 🧩
 
-The =piem= Emacs frontend has basic support for Pi
+=piem= has basic support for Pi
 extensions.  Extension commands show up in slash completion and the
 transient menu, extension tools run normally, and extensions can use
 notifications, confirm/select/input prompts, prefill the input buffer,

--- a/piem-ui.el
+++ b/piem-ui.el
@@ -2320,7 +2320,7 @@ Stores the result in CHAT-BUF and emits a minibuffer notice when available."
 
 (defun piem--format-startup-header ()
   "Format the startup header string with styled separator."
-  (let ((separator (piem--make-separator "Pi Coding Agent for Emacs")))
+  (let ((separator (piem--make-separator "piem")))
     (concat
      separator "\n"
      "C-c C-c   send prompt\n"

--- a/test/piem-ui-test.el
+++ b/test/piem-ui-test.el
@@ -852,11 +852,6 @@ without an input window."
 
 ;;; Startup Header
 
-(ert-deftest piem-test-startup-header-shows-version ()
-  "Startup header includes version."
-  (let ((header (piem--format-startup-header)))
-    (should (string-match-p "Pi" header))))
-
 (ert-deftest piem-test-startup-header-shows-keybindings ()
   "Startup header includes key keybindings."
   (let ((header (piem--format-startup-header)))
@@ -865,10 +860,10 @@ without an input window."
     (should (string-match-p "C-c C-a   attach image (C-u clears)" header))
     (should (string-match-p "C-c C-r   sessions" header))))
 
-(ert-deftest piem-test-startup-header-shows-pi-label ()
-  "Startup header includes the product label."
+(ert-deftest piem-test-startup-header-shows-label ()
+  "Startup header labels the buffer with the package name."
   (let ((header (piem--format-startup-header)))
-    (should (string-match-p "^Pi Coding Agent for Emacs$" header))))
+    (should (string-match-p "^piem$" header))))
 
 (ert-deftest piem-test-extract-pi-version-from-clean-output ()
   "Extract the plain semantic version returned by pi."


### PR DESCRIPTION
Follow-up to the v3.0.0 rename (#277): the mechanical substitution left a few spots reading badly, and one user-facing string escaped it entirely.

- README title: `What is piem for Emacs?` → `What is piem?` — piem *is* the Emacs package
- README upgrade note: `(the rename was dnouri/piem on GitHub)` didn't parse → `(now …)`
- README: the file-visit other-window opener is requested by piem, not the Pi CLI
- README extensions: drop the tautological `The piem Emacs frontend`
- Startup banner still said `Pi Coding Agent for Emacs` — the title-cased variant escaped the hyphen-based rename; now `piem`, matching the `You`/`Assistant` separator-label convention
- Tests: label test asserts `^piem$`; dropped the vestigial `shows-version` test, which only ever matched `Pi`

Left alone deliberately: `@earendil-works/pi-coding-agent` (the CLI's npm name), the *Upgrading from pi-coding-agent* section, the compat shim, and the demo media URLs (no piem-named files are actually hosted).

Evidence: `make check` green (1693 tests, 1 pre-existing skip); `make lint` clean.