### PR TITLE
Capitalize Pilish in prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ tmux new-session -d -s test -x 120 -y 40 \
 sleep 2 && tmux capture-pane -t test -p
 ```
 
-To start a full interactive `pilish` session in tmux:
+To start a full interactive `Pilish` session in tmux:
 ```bash
 tmux new-session -d -s test -x 120 -y 40 \
   "emacs -nw -Q --eval \"(progn (require 'package) (package-initialize) \
@@ -252,7 +252,7 @@ Common gotchas:
 - **Sleep timing**: use `sleep 2` for UI ops, `sleep 10`+ for LLM responses
 - **Buffer names** follow `*pilish-{chat,input}:<dir>*` (abbreviated),
   e.g. `*pilish-chat:~/co/pilish/*`
-- **Window focus**: the `pilish` layout has two windows; `C-x o` switches between them.
+- **Window focus**: the `Pilish` layout has two windows; `C-x o` switches between them.
   Prefer spike scripts over interactive `tmux send-keys` when possible —
   they're reproducible, debuggable, and don't require tracking focus state
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# pilish Makefile
+# Pilish Makefile
 
 EMACS ?= emacs
 export EMACS

--- a/bench/fake-pi-tool-update-storm.py
+++ b/bench/fake-pi-tool-update-storm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Fake pi JSON-over-stdio server emitting a tool_execution_update storm.
 
-Drives the pilish tool-update benchmark.  On ``prompt`` the server
+Drives the Pilish tool-update benchmark.  On ``prompt`` the server
 replays one deterministic synthetic agent turn in two phases:
 
 Fill phase

--- a/bench/fixtures/tables.md
+++ b/bench/fixtures/tables.md
@@ -1,4 +1,4 @@
-# Benchmark fixture tables for pilish
+# Benchmark fixture tables for Pilish
 
 Tables below are extracted by the bench harness.  Each table is
 separated by at least one blank line of non-table text.  The fixture

--- a/bench/pilish-bench.el
+++ b/bench/pilish-bench.el
@@ -6,7 +6,7 @@
 
 ;;; Commentary:
 
-;; Performance benchmarks for display-only table rendering in pilish.
+;; Performance benchmarks for display-only table rendering in Pilish.
 ;; Exercises the full rendering pipeline: tree-sitter detection, visible-text
 ;; extraction, cell wrapping, overlay creation, streaming refresh, and
 ;; hot-tail resize.

--- a/bench/pilish-reload-resume-bench.el
+++ b/bench/pilish-reload-resume-bench.el
@@ -6,7 +6,7 @@
 
 ;;; Commentary:
 
-;; Deterministic reload/resume benchmarks for pilish.
+;; Deterministic reload/resume benchmarks for Pilish.
 ;; The benchmark generates synthetic pi JSONL session files, drives the Emacs
 ;; UI through a fake JSON-over-stdio backend, and records only metrics.  No
 ;; private session files are read.

--- a/bench/pilish-tool-update-bench.el
+++ b/bench/pilish-tool-update-bench.el
@@ -6,7 +6,7 @@
 
 ;;; Commentary:
 
