### PR TITLE
Drop vestigial startup-header shows-version test

### DIFF
--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -852,11 +852,6 @@ without an input window."
 
 ;;; Startup Header
 
-(ert-deftest pi-coding-agent-test-startup-header-shows-version ()
-  "Startup header includes version."
-  (let ((header (pi-coding-agent--format-startup-header)))
-    (should (string-match-p "Pi" header))))
-
 (ert-deftest pi-coding-agent-test-startup-header-shows-keybindings ()
   "Startup header includes key keybindings."
   (let ((header (pi-coding-agent--format-startup-header)))


### PR DESCRIPTION
`startup-header-shows-version` never asserted a version — only the substring "Pi" — and `shows-pi-label`'s exact `^Pi Coding Agent for Emacs$` assertion already covers it.

Salvaged from #279.