### PR TITLE
Add an expandable session summary to the startup header

### DIFF
--- a/README.org
+++ b/README.org
@@ -298,6 +298,11 @@ Press =TAB= on a turn header (=You= or =Assistant=) to fold or unfold
 that turn.  Use =n= and =p= in the chat buffer to jump between user
 messages, and =f= to fork the conversation from the turn at point.
 
+The chat header ends with a session summary line showing the pi and
+Pilish versions plus skill and prompt-template counts.  Press =TAB= on
+that line to expand it into the loaded context files, skills, and
+prompt templates; =TAB= again collapses it back to the summary line.
+
 #+html: <a id="sessions-and-context"></a>
 ** Sessions and context 🗂️
 
@@ -349,7 +354,7 @@ configured warning and error thresholds.
 | =C-r=            | input   | 🕵️ Incremental prompt-history search          |
 | =TAB=            | input   | 🪄 Complete paths, and =/= commands           |
 | =M+<prior/next>= | input   | 🛗 Scroll linked chat window                  |
-| =TAB=            | chat    | 🪗 Toggle thinking block, tool block, or turn |
+| =TAB=            | chat    | 🪗 Toggle summary line, thinking, tool, or turn |
 | =!=              | chat    | 🐚 Run a Dired-inspired command on a file    |
 | =RET=            | chat    | 🎯 Visit strict file target at point          |
 | =n= / =p=        | chat    | 🐾 Navigate user messages                     |

--- a/pilish-render.el
+++ b/pilish-render.el
@@ -3532,6 +3532,103 @@ was toggled successfully."
                       (min original-pos (max new-start (1- new-end))))))
     t))
 
