### PR TITLE
Quote magit-section and md-ts-mode in docstrings

### DIFF
--- a/pi-coding-agent-browse.el
+++ b/pi-coding-agent-browse.el
@@ -754,7 +754,7 @@ Inherits section navigation from `magit-section-mode'."
       (pi-coding-agent--session-browser-insert-session item 0 nil))))
 
 (defun pi-coding-agent--session-browser-insert-session (session depth threaded)
-  "Insert SESSION as a magit-section at DEPTH.
+  "Insert SESSION as a `magit-section' section at DEPTH.
 When THREADED is non-nil, prepend threading connector at DEPTH.
 In non-threaded modes, forked sessions get a \"fork:\" prefix.
 Message count and age are rendered as a right-margin overlay."
@@ -1147,7 +1147,7 @@ Wrapped because that alist is a private Magit internal; if Magit ever
 changes the mechanism, this is the single place to adapt.
 
 Unregistered types (e.g. the `time-group' headings, which are not
-interactive) silently fall back to the plain `magit-section' class;
+interactive) silently fall back to the plain `magit-section' section class;
 that is fine for display-only sections."
   (setf (alist-get 'session magit--section-type-alist)
         'pi-coding-agent-session-section)

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -5084,7 +5084,7 @@ or LIMIT for an incomplete streamed tail."
 (defun pi-coding-agent--semantic-link-markdown-host-parser ()
   "Return md-ts-mode's trustworthy canonical Markdown host parser.
 The canonical host parser is the sole unrestricted Markdown parser whose
-actual root covers the accessible buffer and lookup position.  md-ts-mode uses
+actual root covers the accessible buffer and lookup position.  `md-ts-mode' uses
 that shape for its document parser and restricted, no-reuse parsers for local
 work.  Requiring this shape avoids parser-list ordering and refuses ambiguous
 or partial host state rather than querying the wrong Markdown document."
@@ -5114,7 +5114,7 @@ or partial host state rather than querying the wrong Markdown document."
 
 (defun pi-coding-agent--semantic-link-inline-host-node-at-point ()
   "Return the Markdown host node whose inline grammar owns point.
-Installed md-ts-mode injects `markdown-inline' only into Markdown `inline' and
+Installed `md-ts-mode' injects `markdown-inline' only into Markdown `inline' and
 `pipe_table_cell' nodes.  Consult its canonical unrestricted host tree so
 fenced/indented code, reference definitions, restricted competing parsers, and
 other block source cannot be reinterpreted merely because it resembles inline
@@ -5450,7 +5450,7 @@ single semantic owner at point before projecting only that owner's label.  This
 keeps deeply nested/recovery trees linear and fails ambiguity closed before
 expensive projection.  All node types, bounds, labels, and destinations are
 copied to a plist before deleting the parser; no caller observes a tree node
-after its parser lifetime.  Installed md-ts-mode 0.3 creates its own local
+after its parser lifetime.  Installed `md-ts-mode' 0.3 creates its own local
 inline parsers lazily during fontification and exposes no public link resolver.
 This parser never changes text, overlays, font-lock properties, visibility, or
 the mode's parser set."
@@ -5705,7 +5705,7 @@ identity before its first error is re-signaled."
   "Return explicit tri-state semantic Markdown link resolution at point.
 The `:status' value is exactly one of `:not-a-link', `:owned-valid', or
 `:owned-invalid'.  Ownership is source/tree based, independent of font-lock,
-invisibility, faces, buttons, file existence, and unreleased md-ts-mode APIs.
+invisibility, faces, buttons, file existence, and unreleased `md-ts-mode' APIs.
 This distinction prevents an owned non-file or malformed link from falling
 through to a path-like visible label.
 


### PR DESCRIPTION
Six docstrings (2 in `pi-coding-agent-browse.el`, 4 in `pi-coding-agent-render.el`) refer to symbols without quote markup; quote them so docstring conventions and lint treat them as symbol references. No behavior change.

Salvaged from #278.