-;; Deterministic tool_execution_update storm benchmarks for pilish.
+;; Deterministic tool_execution_update storm benchmarks for Pilish.
 ;; A real session backed by `bench/fake-pi-tool-update-storm.py' renders a
 ;; synthetic long-session fill phase and then a burst-patterned storm of
 ;; subagent progress updates.  The harness measures how the stock frontend

--- a/bench/run-bench.sh
+++ b/bench/run-bench.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# run-bench.sh - Run pilish table rendering benchmarks
+# run-bench.sh - Run Pilish table rendering benchmarks
 #
 # Usage:
 #   ./bench/run-bench.sh              # GUI via xvfb (primary lane)
@@ -42,7 +42,7 @@ EMACS_INIT=(
     -l "$SCRIPT_DIR/pilish-bench.el"
 )
 
-echo "=== pilish Table Rendering Benchmarks ==="
+echo "=== Pilish Table Rendering Benchmarks ==="
 echo "Project: $PROJECT_DIR"
 
 if [ "$BATCH" = "1" ]; then

--- a/bench/run-reload-resume-bench.sh
+++ b/bench/run-reload-resume-bench.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# run-reload-resume-bench.sh - Run pilish reload/resume benchmarks
+# run-reload-resume-bench.sh - Run Pilish reload/resume benchmarks
 #
 # Usage:
 #   ./bench/run-reload-resume-bench.sh                         # GUI via xvfb (primary lane)
@@ -186,7 +186,7 @@ EMACS_INIT=(
     -l "$SCRIPT_DIR/pilish-reload-resume-bench.el"
 )
 
-printf '=== pilish Reload/Resume Benchmarks ===\n'
+printf '=== Pilish Reload/Resume Benchmarks ===\n'
 printf 'Project: %s\n' "$PROJECT_DIR"
 if [[ "$BATCH" = "1" ]]; then
     MODE="batch"
@@ -297,7 +297,7 @@ if rows:
         writer.writerows(rows)
 
 summary_lines: list[str] = []
-summary_lines.append("# pilish reload/resume benchmark summary")
+summary_lines.append("# Pilish reload/resume benchmark summary")
 summary_lines.append("")
 summary_lines.append("Synthetic deterministic fixtures only; no private session content is used.")
 summary_lines.append("")

--- a/bench/run-tool-update-bench.sh
+++ b/bench/run-tool-update-bench.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# run-tool-update-bench.sh - Run pilish tool-update storm benchmarks
+# run-tool-update-bench.sh - Run Pilish tool-update storm benchmarks
 #
 # Usage:
 #   ./bench/run-tool-update-bench.sh                         # GUI via xvfb (primary lane)
@@ -208,7 +208,7 @@ EMACS_INIT=(
     -l "$SCRIPT_DIR/pilish-tool-update-bench.el"
 )
 
-printf '=== pilish Tool-Update Benchmarks ===\n'
+printf '=== Pilish Tool-Update Benchmarks ===\n'
 printf 'Project: %s\n' "$PROJECT_DIR"
 if [[ "$BATCH" = "1" ]]; then
     MODE="batch"
@@ -357,7 +357,7 @@ if rows:
         writer.writerows(rows)
 
 summary_lines: list[str] = []
-summary_lines.append("# pilish tool-update benchmark summary")
+summary_lines.append("# Pilish tool-update benchmark summary")
 summary_lines.append("")
 summary_lines.append("Synthetic deterministic workload only; no private session content is used.")
 summary_lines.append("")

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Git pre-commit hook for pilish
+# Git pre-commit hook for Pilish
 # Runs byte-compilation and tests before allowing commits
 
 exec ./scripts/check.sh

--- a/pilish-browse.el
+++ b/pilish-browse.el
@@ -25,7 +25,7 @@
 
 ;;; Commentary:
 
-;; Session and tree browsing for pilish.
+;; Session and tree browsing for Pilish.
 ;;
 ;; Provides two read-only, refreshable, keyboard-driven buffers:
 ;;   - Session Browser: find, filter, switch sessions (like TUI /resume)
@@ -528,7 +528,7 @@ Groups: \"Today\", \"Yesterday\", \"This Week\", \"Older\"."
     (define-key map (kbd "g") #'pilish-browse-refresh)
     (define-key map (kbd "q") #'quit-window)
     map)
-  "Base keymap for pilish browse modes.")
+  "Base keymap for Pilish browse modes.")
 
 (defvar pilish-session-browser-mode-map
   (let ((map (make-sparse-keymap)))
@@ -653,7 +653,7 @@ browser's state on the real rendering path."
 
 (define-derived-mode pilish-browse-mode magit-section-mode
   "Pi-Browse"
-  "Base mode for pilish browse buffers.
+  "Base mode for Pilish browse buffers.
 Inherits section navigation from `magit-section-mode'."
   :group 'pilish)
 

--- a/pilish-core.el
+++ b/pilish-core.el
@@ -1,4 +1,4 @@
-;;; pilish-core.el --- Core functionality for pilish -*- lexical-binding: t; -*-
+;;; pilish-core.el --- Core functionality for Pilish -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2026 Daniel Nouri
 
@@ -25,7 +25,7 @@
 
 ;;; Commentary:
 
-;; Core functionality for pilish: JSON parsing, line buffering, RPC communication.
+;; Core functionality for Pilish: JSON parsing, line buffering, RPC communication.
 ;; This module provides the low-level plumbing for communicating with the
 ;; pi coding agent via JSON-over-stdio.
 

--- a/pilish-evil.el
+++ b/pilish-evil.el
@@ -1,4 +1,4 @@
-;;; pilish-evil.el --- Evil keybindings for pilish -*- lexical-binding: t; -*-
+;;; pilish-evil.el --- Evil keybindings for Pilish -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2026 Daniel Nouri
 
@@ -25,7 +25,7 @@
 
 ;;; Commentary:
 
