### PR TITLE
Move image attach from C-c C-a into the menu (C-c C-p a i)

### DIFF
--- a/README.org
+++ b/README.org
@@ -202,9 +202,9 @@ registers, spell checks, Evil, or whatever else your setup already
 gives you.  Your prompt stays in the bottom window while the
 conversation streams above it.
 
-Press =C-c C-a= to attach one image: select a file, or paste its path
-into the file prompt.  Attaching another image replaces the first;
-=C-u C-c C-a= clears it.  The header line keeps the attached basename
+Press =C-c C-p a i= to attach one image: select a file, or paste its
+path into the file prompt.  Attaching another image replaces the first;
+=C-u= before the =i= clears it.  The header line keeps the attached basename
 and size visible.  The file is read and materialized when attached,
 and PNG, JPEG, GIF, and WebP are recognized from their content rather
 than their extension.  The default source limit is 3 MiB.  Send it
@@ -335,8 +335,8 @@ configured warning and error thresholds.
 | Key              | Context | Description                                    |
 |------------------+---------+------------------------------------------------|
 | =C-c C-c=        | input   | 📮 Send prompt, or queue follow-up if busy    |
-| =C-c C-a=        | input   | 🖼️ Attach or replace one prompt image         |
-| =C-u C-c C-a=    | input   | 🧹 Clear the attached prompt image            |
+| =C-c C-p a i=    | menu    | 🖼️ Attach or replace one prompt image         |
+| =C-u … a i=      | menu    | 🧹 Clear the attached prompt image            |
 | =C-c C-s=        | input   | 🐎 Send steering message while Pi is busy     |
 | =C-c C-k=        | input   | 🪓 Abort current response or compaction       |
 | =C-c C-p=        | input   | 🎛️ Open transient menu                        |

--- a/pilish-input.el
+++ b/pilish-input.el
@@ -33,7 +33,7 @@
 ;;
 ;; Key entry points:
 ;;   `pilish-send'                  Send prompt (C-c C-c)
-;;   `pilish-attach-image'          Attach one prompt image (C-c C-a)
+;;   `pilish-attach-image'          Attach one prompt image (menu C-c C-p a i)
 ;;   `pilish-abort'                 Abort current operation (C-c C-k)
 ;;   `pilish-quit'                  Close session
 ;;   `pilish-previous-input'        History backward (M-p)

--- a/pilish-menu.el
+++ b/pilish-menu.el
@@ -1366,6 +1366,7 @@ Uses commands from pi's `get_commands' RPC."
    ["Actions"
     ("RET" "send" pilish-send)
     ("s" "steer" pilish-queue-steering)
+    ("a" "attach" pilish-attach-menu)
     ("k" "abort" pilish-abort)]]
   [["Model"
     ("m" "select" pilish-select-model)
@@ -1376,6 +1377,14 @@ Uses commands from pi's `get_commands' RPC."
    ["Info"
     ("i" "stats" pilish-session-stats)
     ("y" "copy last" pilish-copy-last-message)]])