+(defun pilish--startup-banner-section (label names)
+  "Return the LABEL detail line listing NAMES for the startup banner.
+NAMES is a list of strings; returns nil when empty so empty sections are
+omitted from the expanded banner entirely."
+  (when names
+    (concat label " " (mapconcat #'identity names ", "))))
+
+(defun pilish--format-startup-banner-expanded ()
+  "Return the propertized expanded startup banner text.
+Line one carries the version segments and a TAB collapse hint; then one
+line per non-empty section with context files, skill names (the skill:
+prefix stripped), and prompt names (each prefixed with a slash), all in
+`pilish--commands' order."
+  (let ((sections
+         (delq nil
+               (list
+                (pilish--startup-banner-section
+                 "[Context]" (pilish--startup-context-files))
+                (pilish--startup-banner-section
+                 "[Skills]"
+                 (mapcar (lambda (name) (string-remove-prefix "skill:" name))
+                         (pilish--startup-banner-command-names "skill")))
+                (pilish--startup-banner-section
+                 "[Prompts]"
+                 (mapcar (lambda (name) (concat "/" name))
+                         (pilish--startup-banner-command-names "prompt")))))))
+    (pilish--propertize-startup-banner
+     (mapconcat
+      #'identity
+      (cons (concat (mapconcat #'identity
+                               (pilish--startup-banner-version-segments)
+                               " · ")
+                   " · TAB collapse")
+            sections)
+      "\n")
+     'expanded)))
+
+(defun pilish--startup-banner-probe-pos (pos)
+  "Return a position inside the startup banner at POS, or nil.
+Checks POS and the preceding character so point resting on a banner
+boundary still resolves to the banner being toggled."
+  (when (> (point-max) (point-min))
+    (let ((probe (cond ((<= pos (point-min)) (point-min))
+                       ((>= pos (point-max)) (max (point-min)
+                                                  (1- (point-max))))
+                       (t pos))))
+      (cond ((get-text-property probe 'pilish-startup-banner) probe)
+            ((and (> probe (point-min))
+                  (get-text-property (1- probe)
+                                     'pilish-startup-banner))
+             (1- probe))))))
+
+(defun pilish--replace-startup-banner-region (start end rendered)
+  "Replace the startup banner START..END with RENDERED text.
+Returns the new bounds as (START . NEW-END) and keeps visible windows
+usable after the rewrite."
+  (let* ((buffer (current-buffer))
+         (saved-windows (pilish--capture-window-rewrite-states))
+         (inhibit-read-only t)
+         new-end)
+    (save-excursion
+      (goto-char start)
+      (delete-region start end)
+      (insert rendered)
+      (setq new-end (point))
+      (condition-case-unless-debug nil
+          (font-lock-ensure start new-end)
+        (error nil)))
+    (pilish--restore-window-rewrite-states
+     buffer
+     saved-windows
+     (let ((delta (- new-end end)))
+       (lambda (pos)
+         (pilish--adjust-pos-after-region-replacements
+          pos (list (list start end delta))))))
+    (cons start new-end)))
+
+(defun pilish--toggle-startup-banner-at-point ()
+  "Toggle the startup banner at point between compact and expanded.
+Returns non-nil when point was on the startup banner."
+  (when-let* ((probe (pilish--startup-banner-probe-pos (point)))
+              (state (get-text-property probe 'pilish-startup-banner)))
+    (let* ((original-pos (point))
+           (start (or (previous-single-property-change
+                       (1+ probe) 'pilish-startup-banner)
+                      (point-min)))
+           (end (next-single-property-change
+                 probe 'pilish-startup-banner nil (point-max)))
+           (rendered (if (eq state 'expanded)
+                         (pilish--format-startup-banner-compact)
+                       (pilish--format-startup-banner-expanded)))
+           (new-bounds (pilish--replace-startup-banner-region
+                        start end rendered)))
+      (goto-char (max (car new-bounds)
+                      (min original-pos (1- (cdr new-bounds)))))
+      t)))
+
 (defun pilish--insert-rendered-tool-content (content lang is-edit-diff)
   "Insert CONTENT rendered for LANG with a trailing newline.
 When IS-EDIT-DIFF is non-nil, apply diff overlays to the inserted block."
@@ -3595,26 +3692,28 @@ Returns (START . END) if inside a tool block, nil otherwise."
 
 (defun pilish-toggle-tool-section ()
   "Toggle the section at point.
-Completed thinking blocks toggle first, then tool output blocks, then the
-command falls back to `outline-cycle' for turn folding."
+The startup banner toggles first, then completed thinking blocks, then tool
+output blocks, then the command falls back to `outline-cycle' for turn
+folding."
   (interactive)
-  (unless (pilish--toggle-thinking-block-at-point)
-    (let ((original-pos (point)))
-      (if-let* ((bounds (pilish--find-tool-block-bounds)))
-          (if-let* ((btn (pilish--find-toggle-button-in-region
-                          (car bounds) (cdr bounds))))
-              (progn
-                (pilish--toggle-tool-output btn)
-                ;; Try to restore position, clamped to new block bounds.
-                ;; Use (1- end) because overlays-at uses half-open [start, end),
-                ;; so clamping to exactly end would place cursor outside the
-                ;; overlay, breaking the next toggle.
-                (when-let* ((new-bounds (pilish--find-tool-block-bounds)))
-                  (goto-char (min original-pos (1- (cdr new-bounds))))))
-            ;; No button found - short output, use outline-cycle
-            (outline-cycle))
-        ;; Not in a tool block
-        (outline-cycle)))))
+  (unless (pilish--toggle-startup-banner-at-point)
+    (unless (pilish--toggle-thinking-block-at-point)
+      (let ((original-pos (point)))
+        (if-let* ((bounds (pilish--find-tool-block-bounds)))
+            (if-let* ((btn (pilish--find-toggle-button-in-region
+                            (car bounds) (cdr bounds))))
+                (progn
+                  (pilish--toggle-tool-output btn)
+                  ;; Try to restore position, clamped to new block bounds.
+                  ;; Use (1- end) because overlays-at uses half-open [start, end),
+                  ;; so clamping to exactly end would place cursor outside the
+                  ;; overlay, breaking the next toggle.
+                  (when-let* ((new-bounds (pilish--find-tool-block-bounds)))
+                    (goto-char (min original-pos (1- (cdr new-bounds))))))
+              ;; No button found - short output, use outline-cycle
+              (outline-cycle))
+          ;; Not in a tool block
+          (outline-cycle))))))
 
 ;;;; Tool Block Cooling
 ;;

--- a/pilish-ui.el
+++ b/pilish-ui.el
@@ -1670,7 +1670,12 @@ setter updates all of them to keep them in sync."
       (when (and (buffer-live-p buf)
                  (not (eq buf (current-buffer))))
         (with-current-buffer buf
-          (setq pilish--commands commands))))))
+          (setq pilish--commands commands))))
+    ;; The banner summary reads buffer-local commands, so refresh it in the
+    ;; chat buffer wherever the RPC callback happened to run.
+    (when (buffer-live-p chat-buf)
+      (with-current-buffer chat-buf
+        (pilish--refresh-startup-banner)))))
 
 ;;;; Buffer Navigation
 
@@ -2315,21 +2320,154 @@ Stores the result in CHAT-BUF and emits a minibuffer notice when available."
              (with-current-buffer chat-buf
                (setq pilish--process-version version)
                (message "Pi: version %s" version)
-               (pilish--warn-if-pi-version-outdated version)))))))))
+               (pilish--warn-if-pi-version-outdated version)
+               ;; The banner summary shows the probed version; the callback
+               ;; already re-established the chat-buffer context above.
+               (pilish--refresh-startup-banner)))))))))
 
 (defun pilish--format-startup-header ()
-  "Format the startup header string with styled separator."
+  "Format the startup header string with separator and session summary.
+Ends with the compact, toggleable banner line built by
+`pilish--format-startup-banner-compact'."
   (let ((separator (pilish--make-separator "Pilish")))
     (concat
      separator "\n"
      "C-c C-c   send prompt\n"
      "C-c C-k   abort\n"
      "C-c C-r   sessions\n"
-     "C-c C-p   menu\n")))
+     "C-c C-p   menu\n"
+     (pilish--format-startup-banner-compact) "\n")))
 
 (defun pilish--display-startup-header ()
   "Display the startup header in the chat buffer."
   (pilish--append-to-chat (pilish--format-startup-header)))
+
+;;;; Startup Banner
+
+(defconst pilish--startup-context-candidates
+  '("AGENTS.override.md" "AGENTS.md" "AGENTS.MD" "CLAUDE.md" "CLAUDE.MD")
+  "Context file names pi loads, in per-directory precedence order.
+AGENTS.override.md shadows AGENTS.md within the same directory.")
+
+(defun pilish--startup-context-file-in-dir (directory)
+  "Return the first existing context file path in DIRECTORY, or nil.
+Candidates from `pilish--startup-context-candidates' are checked in order
+and only regular files count."
+  (catch 'found
+    (dolist (name pilish--startup-context-candidates nil)
+      (let ((path (expand-file-name name directory)))
+        (when (and (file-exists-p path) (file-regular-p path))
+          (throw 'found path))))))
+
+(defun pilish--startup-context-files (&optional directory user-agent-dir)
+  "Return existing AGENTS-family context files pi would load.
+The user-level file from USER-AGENT-DIR (default \"~/.pi/agent\", expanded)
+comes first when present, then one file per ancestor of DIRECTORY walking up
+to the root, nearest directory first.  DIRECTORY defaults to the chat
+buffer's session directory.  Only the first existing candidate is returned
+per directory."
+  (let* ((user-dir (expand-file-name (or user-agent-dir "~/.pi/agent")))
+         (start-dir (expand-file-name
+                     (or directory (pilish--chat-session-directory))))
+         (files (when-let* ((user-file
+                             (pilish--startup-context-file-in-dir user-dir)))
+                  (list user-file)))
+         (dir (directory-file-name start-dir)))
+    (catch 'done
+      (while t
+        (when-let* ((file (pilish--startup-context-file-in-dir dir)))
+          (unless (member file files)
+            (setq files (append files (list file)))))
+        (let ((parent (directory-file-name (file-name-directory dir))))
+          (when (string= parent dir)
+            (throw 'done nil))
+          (setq dir parent))))
+    files))
+
+(defun pilish--startup-banner-command-names (source)
+  "Return names of `pilish--commands' entries whose :source equals SOURCE.
+Order follows `pilish--commands' so the banner preserves command order."
+  (delq nil
+        (mapcar (lambda (command)
+                  (when (equal (plist-get command :source) source)
+                    (plist-get command :name)))
+                pilish--commands)))
+
+(defun pilish--startup-banner-count-commands (source)
+  "Return how many `pilish--commands' entries have :source equal to SOURCE."
+  (length (pilish--startup-banner-command-names source)))
+
+(defun pilish--startup-banner-version-segments ()
+  "Return version segments for the startup banner summary.
+Includes \"pi V\" only when `pilish--process-version' is set and always
+includes \"pilish V\" from `pilish-version'."
+  (delq nil
+        (list (when pilish--process-version
+                (concat "pi v" pilish--process-version))
+              (concat "pilish " pilish-version))))
+
+(defun pilish--propertize-startup-banner (text state)
+  "Return TEXT tagged as a startup banner shown in display STATE.
+STATE is `compact' or `expanded'; the `pilish-startup-banner' text property
+marks the toggleable span and records its current display, mirroring how
+completed thinking blocks tag their spans."
+  (propertize text
+              'pilish-startup-banner state
+              'help-echo "TAB: toggle session details"))
+
+(defun pilish--format-startup-banner-compact ()
+  "Return the propertized compact startup banner summary line.
+Count segments are omitted entirely while `pilish--commands' is unset, so a
+session that has not loaded commands yet never shows misleading zero
+counts."
+  (let ((segments (pilish--startup-banner-version-segments)))
+    (when pilish--commands
+      (setq segments
+            (append segments
+                    (list (format "%d skills"
+                                  (pilish--startup-banner-count-commands
+                                   "skill"))
+                          (format "%d prompts"
+                                  (pilish--startup-banner-count-commands
+                                   "prompt"))))))
+    (pilish--propertize-startup-banner
+     (concat (mapconcat #'identity segments " · ") " · TAB details")
+     'compact)))
+
+(defun pilish--startup-banner-region ()
+  "Return the startup banner span in the current buffer as (START . END).
+Returns nil when the buffer contains no banner."
+  (let ((pos (point-min)))
+    (catch 'found
+      (while (< pos (point-max))
+        (if (get-text-property pos 'pilish-startup-banner)
+            (throw 'found
+                   (cons pos
+                         (next-single-property-change
+                          pos 'pilish-startup-banner nil (point-max))))
+          (setq pos (next-single-property-change
+                     pos 'pilish-startup-banner nil (point-max)))))
+      nil)))
+
+(defun pilish--refresh-startup-banner ()
+  "Re-render the compact startup banner in place from current buffer state.
+No-op when the buffer has no banner or the banner is expanded, so a
+background refresh never collapses details the user opened.  Idempotent."
+  (when-let* ((region (pilish--startup-banner-region))
+              (state (get-text-property (car region)
+                                        'pilish-startup-banner)))
+    (when (eq state 'compact)
+      (let ((inhibit-read-only t)
+            (start (car region))
+            (end (cdr region)))
+        (pilish--with-scroll-preservation
+          (save-excursion
+            (goto-char start)
+            (delete-region start end)
+            (insert (pilish--format-startup-banner-compact))
+            (condition-case-unless-debug nil
+                (font-lock-ensure start (point))
+              (error nil))))))))
 
 ;;;; Header Line
 

--- a/test/pilish-render-test.el
+++ b/test/pilish-render-test.el
@@ -847,6 +847,114 @@ agent_end + next section's leading newline must not create triple newlines."
       (should (< first-pos custom-pos))
       (should (< custom-pos second-pos)))))
 
+(defun pilish-test--startup-banner-history ()
+  "Return a one-turn history used by startup banner tests."
+  [(:role "user"
+    :content [(:type "text" :text "Question?")]
+    :timestamp 1704067200000)])
+
+(ert-deftest pilish-test-tab-toggles-startup-banner-details ()
+  "TAB on the startup banner expands and collapses the summary details.
+The banner is toggled before thinking blocks and outline cycling."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (setq pilish--process-version "0.84.2"
+          pilish--commands
+          (list '(:name "create-todo" :description "New todo" :source "prompt")
+                '(:name "fix-tests" :description "Fix tests" :source "prompt")
+                '(:name "skill:aws-sso" :description "AWS SSO" :source "skill")
+                '(:name "skill:uv" :description "uv runner" :source "skill")))
+    (pilish--display-startup-header)
+    (goto-char (point-min))
+    (search-forward "TAB details")
+    (pilish-toggle-tool-section)
+    (let ((text (buffer-string)))
+      (should (string-match-p "^pi v0\.84\.2 · pilish 3\.0\.0 · TAB collapse$" text))
+      (should (string-match-p "^\\[Skills\\] aws-sso, uv$" text))
+      (should (string-match-p "^\\[Prompts\\] /create-todo, /fix-tests$" text)))
+    ;; TAB again restores the compact form.
+    (pilish-toggle-tool-section)
+    (let ((text (buffer-string)))
+      (should (string-match-p
+               "^pi v0\.84\.2 · pilish 3\.0\.0 · 2 skills · 2 prompts · TAB details$"
+               text))
+      (should-not (string-match-p "\\[Skills\\]" text))
+      (should-not (string-match-p "\\[Prompts\\]" text))
+      (should-not (string-match-p "TAB collapse" text)))))
+
+(ert-deftest pilish-test-startup-banner-details-list-skills-and-prompts ()
+  "Expanded banner strips the skill: prefix, prefixes prompts with /, and
+joins context files with comma and space."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (setq pilish--process-version "0.84.2"
+          pilish--commands
+          (list '(:name "create-todo" :description "New todo" :source "prompt")
+                '(:name "fix-tests" :description "Fix tests" :source "prompt")
+                '(:name "skill:aws-sso" :description "AWS SSO" :source "skill")
+                '(:name "skill:uv" :description "uv runner" :source "skill")))
+    (cl-letf (((symbol-function 'pilish--startup-context-files)
+               (lambda (&optional _directory _user-agent-dir)
+                 '("/home/u/.pi/agent/AGENTS.md" "/p/AGENTS.md"))))
+      (pilish--display-startup-header)
+      (goto-char (point-min))
+      (search-forward "TAB details")
+      (pilish-toggle-tool-section)
+      (let ((text (buffer-string)))
+        (should (string-match-p "^\\[Skills\\] aws-sso, uv$" text))
+        (should-not (string-match-p "skill:" text))
+        (should (string-match-p "^\\[Prompts\\] /create-todo, /fix-tests$" text))
+        (should (string-match-p
+                 "^\\[Context\\] /home/u/.pi/agent/AGENTS.md, /p/AGENTS.md$"
+                 text))))))
+
+(ert-deftest pilish-test-display-session-history-includes-startup-summary ()
+  "History replay renders the compact startup summary above session messages."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (setq pilish--process-version "0.84.2"
+          pilish--commands
+          (list '(:name "create-todo" :description "New todo" :source "prompt")
+                '(:name "fix-tests" :description "Fix tests" :source "prompt")
+                '(:name "skill:aws-sso" :description "AWS SSO" :source "skill")
+                '(:name "skill:uv" :description "uv runner" :source "skill")))
+    (pilish--display-session-history
+     (pilish-test--startup-banner-history)
+     (current-buffer))
+    (let ((text (buffer-string)))
+      (should (string-match-p
+               (regexp-quote
+                "pi v0.84.2 · pilish 3.0.0 · 2 skills · 2 prompts · TAB details")
+               text))
+      ;; The summary line sits above the first session message.
+      (should (< (match-beginning 0) (string-match "Question\\?" text))))))
+
+(ert-deftest pilish-test-rerender-reverts-startup-banner-expansion ()
+  "A canonical-history rebuild resets an expanded banner to compact form."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (setq pilish--process-version "0.84.2"
+          pilish--commands
+          (list '(:name "create-todo" :description "New todo" :source "prompt")
+                '(:name "fix-tests" :description "Fix tests" :source "prompt")
+                '(:name "skill:aws-sso" :description "AWS SSO" :source "skill")
+                '(:name "skill:uv" :description "uv runner" :source "skill")))
+    (pilish--display-session-history
+     (pilish-test--startup-banner-history)
+     (current-buffer))
+    (goto-char (point-min))
+    (search-forward "TAB details")
+    (pilish-toggle-tool-section)
+    (should (string-match-p "TAB collapse" (buffer-string)))
+    (pilish--rerender-canonical-history)
+    (let ((text (buffer-string)))
+      (should (string-match-p
+               (regexp-quote
+                "pi v0.84.2 · pilish 3.0.0 · 2 skills · 2 prompts · TAB details")
+               text))
+      (should-not (string-match-p "\\[Skills\\]" text))
+      (should-not (string-match-p "TAB collapse" text)))))
+
 (defun pilish-test--history-with-toggleable-thinking ()
   "Return history containing text, thinking, and a collapsed tool block."
   [(:role "assistant"

--- a/test/pilish-ui-test.el
+++ b/test/pilish-ui-test.el
@@ -864,6 +864,108 @@ without an input window."
   (let ((header (pilish--format-startup-header)))
     (should (string-equal "Pilish" (car (split-string header "\n"))))))
 
+(defun pilish-test--banner-commands ()
+  "Return a command fixture with two prompts and two skills."
+  (list '(:name "create-todo" :description "New todo" :source "prompt")
+        '(:name "fix-tests" :description "Fix tests" :source "prompt")
+        '(:name "skill:aws-sso" :description "AWS SSO" :source "skill")
+        '(:name "skill:uv" :description "uv runner" :source "skill")))
+
+(ert-deftest pilish-test-startup-header-shows-summary-line ()
+  "Startup header ends with a compact summary line after the keybindings.
+Counts come from `pilish--commands' and the pi version from
+`pilish--process-version'."
+  (let ((dir (pilish-test--make-temp-directory "pilish-test-banner-summary-")))
+    (unwind-protect
+        (pilish-test-with-mock-session dir
+          (let ((chat (get-buffer (pilish-test--chat-buffer-name dir))))
+            (with-current-buffer chat
+              (setq pilish--process-version "0.84.2"
+                    pilish--commands (pilish-test--banner-commands))
+              (pilish--display-startup-header)
+              (should (string-match-p
+                       (regexp-quote
+                        "pi v0.84.2 · pilish 3.0.0 · 2 skills · 2 prompts · TAB details")
+                       (buffer-string))))))
+      (delete-directory dir t))))
+
+(ert-deftest pilish-test-startup-header-omits-missing-summary-data ()
+  "Summary line drops the pi version and count segments when data is missing.
+Never renders misleading zero counts."
+  (let ((dir (pilish-test--make-temp-directory "pilish-test-banner-omitted-")))
+    (unwind-protect
+        (pilish-test-with-mock-session dir
+          (let* ((chat (get-buffer (pilish-test--chat-buffer-name dir)))
+                 (text (with-current-buffer chat (buffer-string)))
+                 (lines (split-string text "\n")))
+            (should (member "pilish 3.0.0 · TAB details" lines))
+            (should-not (string-match-p "pi v" text))
+            (should-not (string-match-p "[0-9]+ skills" text))
+            (should-not (string-match-p "[0-9]+ prompts" text))))
+      (delete-directory dir t))))
+
+(ert-deftest pilish-test-refresh-startup-banner-fills-summary-line ()
+  "Refreshing the banner replaces the summary line in place, idempotently."
+  (let ((dir (pilish-test--make-temp-directory "pilish-test-banner-refresh-")))
+    (unwind-protect
+        (pilish-test-with-mock-session dir
+          (let ((chat (get-buffer (pilish-test--chat-buffer-name dir))))
+            (with-current-buffer chat
+              ;; The mock session displayed the banner with no data yet.
+              (setq pilish--process-version "0.84.2")
+              (pilish--set-commands (pilish-test--banner-commands))
+              (pilish--refresh-startup-banner)
+              (should (string-match-p
+                       (regexp-quote
+                        "pi v0.84.2 · pilish 3.0.0 · 2 skills · 2 prompts · TAB details")
+                       (buffer-string)))
+              (should-not (member "pilish 3.0.0 · TAB details"
+                                  (split-string (buffer-string) "\n")))
+              (let ((after-first (buffer-string)))
+                (pilish--refresh-startup-banner)
+                (should (equal (buffer-string) after-first))))))
+      (delete-directory dir t))))
+
+(ert-deftest pilish-test-refresh-startup-banner-noop-without-banner ()
+  "Refreshing the banner is a no-op when the buffer shows no banner."
+  (let ((dir (pilish-test--make-temp-directory "pilish-test-banner-noop-")))
+    (unwind-protect
+        (pilish-test-with-mock-session dir
+          (let ((chat (get-buffer (pilish-test--chat-buffer-name dir))))
+            (with-current-buffer chat
+              (let ((inhibit-read-only t))
+                (erase-buffer))
+              ;; Must not signal and must not insert anything.
+              (pilish--refresh-startup-banner)
+              (should-not (string-match-p "TAB details" (buffer-string))))))
+      (delete-directory dir t))))
+
+(ert-deftest pilish-test-startup-context-files-scan ()
+  "Context scan walks up from DIRECTORY collecting AGENTS-family files.
+The user-level file comes first, then nearest directory first walking
+upward; in a given directory AGENTS.override.md wins and shadows the
+other family names there."
+  (let* ((root (pilish-test--make-temp-directory "pilish-test-banner-context-"))
+         (user-dir (expand-file-name "home" root))
+         (walk-dir (expand-file-name "walk" root))
+         (sub-dir (expand-file-name "sub" walk-dir))
+         (proj-dir (expand-file-name "proj" sub-dir))
+         (user-file (expand-file-name "AGENTS.md" user-dir))
+         (proj-file (expand-file-name "CLAUDE.md" proj-dir))
+         (override-file (expand-file-name "AGENTS.override.md" sub-dir))
+         (walk-file (expand-file-name "AGENTS.md" walk-dir)))
+    (make-directory user-dir t)
+    (make-directory proj-dir t)
+    ;; sub-dir carries both the override and a plain AGENTS.md; only the
+    ;; override may be reported.
+    (dolist (file (list user-file proj-file override-file
+                        (expand-file-name "AGENTS.md" sub-dir) walk-file))
+      (with-temp-file file (insert "agents\n")))
+    (unwind-protect
+        (should (equal (pilish--startup-context-files proj-dir user-dir)
+                       (list user-file proj-file override-file walk-file)))
+      (delete-directory root t))))
+
 (ert-deftest pilish-test-extract-pi-version-from-clean-output ()
   "Extract the plain semantic version returned by pi."
   (should (equal (pilish--extract-pi-version "0.79.1\n")


### PR DESCRIPTION
Closes #249.

## What you get

The chat header keeps its calm shape and gains one summary line, filled in asynchronously as the version probe and `get_commands` land:

```
pi v0.84.2 · pilish 3.0.0 · 15 skills · 9 prompts · TAB details
```

Press `TAB` on that line to expand it, pi-banner style but without pi's noise:

```
pi v0.84.2 · pilish 3.0.0 · TAB collapse
[Context] ~/.pi/agent/AGENTS.md, <project>/AGENTS.md
[Skills] aws-sso, uv, ...
[Prompts] /create-todo, /fix-tests, ...
```

`TAB` collapses it back. Empty sections are omitted, and before the async data arrives the line simply shows less (`pilish 3.0.0 · TAB details`) rather than misleading zeros.

## Design notes

- **Calm by default, informative on demand.** The issue's data is all reachable, but only the one-line summary is always visible — none of pi's transient notices, hint paragraphs, or changelog blocks are replicated.
- **No new protocol.** Versions come from the existing `pi --version` probe, skills and prompt templates from the `get_commands` RPC already fetched at startup. Only context files have no RPC source, so a small scanner mirrors pi's AGENTS.md-family discovery (`AGENTS.override.md`, `AGENTS.md`, `AGENTS.MD`, `CLAUDE.md`, `CLAUDE.MD`; user dir first, then nearest directory walking up). If pi grows a resources RPC later, the scanner is one function to retire.
- **Follows the buffer's own idioms.** The toggleable line is a text-property span (like completed thinking blocks), and the toggle is the first branch of the existing `TAB` cascade. Expansion is a view state, so re-rendered history always returns to the compact form, matching how manual thinking expansions behave.
- **Deliberate scope cut:** no `minimal`/`verbose`/`none` defcustom for now — the compact line *is* the calm default. Tiers can be layered on later without changing this shape.

## Known display nuance

md-ts markup hiding can render the section brackets invisibly (`[Skills]` displays as `Skills`); the buffer text keeps the brackets, and both renderings read fine, so the fontifier is left alone.

## Validation

- 9 new unit tests (summary content, missing-data omission, async fill + idempotence, context scan with override shadowing, TAB expand/collapse, expanded contents, history render, rerender reverts); full suite 1692/1693 green (1 pre-existing skip), byte-compile + checkdoc + package-lint clean.
- Driven in a real `emacs -nw` session under tmux against a live `pi`: async fill observed at ~2s, expansion/collapse through real keypresses, real context files/skills/prompts listed.