-;; Optional Evil integration for pilish, modeled on how Evil
+;; Optional Evil integration for Pilish, modeled on how Evil
 ;; and Magit cooperate: the read-only chat buffer starts in motion
 ;; state so navigation keys work unmodified, the input buffer starts
 ;; in insert state, and `?' opens the transient menu.
@@ -197,7 +197,7 @@ When APPEND is non-nil, move point to the end of the input buffer."
 
 ;;;###autoload
 (defun pilish-evil-setup ()
-  "Set up Evil integration for pilish.
+  "Set up Evil integration for Pilish.
 Set initial buffer states, install keybindings, and apply the user
 options `pilish-evil-chat-state',
 `pilish-evil-input-state',

--- a/pilish-grammars.el
+++ b/pilish-grammars.el
@@ -85,7 +85,7 @@ Each entry is (LANG URL REVISION [SOURCE-DIR]).")
 (defconst pilish-grammar-recipes
   (append pilish-essential-grammar-recipes
           pilish-optional-grammar-recipes)
-  "All tree-sitter grammar recipes needed by pilish.")
+  "All tree-sitter grammar recipes needed by Pilish.")
 
 ;; Register recipes so `M-x treesit-install-language-grammar' works
 ;; on Emacs 29/30 (which ship with zero recipes).  Use APPEND so user
