### PR TITLE
Fix missing table cells and lingering thinking text

### DIFF
--- a/pilish-render.el
+++ b/pilish-render.el
@@ -477,6 +477,7 @@ non-empty."
                 (pilish--apply-completed-thinking-properties
                  start end order normalized display))
             (goto-char start)
+            (pilish--remove-table-overlays start end)
             (delete-region start end)
             (insert text)
             (set-marker pilish--thinking-marker (point))))
@@ -3447,6 +3448,8 @@ Returns the new bounds as (START . NEW-END)."
         new-end)
     (save-excursion
       (goto-char start)
+      ;; A table overlay may include a trailing newline outside this block.
+      (pilish--remove-table-overlays start end)
       (delete-region start end)
       (insert rendered)
       (setq new-end (point))

--- a/pilish-table.el
+++ b/pilish-table.el
@@ -429,6 +429,8 @@ Plain tables (no prefix) take a fast path that skips prefix splitting."
                             (if display-rows
                                 (apply #'max (mapcar #'length display-rows))
                               0)))
+             (aligns (append aligns
+                             (make-list (- num-cols (length aligns)) nil)))
              (content-width (max 1 (- width prefix-width)))
              (col-widths
               (markdown-table-wrap-compute-widths

--- a/test/pilish-render-test.el
+++ b/test/pilish-render-test.el
@@ -870,6 +870,111 @@ agent_end + next section's leading newline must not create triple newlines."
   (pilish--thinking-hidden-stub
    (pilish--thinking-normalize-text text)))
 
+(defconst pilish-test--thinking-with-table
+  "Weigh options:\n| A | B |\n|---|---|\n| keep | details |\n"
+  "Thinking ending in a table, for display invalidation tests.")
+
+(ert-deftest pilish-test-thinking-table-collapse-clears-stale-display ()
+  "Collapsing live or replayed thinking removes only its table displays."
+  (dolist (source '(stream history))
+    (dolist (action '(tab display-mode))
+      (let ((pilish-thinking-display 'visible)
+            (reply "| Reply | Value |\n|---|---|\n| yes | retained |\n"))
+        (with-temp-buffer
+          (pilish-chat-mode)
+          (if (eq source 'stream)
+              (progn
+                (pilish--display-agent-start)
+                (pilish--display-thinking-start)
+                (pilish--display-thinking-delta pilish-test--thinking-with-table)
+                (pilish--display-thinking-end "")
+                (pilish--display-message-delta reply)
+                (pilish--render-complete-message))
+            (pilish--display-session-history
+             `[(:role "assistant"
+                :content [(:type "thinking"
+                           :thinking ,pilish-test--thinking-with-table)
+                          (:type "text" :text ,reply)])]
+             (current-buffer)))
+          (goto-char (text-property-any (point-min) (point-max)
+                                        'pilish-thinking-block 0))
+          (let* ((bounds (pilish--thinking-block-bounds-at-pos (point)))
+                 (thinking-overlays
+                  (seq-filter (lambda (ov) (overlay-get ov 'pilish-table-display))
+                              (overlays-in (car bounds) (cdr bounds))))
+                 (reply-overlays
+                  (seq-filter (lambda (ov) (overlay-get ov 'pilish-table-display))
+                              (overlays-in (cdr bounds) (point-max))))
+                 ;; The thinking table may overlap the separator newline.
+                 (reply-overlays (seq-difference reply-overlays thinking-overlays))
+                 (reply-displays (mapcar (lambda (ov) (overlay-get ov 'display))
+                                         reply-overlays)))
+            (should (= (length thinking-overlays) 3))
+            (should (= (length reply-overlays) 3))
+            (should (seq-some (lambda (ov) (> (overlay-end ov) (cdr bounds)))
+                              thinking-overlays))
+            (if (eq action 'tab)
+                (pilish-toggle-tool-section)
+              (pilish--set-chat-thinking-display 'hidden))
+            ;; Checking raw text alone misses an old display over the stub.
+            (should-not (seq-some #'overlay-buffer thinking-overlays))
+            (should (string-match-p
+                     (regexp-quote (pilish-test--collapsed-thinking-stub
+                                    pilish-test--thinking-with-table))
+                     (buffer-string)))
+            (should (cl-every (lambda (ov) (eq (overlay-buffer ov) (current-buffer)))
+                              reply-overlays))
+            (should (equal reply-displays
+                           (mapcar (lambda (ov) (overlay-get ov 'display))
+                                   reply-overlays)))
+            (should (string-match-p (regexp-quote reply) (buffer-string)))
+            (goto-char (text-property-any (point-min) (point-max)
+                                          'pilish-thinking-block 0))
+            (if (eq action 'tab)
+                (pilish-toggle-tool-section)
+              (pilish--set-chat-thinking-display 'visible))
+            ;; Expanded thinking still supports table decoration.
+            (pilish--decorate-tables-in-region (point-min) (point-max) 80)
+            (should (= (pilish-test--count-overlays-with-prop
+                        'pilish-table-display) 6))))))))
+
+(ert-deftest pilish-test-thinking-table-end-invalidates-only-replaced-display ()
+  "Hidden completion clears stale tables; equal-text completion keeps them."
+  (dolist (display '(hidden visible))
+    (let ((pilish-thinking-display display))
+      (pilish-test--with-streaming-assistant
+        (pilish--display-thinking-start)
+        (pilish--display-thinking-delta pilish-test--thinking-with-table)
+        ;; A streamed tool header adds a newline outside the live thinking
+        ;; marker.  Resize decoration includes it in the last table overlay.
+        (pilish-test--send-assistant-message-update
+         '(:type "toolcall_start" :contentIndex 1
+           :id "call_1" :toolName "read"))
+        (pilish-test--send-assistant-message-update
+         '(:type "toolcall_delta" :contentIndex 1
+           :delta "{\"path\":\"/tmp/example.txt\"}"))
+        (pilish--refresh-hot-tail-tables 70)
+        (let* ((overlays (seq-filter
+                          (lambda (ov) (overlay-get ov 'pilish-table-display))
+                          (overlays-in (point-min) (point-max))))
+               (displays (mapcar (lambda (ov) (overlay-get ov 'display)) overlays)))
+          (should (= (length overlays) 3))
+          (should (seq-some (lambda (ov) (> (overlay-end ov) pilish--thinking-marker))
+                            overlays))
+          (pilish--display-thinking-end "")
+          (if (eq display 'hidden)
+              (progn
+                (should-not (seq-some #'overlay-buffer overlays))
+                (should (string-match-p
+                         (regexp-quote (pilish-test--collapsed-thinking-stub
+                                        pilish-test--thinking-with-table))
+                         (buffer-string))))
+            (should (cl-every (lambda (ov) (eq (overlay-buffer ov) (current-buffer)))
+                              overlays))
+            (should (equal displays
+                           (mapcar (lambda (ov) (overlay-get ov 'display)) overlays))))
+          (should (string-match-p "read /tmp/example\\.txt" (buffer-string))))))))
+
 (defun pilish-test--long-thinking-text (&optional count)
   "Return COUNT lines of long thinking text."
   (mapconcat (lambda (n)

--- a/test/pilish-table-test.el
+++ b/test/pilish-table-test.el
@@ -543,6 +543,77 @@ markdown faces do."
         (should (string-match-p "alice" display))
         (should (pilish-test--string-has-face-attr-p display :weight 'bold))))))
 
+(defun pilish-test--table-row-tokens (lines)
+  "Recover whitespace-free cell tokens from wrapped display LINES."
+  (let ((rows
+         (mapcar
+          (lambda (line)
+            (let ((bare (string-remove-prefix "> " line)))
+              (mapcar #'string-trim
+                      (if pilish-prettify-tables
+                          (butlast (cdr (split-string bare "│")))
+                        (markdown-table-wrap--split-table-row bare)))))
+          lines)))
+    (apply #'cl-mapcar (lambda (&rest chunks) (apply #'concat chunks)) rows)))
+
+(ert-deftest pilish-test-decorate-ragged-table-retains-all-cells ()
+  "Ragged rows keep every cell and full-width separators when wrapped."
+  (dolist (pretty '(t nil))
+    (dolist (prefix '("" "> "))
+      (dolist (width '(38 80 140))
+        (with-temp-buffer
+          (pilish-chat-mode)
+          (let* ((pilish-prettify-tables pretty)
+                 (inhibit-read-only t)
+                 (raw-lines
+                  '("| H1 | H2 |" "|:---|---:|"
+                    "| Cell01 | Cell02 | Cell03 | Cell04 | Cell05 | Cell06 | Cell07 | Cell08 |"))
+                 (raw (concat (mapconcat (lambda (line) (concat prefix line))
+                                        raw-lines "\n")
+                              "\n")))
+            (insert raw)
+            (font-lock-ensure)
+            (pilish--decorate-tables-in-region (point-min) (point-max) width)
+            (let* ((displays (pilish-test--table-overlay-displays-in-region
+                              (point-min) (point-max)))
+                   (groups (mapcar (lambda (display)
+                                     (split-string
+                                      (string-trim-right display "\n+") "\n"))
+                                   displays)))
+              (should (= (length groups) 3))
+              ;; Reassemble wrapped columns: substring checks would miss
+              ;; cells split across lines, or silently dropped columns.
+              (should (equal (pilish-test--table-row-tokens (nth 2 groups))
+                             '("Cell01" "Cell02" "Cell03" "Cell04"
+                               "Cell05" "Cell06" "Cell07" "Cell08")))
+              (should (equal (pilish-test--table-row-tokens (car groups))
+                             '("H1" "H2" "" "" "" "" "" "")))
+              (should (apply #'= (mapcar #'string-width
+                                        (apply #'append groups))))
+              (should (equal raw (buffer-substring-no-properties
+                                  (point-min) (point-max)))))))))))
+
+(ert-deftest pilish-test-ragged-table-keeps-alignment-and-empty-cells ()
+  "Extra columns default to left alignment without changing existing cells."
+  (dolist (pretty '(t nil))
+    (let* ((pilish-prettify-tables pretty)
+           (groups (pilish--table-display-groups
+                    '("| LongLeft | LongRight | Center |" "|:---|---:|:---:|"
+                      "| a | b | c | D4 |" "| short | | | LongerD4 |"
+                      "| left\\|right | right | center | E4 |" "| one |")
+                    140)))
+      (should (apply #'= (mapcar #'string-width (apply #'append groups))))
+      (should (equal (car (nth 2 groups))
+                     (if pretty
+                         "│ a           │         b │   c    │ D4       │"
+                       "| a           |         b |   c    | D4       |")))
+      (should (equal (pilish-test--table-row-tokens (nth 3 groups))
+                     '("short" "" "" "LongerD4")))
+      (should (equal (pilish-test--table-row-tokens (nth 4 groups))
+                     '("left\\|right" "right" "center" "E4")))
+      (should (equal (pilish-test--table-row-tokens (nth 5 groups))
+                     '("one" "" "" ""))))))
+
 (ert-deftest pilish-test-decorate-table-keeps-blockquote-prefix ()
   "Display-only wrapping preserves blockquote prefixes on every visual line."
   (with-temp-buffer


### PR DESCRIPTION
- Keep every cell visible when a table row has more columns than its header.
- Stop old table rows covering collapsed thinking. Quoted tables remain supported.

Checks: `make check`, GUI suite, and 10 scenarios in Ghostty 1.3.1.

~~Related to #274; the reported narrowing still needs a reproduction.~~