+
+(transient-define-prefix pilish-attach-menu ()
+  "Attach objects to the current prompt draft.
+Each entry attaches to the input buffer's draft; a prefix argument
+clears the attachment instead.  Object-specific keys leave room for
+future attachment kinds such as video or files."
+  ["Attach"
+   ("i" "image" pilish-attach-image)])
 
 (defun pilish-refresh-commands ()
   "Refresh commands from pi via RPC."

--- a/pilish-ui.el
+++ b/pilish-ui.el
@@ -927,7 +927,6 @@ removing the instructional header that would otherwise appear."
 (defvar pilish-input-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") #'pilish-send)
-    (define-key map (kbd "C-c C-a") #'pilish-attach-image)
     (define-key map (kbd "TAB") #'pilish-complete)
     (define-key map (kbd "C-c C-k") #'pilish-abort)
     (define-key map (kbd "C-c C-p") #'pilish-menu)
@@ -2324,7 +2323,6 @@ Stores the result in CHAT-BUF and emits a minibuffer notice when available."
     (concat
      separator "\n"
      "C-c C-c   send prompt\n"
-     "C-c C-a   attach image (C-u clears)\n"
      "C-c C-k   abort\n"
      "C-c C-r   sessions\n"
      "C-c C-p   menu\n")))

--- a/pilish.el
+++ b/pilish.el
@@ -58,7 +58,6 @@
 ;; Key Bindings:
 ;;   Input buffer:
 ;;     C-c C-c        Send prompt (queues text as follow-up if busy)
-;;     C-c C-a        Attach/replace one prompt image (C-u clears)
 ;;     C-c C-s        Queue steering (interrupts after current tool; busy only)
 ;;     C-c C-k        Abort current operation
 ;;     C-c C-p        Open menu

--- a/test/pilish-input-test.el
+++ b/test/pilish-input-test.el
@@ -2718,18 +2718,18 @@ Pi handles command expansion on the server side."
       (delete-process fake-proc))))
 
 (ert-deftest pilish-test-prompt-image-png-end-to-end ()
-  "C-c C-a content-sniffs a misleadingly named PNG for exact RPC content."
+  "Menu attach-image entry content-sniffs a misleadingly named PNG for exact RPC content."
   (pilish-test-with-prompt-image-session (dir chat-buf input-buf)
     (let* ((path (pilish-test--write-prompt-image
                   (expand-file-name "pixel.txt" dir) 'png))
            (data (pilish-test--prompt-image-base64 'png))
            rpc-message)
       (with-current-buffer input-buf
-        (pilish-test--attach-image-via-key path)
+        (pilish-test--attach-image-via-menu path)
         (should (string-match-p "pixel.txt" (pilish-test--input-header)))
-        (pilish-test--attach-image-via-key path 'clear)
+        (pilish-test--attach-image-via-menu path 'clear)
         (should-not (string-match-p "pixel.txt" (pilish-test--input-header)))
-        (pilish-test--attach-image-via-key path)
+        (pilish-test--attach-image-via-menu path)
         (delete-file path)
         (insert "Describe the pixel")
         (cl-letf (((symbol-function 'pilish--get-process)
@@ -2784,7 +2784,7 @@ Pi handles command expansion on the server side."
         (dolist (spec '((jpeg "photo.jpg") (gif "pixel.gif")
                         (webp "pixel.webp")))
           (when previous
-            (pilish-test--attach-image-via-key previous 'clear))
+            (pilish-test--attach-image-via-menu previous 'clear))
           (setq previous
                 (pilish-test--write-prompt-image
                  (expand-file-name (cadr spec) dir) (car spec)))
@@ -2792,7 +2792,7 @@ Pi handles command expansion on the server side."
           (should (string-match-p
                    (regexp-quote (file-name-nondirectory previous))
                    (pilish-test--input-header))))
-        (pilish-test--attach-image-via-key previous 'clear))
+        (pilish-test--attach-image-via-menu previous 'clear))
       (let* ((not-image (expand-file-name "not-image.txt" dir))
              (too-large (pilish-test--write-prompt-image
                          (expand-file-name "too-large.png" dir) 'png)))
@@ -2862,7 +2862,7 @@ Pi handles command expansion on the server side."
               (should-not builtin-called)
               (should (string-match-p reason (downcase (or feedback "")))))
           (with-current-buffer input-buf
-            (pilish-test--attach-image-via-key path 'clear))))))))
+            (pilish-test--attach-image-via-menu path 'clear))))))))
 
 (ert-deftest pilish-test-prompt-image-waits-for-model-change ()
   "Image send waits for model selection, then uses the accepted model state."

--- a/test/pilish-menu-test.el
+++ b/test/pilish-menu-test.el
@@ -570,6 +570,13 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
     (pilish-input-mode)
     (should (eq (key-binding (kbd "C-c C-p")) 'pilish-menu))))
 
+(ert-deftest pilish-test-attach-routes-through-menu-submenu ()
+  "Menu `a' opens the attach submenu; its `i' attaches prompt images."
+  (should (eq (pilish-test--menu-suffix-command 'pilish-menu "a")
+              'pilish-attach-menu))
+  (should (eq (pilish-test--menu-suffix-command 'pilish-attach-menu "i")
+              'pilish-attach-image)))
+
 ;;; Chat Navigation
 
 (ert-deftest pilish-test-chat-has-navigation-keys ()

--- a/test/pilish-test-common.el
+++ b/test/pilish-test-common.el
@@ -289,11 +289,16 @@ Uses tool call ID \"call_1\" and contentIndex 0."
   (cl-letf (((symbol-function 'read-file-name) (lambda (&rest _) path)))
     (call-interactively #'pilish-attach-image)))
 
-(defun pilish-test--attach-image-via-key (path &optional clear)
-  "Invoke the input binding for PATH, with prefix argument when CLEAR."
+(defun pilish-test--menu-suffix-command (prefix key)
+  "Return the command bound to KEY in transient PREFIX's layout."
+  (plist-get (cdr (transient-get-suffix prefix key)) :command))
+
+(defun pilish-test--attach-image-via-menu (path &optional clear)
+  "Invoke the attach-menu image entry for PATH, with prefix arg when CLEAR."
   (cl-letf (((symbol-function 'read-file-name) (lambda (&rest _) path)))
-    (let ((current-prefix-arg (and clear '(4))))
-      (call-interactively (key-binding (kbd "C-c C-a"))))))
+    (let* ((command (pilish-test--menu-suffix-command 'pilish-attach-menu "i"))
+           (current-prefix-arg (and clear '(4))))
+      (call-interactively command))))
 
 (cl-defmacro pilish-test-with-prompt-image-session
     ((dir chat-buf input-buf) &rest body)

--- a/test/pilish-ui-test.el
+++ b/test/pilish-ui-test.el
@@ -857,7 +857,6 @@ without an input window."
   (let ((header (pilish--format-startup-header)))
     (should (string-match-p "C-c C-c" header))
     (should (string-match-p "send" header))
-    (should (string-match-p "C-c C-a   attach image (C-u clears)" header))
     (should (string-match-p "C-c C-r   sessions" header))))
 
 (ert-deftest pilish-test-startup-header-shows-label ()


### PR DESCRIPTION
Attaching no longer has its own chord. The transient menu gains an "attach" entry that opens a submenu of attachment kinds; `i` attaches one prompt image, and `C-u` before it clears the draft image. The submenu layout leaves room for future kinds such as video or file attachments once pi's RPC grows beyond images.

Also drops the attach line from the startup header and updates README, code commentary, and tests. The attach test helper now resolves the command through the real transient layout, and a wiring test pins menu `a` → attach submenu → `i` → `pilish-attach-image`.