@@ -319,7 +319,7 @@ then offers to install the missing ones."
         (with-current-buffer buf
           (let ((inhibit-read-only t))
             (erase-buffer)
-            (insert (format "pilish Tree-sitter Grammars\n\
+            (insert (format "Pilish Tree-sitter Grammars\n\
 ====================================\n\n"))
             (when essential-missing
               (insert (format "⚠ ESSENTIAL (required for chat rendering):\n"))

--- a/pilish-input.el
+++ b/pilish-input.el
@@ -25,7 +25,7 @@
 
 ;;; Commentary:
 
-;; Input buffer features for pilish: prompt composition,
+;; Input buffer features for Pilish: prompt composition,
 ;; history navigation (comint/eshell-style M-p/M-n), incremental
 ;; history search (readline-style C-r), file reference completion (@),
 ;; path completion (Tab), slash command completion, message queuing

--- a/pilish-menu.el
+++ b/pilish-menu.el
@@ -26,7 +26,7 @@
 ;;; Commentary:
 
 ;; Transient menu, session management, model selection, and command
-;; infrastructure for pilish.
+;; infrastructure for Pilish.
 ;;
 ;; Key entry points:
 ;;   `pilish-menu'            Transient menu (C-c C-p)
@@ -70,7 +70,7 @@ VERSION may include a leading prefix like `v' or extra suffix text."
                      transient-version
                      pilish--minimum-transient-version))))
   (display-warning 'pilish
-                   (format "pilish requires transient >= %s, \
+                   (format "Pilish requires transient >= %s, \
 but %s is loaded.
   Fix: upgrade transient from MELPA.  If Emacs is using an older built-in
   copy, set `package-install-upgrade-built-in' to t before running

--- a/pilish-render.el
+++ b/pilish-render.el
@@ -25,7 +25,7 @@
 
 ;;; Commentary:
 
-;; Rendering module for pilish: streaming chat display, tool output,
+;; Rendering module for Pilish: streaming chat display, tool output,
 ;; and fontification.
 ;;
 ;; This module handles everything that appears in the chat buffer:

--- a/pilish-table.el
+++ b/pilish-table.el
@@ -25,7 +25,7 @@
 
 ;;; Commentary:
 
-;; Display-only markdown pipe table rendering for pilish chat buffers.
+;; Display-only markdown pipe table rendering for Pilish chat buffers.
 ;;
 ;; Detects pipe tables via tree-sitter, wraps them to the window width via
 ;; `markdown-table-wrap', and renders the wrapped output as per-line display

--- a/pilish-ui.el
+++ b/pilish-ui.el
@@ -25,10 +25,10 @@
 
 ;;; Commentary:
 
-;; Foundation module for pilish: shared state, faces, customization,
+;; Foundation module for Pilish: shared state, faces, customization,
 ;; buffer management, display primitives, header-line, and major modes.
 ;;
-;; This is the base layer that all other pilish modules require.
+;; This is the base layer that all other Pilish modules require.
 ;; It provides:
 ;; - Customization options and face definitions
 ;; - Buffer-local session variables (the shared mutable state)
@@ -174,7 +174,7 @@ real session phase change from buffer lifecycle events that merely
 reapply or clean up buffer-local UI.
 
 This is an abnormal hook.  Functions should be idempotent because
-pilish may call them again with the same OLD-PHASE and
+Pilish may call them again with the same OLD-PHASE and
 NEW-PHASE when session buffers are relinked or reset."
   :type 'hook
   :group 'pilish)
@@ -2069,7 +2069,7 @@ Returns nil if MS is nil."
 ;;;; Dependency Checking
 
 (defconst pilish--pi-package "@earendil-works/pi-coding-agent"
-  "Npm package name for the pi CLI supported by pilish.")
+  "Npm package name for the pi CLI supported by Pilish.")
 
 (defconst pilish--minimum-pi-version "0.84.2"
   "Minimum supported pi CLI version.")
@@ -2209,7 +2209,7 @@ warnings for missing dependencies."
 ;;;; Startup Header
 
 (defconst pilish-version "3.0.0"
-  "Version of pilish.")
+  "Version of Pilish.")
 
 (defconst pilish--version-probe-delay 0.1
   "Seconds to wait before probing `pi --version' for a new process.")
@@ -2319,7 +2319,7 @@ Stores the result in CHAT-BUF and emits a minibuffer notice when available."
 
 (defun pilish--format-startup-header ()
   "Format the startup header string with styled separator."
-  (let ((separator (pilish--make-separator "pilish")))
+  (let ((separator (pilish--make-separator "Pilish")))
     (concat
      separator "\n"
      "C-c C-c   send prompt\n"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Quality checks for pilish - run before commits
+# Quality checks for Pilish - run before commits
 #
 # Usage:
 #   ./scripts/check.sh              # Unit tests only (fast)

--- a/scripts/install-ts-grammars.el
+++ b/scripts/install-ts-grammars.el
@@ -8,7 +8,7 @@
 ;;; Commentary:
 
 ;; Batch entry point used by the Makefile and CI to install the
-;; tree-sitter grammars needed by pilish.
+;; tree-sitter grammars needed by Pilish.
 ;;
 ;; Usage:
 ;;   Emacs --batch -Q -L . -l scripts/install-ts-grammars.el

--- a/scripts/ollama.sh
+++ b/scripts/ollama.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/ollama.sh - Manage Ollama Docker container for testing
 #
-# This script provides isolated Ollama setup for pilish integration tests.
+# This script provides isolated Ollama setup for Pilish integration tests.
 # All data stays in .ollama/ within the project directory.
 #
 # Usage:
@@ -149,7 +149,7 @@ cmd_logs() {
 }
 
 cmd_help() {
-    echo "Ollama Docker management for pilish testing"
+    echo "Ollama Docker management for Pilish testing"
     echo ""
     echo "Usage: $0 <command>"
     echo ""

--- a/scripts/pilish-build.el
+++ b/scripts/pilish-build.el
@@ -93,12 +93,12 @@ version after installation finishes."
     t))
 
 (defun pilish-build--default-grammars ()
-  "Return all grammars needed by pilish."
+  "Return all grammars needed by Pilish."
   (require 'pilish-grammars)
   (mapcar #'car pilish-grammar-recipes))
 
 (defun pilish-build-install-grammars (&optional grammars)
-  "Install tree-sitter GRAMMARS used by pilish.
+  "Install tree-sitter GRAMMARS used by Pilish.
 GRAMMARS defaults to all recipes from `pilish-grammar-recipes'.
 Returns a plist with counts for already installed, newly installed,
 failed, and total grammars.  Signals an error if any grammar fails."

--- a/test/fixtures/test-extension.ts
+++ b/test/fixtures/test-extension.ts
@@ -1,5 +1,5 @@
 /**
- * Test extension for pilish integration tests.
+ * Test extension for Pilish integration tests.
  * Load with: pi --mode rpc -e test/fixtures/test-extension.ts --no-extensions
  */
 

--- a/test/pilish-core-test.el
+++ b/test/pilish-core-test.el
@@ -2,7 +2,7 @@
 
 ;;; Commentary:
 
-;; ERT tests for the core pilish functionality: JSON parsing,
+;; ERT tests for the core Pilish functionality: JSON parsing,
 ;; line accumulation, and command encoding.
 
 ;;; Code:

--- a/test/pilish-fake-pi-test.el
+++ b/test/pilish-fake-pi-test.el
@@ -514,7 +514,7 @@ SPEC is (PROC SCENARIO &rest EXTRA-ARGS)."
             :output (buffer-string)))))
 
 (defmacro pilish-fake-pi-test-with-session (spec &rest body)
-  "Create a real pilish session against fake-pi, then run BODY.
+  "Create a real Pilish session against fake-pi, then run BODY.
 SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
   (declare (indent 1) (debug t))
   (let ((session (nth 0 spec))

--- a/test/pilish-gui-test-utils.el
+++ b/test/pilish-gui-test-utils.el
@@ -1,4 +1,4 @@
-;;; pilish-gui-test-utils.el --- Utilities for pilish GUI tests -*- lexical-binding: t; -*-
+;;; pilish-gui-test-utils.el --- Utilities for Pilish GUI tests -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;

--- a/test/pilish-gui-tests.el
+++ b/test/pilish-gui-tests.el
@@ -1,4 +1,4 @@
-;;; pilish-gui-tests.el --- GUI integration tests for pilish -*- lexical-binding: t; -*-
+;;; pilish-gui-tests.el --- GUI integration tests for Pilish -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;

--- a/test/pilish-test-common.el
+++ b/test/pilish-test-common.el
@@ -2,7 +2,7 @@
 
 ;;; Commentary:
 
-;; Common definitions shared across pilish test files.
+;; Common definitions shared across Pilish test files.
 ;; Centralizes timeout values, fake-pi launch helpers, the mock-session
 ;; macro, and toolcall streaming helpers for easy adjustment (e.g., slow CI).
 

--- a/test/pilish-test.el
+++ b/test/pilish-test.el
@@ -1,8 +1,8 @@
-;;; pilish-test.el --- Tests for pilish -*- lexical-binding: t; -*-
+;;; pilish-test.el --- Tests for Pilish -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 
-;; Entry-point and cross-module integration tests for pilish.
+;; Entry-point and cross-module integration tests for Pilish.
 
 ;;; Code:
 
@@ -784,7 +784,7 @@ still mock the RPC boundary, so the process is never used for I/O."
             (dired-goto-file session-file)
             (cl-letf (((symbol-function 'dired-get-filename)
                        (lambda (&rest _)
-                         (ert-fail "pilish inspected Dired point")))
+                         (ert-fail "Pilish inspected Dired point")))
                       ((symbol-function 'project-current)
                        (lambda (&rest _) nil))
                       ((symbol-function 'pilish--check-dependencies)
@@ -818,13 +818,13 @@ still mock the RPC boundary, so the process is never used for I/O."
           (with-current-buffer file-buf
             (cl-letf (((symbol-function 'pilish--read-session-file-name)
                        (lambda ()
-                         (ert-fail "pilish read a session file")))
+                         (ert-fail "Pilish read a session file")))
                       ((symbol-function 'pilish--session-file-cwd-or-error)
                        (lambda (&rest _)
-                         (ert-fail "pilish validated a session file")))
+                         (ert-fail "Pilish validated a session file")))
                       ((symbol-function 'pilish--resume-selected-session)
                        (lambda (&rest _)
-                         (ert-fail "pilish resumed a session file")))
+                         (ert-fail "Pilish resumed a session file")))
                       ((symbol-function 'project-current)
                        (lambda (&rest _) nil))
                       ((symbol-function 'pilish--check-dependencies)

--- a/test/pilish-ui-test.el
+++ b/test/pilish-ui-test.el
@@ -860,9 +860,9 @@ without an input window."
     (should (string-match-p "C-c C-r   sessions" header))))
 
 (ert-deftest pilish-test-startup-header-shows-label ()
-  "Startup header labels the buffer with the package name."
+  "Startup header labels the buffer with the project title."
   (let ((header (pilish--format-startup-header)))
-    (should (string-match-p "^pilish$" header))))
+    (should (string-equal "Pilish" (car (split-string header "\n"))))))
 
 (ert-deftest pilish-test-extract-pi-version-from-clean-output ()
   "Extract the plain semantic version returned by pi."


### PR DESCRIPTION
Lower-case `pilish` now appears only where it strictly refers to the
package, feature, or commands (symbols, `M-x pilish`, `pilish.el`,
URLs, `:group 'pilish`, `pilish:`/`[pilish]` message prefixes). All
prose — comments, docstrings, user-facing strings, test text, docs,
bench banners — uses the project title `Pilish`.

Notable changes:

- Startup greeting label is now `Pilish`, matching the title-cased
  separator convention ("You", "Assistant", "Compaction").
- The greeting test now compares the label case-sensitively
  (`string-equal`); the previous `string-match-p "^pilish$"` was
  case-insensitive under `case-fold-search` and could not fail.
- User-facing strings: transient-version warning and the tree-sitter
  grammars buffer heading.

Kept lower-case on purpose: `=pilish=` in the README choice guide
(package comparison beside `=gptel=`/Aidermacs) and "loading pilish"
where it refers to the loadable Lisp feature.

Full check green: byte-compile + checkdoc + package-lint + 1680 tests,
0 unexpected.