### PR TITLE
Make session details easier to browse

### DIFF
--- a/README.org
+++ b/README.org
@@ -299,8 +299,14 @@ messages, and =f= to fork the conversation from the turn at point.
 
 The chat header ends with a session summary line showing the pi and
 Pilish versions plus skill and prompt-template counts.  Press =TAB= on
-that line to expand it into the loaded context files, skills, and
-prompt templates; =TAB= again collapses it back to the summary line.
+that line to show context files, skills, prompt templates, and extension
+commands in Markdown sections.  Skills, prompts, and extension commands
+are grouped by Project and User, with explicit paths and resources of
+unknown scope kept separate.  Names link to their source files when
+available: press =RET= on a link to open the file, just as in chat output.
+Descriptions help you explore what is available; use =C-c C-p= to run
+commands from the menu.  =TAB= anywhere in the details collapses the summary.
+The extension section lists registered commands, not extensions without commands.
 
 #+html: <a id="sessions-and-context"></a>
 ** Sessions and context 🗂️

--- a/pilish-menu.el
+++ b/pilish-menu.el
@@ -1404,21 +1404,10 @@ future attachment kinds such as video or files."
 
 ;;;; Command Submenus (Templates, Extensions, Skills)
 
-(defun pilish--commands-by-source (source)
-  "Return commands filtered by SOURCE, sorted alphabetically."
-  (sort (seq-filter (lambda (c) (equal (plist-get c :source) source))
-                    pilish--commands)
-        (lambda (a b)
-          (string< (plist-get a :name) (plist-get b :name)))))
-
 (defun pilish--commands-by-source-and-location (source location)
   "Return commands filtered by SOURCE and LOCATION, sorted alphabetically."
-  (sort (seq-filter (lambda (c)
-                      (and (equal (plist-get c :source) source)
-                           (equal (plist-get c :location) location)))
-                    pilish--commands)
-        (lambda (a b)
-          (string< (plist-get a :name) (plist-get b :name)))))
+  (seq-filter (lambda (c) (equal (plist-get c :location) location))
+              (pilish--commands-by-source source)))
 
 (defun pilish--submenu-commands-ordered (source)
   "Return commands for SOURCE ordered by location then name.

--- a/pilish-render.el
+++ b/pilish-render.el
@@ -46,6 +46,7 @@
 (require 'cl-lib)
 (require 'ansi-color)
 (require 'image)
+(require 'url-util)
 
 ;; Forward references for functions in other modules
 (declare-function pilish-compact "pilish-menu" (&optional custom-instructions))
@@ -3532,42 +3533,83 @@ was toggled successfully."
                       (min original-pos (max new-start (1- new-end))))))
     t))
 
-(defun pilish--startup-banner-section (label names)
-  "Return the LABEL detail line listing NAMES for the startup banner.
-NAMES is a list of strings; returns nil when empty so empty sections are
-omitted from the expanded banner entirely."
-  (when names
-    (concat label " " (mapconcat #'identity names ", "))))
+(defun pilish--startup-banner-label (name)
+  "Return NAME as a Markdown code span, preserving literal punctuation."
+  (let ((delimiter "`"))
+    (while (string-match-p (regexp-quote delimiter) name)
+      (setq delimiter (concat delimiter "`")))
+    (concat delimiter
+            (if (or (string-prefix-p "`" name) (string-suffix-p "`" name))
+                (concat " " name " ")
+              name)
+            delimiter)))
+
+(defun pilish--startup-banner-item (name path &optional description)
+  "Format a Markdown list item for NAME, source PATH, and DESCRIPTION.
+PATH is an already normalized Emacs source path, or nil when unavailable.
+Keep it on the link label so the existing file visitor can open known sources
+without imposing the stricter path grammar used for arbitrary chat prose."
+  (let ((label (pilish--startup-banner-label name))
+        (description (string-join (split-string (or description "")) " ")))
+    (concat
+     "- "
+     (if path
+         (format "[%s](<%s>)"
+                 (propertize label 'pilish-startup-source path)
+                 (mapconcat #'url-hexify-string
+                            (split-string (pilish--local-name-for-process path) "/")
+                            "/"))
+       label)
+     (unless (string-empty-p description) (concat " — " description)))))
+
+(defun pilish--startup-banner-section (heading contents)
+  "Return Markdown HEADING followed by CONTENTS, omitting empty sections."
+  (when contents
+    (concat heading "\n\n" (string-join contents "\n"))))
+
+(defun pilish--startup-banner-commands (heading source)
+  "Format a HEADING section for commands of SOURCE, grouped by scope."
+  (let ((groups (seq-group-by (lambda (command) (plist-get command :location))
+                              (pilish--commands-by-source source)))
+        sections)
+    (dolist (scope '(("project" . "Project") ("user" . "User")
+                     ("path" . "Explicit paths") (nil . "Other")))
+      (when-let* ((commands (cdr (assoc (car scope) groups))))
+        (push
+         (pilish--startup-banner-section
+          (concat "### " (cdr scope))
+          (mapcar
+           (lambda (command)
+             (let ((name (plist-get command :name)))
+               (pilish--startup-banner-item
+                (if (equal source "skill")
+                    (string-remove-prefix "skill:" name)
+                  (concat "/" name))
+                (plist-get command :path) (plist-get command :description))))
+           commands))
+         sections)))
+    (when sections
+      (concat heading "\n\n" (string-join (nreverse sections) "\n\n")))))
 
 (defun pilish--format-startup-banner-expanded ()
-  "Return the propertized expanded startup banner text.
-Line one carries the version segments and a TAB collapse hint; then one
-line per non-empty section with context files, skill names (the skill:
-prefix stripped), and prompt names (each prefixed with a slash), all in
-`pilish--commands' order."
-  (let ((sections
-         (delq nil
-               (list
-                (pilish--startup-banner-section
-                 "[Context]" (pilish--startup-context-files))
-                (pilish--startup-banner-section
-                 "[Skills]"
-                 (mapcar (lambda (name) (string-remove-prefix "skill:" name))
-                         (pilish--startup-banner-command-names "skill")))
-                (pilish--startup-banner-section
-                 "[Prompts]"
-                 (mapcar (lambda (name) (concat "/" name))
-                         (pilish--startup-banner-command-names "prompt")))))))
-    (pilish--propertize-startup-banner
-     (mapconcat
-      #'identity
-      (cons (concat (mapconcat #'identity
-                               (pilish--startup-banner-version-segments)
-                               " · ")
-                   " · TAB collapse")
-            sections)
-      "\n")
-     'expanded)))
+  "Return Markdown session details with source links and scoped command lists."
+  (pilish--propertize-startup-banner
+   (string-join
+    (delq nil
+          (list
+           (concat (string-join (pilish--startup-banner-version-segments) " · ")
+                   " · TAB collapse · RET opens source")
+           (pilish--startup-banner-section
+            "## Context files 📚"
+            (mapcar (lambda (path)
+                      (pilish--startup-banner-item
+                       (pilish--route-preserving-abbreviate-file-name path) path))
+                    (pilish--startup-context-files)))
+           (pilish--startup-banner-commands "## Skills 🧠" "skill")
+           (pilish--startup-banner-commands "## Prompts ✍️" "prompt")
+           (pilish--startup-banner-commands "## Extension commands 🧩" "extension")))
+    "\n\n")
+   'expanded))
 
 (defun pilish--startup-banner-probe-pos (pos)
   "Return a position inside the startup banner at POS, or nil.
@@ -5648,7 +5690,8 @@ and collapsed references always own and suppress fallback."
 
 (defun pilish--semantic-link-target (owner)
   "Return the valid local file target for semantic link OWNER, or nil.
-Only an inline link or inline image with a strict local destination qualifies.
+Generated startup source links carry their known Emacs paths.  Otherwise,
+only an inline link or inline image with a strict local destination qualifies.
 URL schemes, mailto links, protocol-relative links, fragment-only links, empty
 or malformed destinations, bare filenames, and reference forms are owned but
 invalid.  A local fragment is returned separately and is never interpreted as
@@ -5679,14 +5722,19 @@ line metadata."
                             source))
              (fragment (and fragment-index
                             (substring source (1+ fragment-index))))
-             (path (pilish--semantic-link-unescape path-source))
+             (source-path
+              (and (eq (get-text-property position 'pilish-startup-banner)
+                       'expanded)
+                   (get-text-property position 'pilish-startup-source)))
+             (path (or source-path (pilish--semantic-link-unescape path-source)))
              (case-fold-search t))
-        (when (and (not (string-empty-p path))
-                   (not (string-prefix-p "#" source))
-                   (not (string-prefix-p "//" source))
-                   (not (string-match-p
-                         "\\`[[:alpha:]][[:alnum:]+.-]*:" source))
-                   (pilish--strict-text-file-path-p path angle))
+        (when (or source-path
+                  (and (not (string-empty-p path))
+                       (not (string-prefix-p "#" source))
+                       (not (string-prefix-p "//" source))
+                       (not (string-match-p
+                             "\\`[[:alpha:]][[:alnum:]+.-]*:" source))
+                       (pilish--strict-text-file-path-p path angle)))
           (let* ((anchor (pilish--chat-session-directory))
                  (emacs-path (pilish--emacs-path path anchor))
                  (label (plist-get label-projection :text)))

--- a/pilish-ui.el
+++ b/pilish-ui.el
@@ -1658,9 +1658,17 @@ Descriptions come from the handler's docstring.")
   "Return non-nil when TEXT names a client-side built-in command."
   (and (pilish--builtin-command-name text) t))
 
+(defun pilish--commands-by-source (source)
+  "Return commands filtered by SOURCE, sorted alphabetically."
+  (sort (seq-filter (lambda (c) (equal (plist-get c :source) source))
+                    pilish--commands)
+        (lambda (a b)
+          (string< (plist-get a :name) (plist-get b :name)))))
+
 (defun pilish--set-commands (commands)
   "Set COMMANDS in current buffer and propagate to sibling session buffers.
-COMMANDS is a list of plists with :name, :description, :source.
+COMMANDS is a list of plists with :name, :source, and optional
+:description, :location, and normalized Emacs :path metadata.
 Both chat and input buffers share the same commands list, so this
 setter updates all of them to keep them in sync."
   (setq pilish--commands commands)
@@ -2335,7 +2343,7 @@ Ends with the compact, toggleable banner line built by
      "C-c C-c   send prompt\n"
      "C-c C-k   abort\n"
      "C-c C-r   sessions\n"
-     "C-c C-p   menu\n"
+     "C-c C-p   menu\n\n"
      (pilish--format-startup-banner-compact) "\n")))
 
 (defun pilish--display-startup-header ()
@@ -2384,19 +2392,6 @@ per directory."
           (setq dir parent))))
     files))
 
-(defun pilish--startup-banner-command-names (source)
-  "Return names of `pilish--commands' entries whose :source equals SOURCE.
-Order follows `pilish--commands' so the banner preserves command order."
-  (delq nil
-        (mapcar (lambda (command)
-                  (when (equal (plist-get command :source) source)
-                    (plist-get command :name)))
-                pilish--commands)))
-
-(defun pilish--startup-banner-count-commands (source)
-  "Return how many `pilish--commands' entries have :source equal to SOURCE."
-  (length (pilish--startup-banner-command-names source)))
-
 (defun pilish--startup-banner-version-segments ()
   "Return version segments for the startup banner summary.
 Includes \"pi V\" only when `pilish--process-version' is set and always
@@ -2425,11 +2420,9 @@ counts."
       (setq segments
             (append segments
                     (list (format "%d skills"
-                                  (pilish--startup-banner-count-commands
-                                   "skill"))
+                                  (length (pilish--commands-by-source "skill")))
                           (format "%d prompts"
-                                  (pilish--startup-banner-count-commands
-                                   "prompt"))))))
+                                  (length (pilish--commands-by-source "prompt")))))))
     (pilish--propertize-startup-banner
      (concat (mapconcat #'identity segments " · ") " · TAB details")
      'compact)))

--- a/test/pilish-render-test.el
+++ b/test/pilish-render-test.el
@@ -869,44 +869,237 @@ The banner is toggled before thinking blocks and outline cycling."
     (search-forward "TAB details")
     (pilish-toggle-tool-section)
     (let ((text (buffer-string)))
-      (should (string-match-p "^pi v0\.84\.2 · pilish 3\.0\.0 · TAB collapse$" text))
-      (should (string-match-p "^\\[Skills\\] aws-sso, uv$" text))
-      (should (string-match-p "^\\[Prompts\\] /create-todo, /fix-tests$" text)))
+      (should (string-match-p "TAB collapse · RET opens source" text))
+      (should (string-match-p "\n\n## Skills 🧠\n\n### Other\n\n- `aws-sso` — AWS SSO\n- `uv` — uv runner" text))
+      (should (string-match-p "\n\n## Prompts ✍️\n\n### Other\n\n- `/create-todo` — New todo\n- `/fix-tests` — Fix tests" text)))
     ;; TAB again restores the compact form.
     (pilish-toggle-tool-section)
     (let ((text (buffer-string)))
       (should (string-match-p
                "^pi v0\.84\.2 · pilish 3\.0\.0 · 2 skills · 2 prompts · TAB details$"
                text))
-      (should-not (string-match-p "\\[Skills\\]" text))
-      (should-not (string-match-p "\\[Prompts\\]" text))
+      (should-not (string-match-p "^## " text))
+      (should (string-match-p "C-c C-p   menu\n\npi v" text))
       (should-not (string-match-p "TAB collapse" text)))))
 
-(ert-deftest pilish-test-startup-banner-details-list-skills-and-prompts ()
-  "Expanded banner strips the skill: prefix, prefixes prompts with /, and
-joins context files with comma and space."
+(ert-deftest pilish-test-startup-banner-details-group-resources ()
+  "Details use Markdown headings and source lists ordered by scope and name."
   (with-temp-buffer
     (pilish-chat-mode)
-    (setq pilish--process-version "0.84.2"
-          pilish--commands
-          (list '(:name "create-todo" :description "New todo" :source "prompt")
-                '(:name "fix-tests" :description "Fix tests" :source "prompt")
-                '(:name "skill:aws-sso" :description "AWS SSO" :source "skill")
-                '(:name "skill:uv" :description "uv runner" :source "skill")))
+    (setq pilish--commands
+          '((:name "skill:uv" :source "skill" :location "user"
+             :path "/home/u/skills/uv/SKILL.md" :description "Run scripts")
+            (:name "skill:z-tests" :source "skill" :location "project"
+             :path "/p/skills/z-tests/SKILL.md")
+            (:name "skill:a-tests" :source "skill" :location "project"
+             :path "/p/skills/a-tests/SKILL.md" :description "Run tests")
+            (:name "review" :source "prompt" :location "user"
+             :path "/home/u/prompts/review.md")
+            (:name "commit" :source "prompt" :location "project"
+             :path "/p/prompts/commit.md")
+            (:name "inspect" :source "extension" :location "path"
+             :path "/tmp/inspect.ts" :description "Inspect state")
+            (:name "user-tool" :source "extension" :location "user"
+             :path "/home/u/extensions/tool.ts")
+            (:name "project-tool" :source "extension" :location "project"
+             :path "/p/extensions/tool.ts")
+            (:name "no-source" :source "extension")))
     (cl-letf (((symbol-function 'pilish--startup-context-files)
-               (lambda (&optional _directory _user-agent-dir)
-                 '("/home/u/.pi/agent/AGENTS.md" "/p/AGENTS.md"))))
+               (lambda () '("/p/AGENTS.md"))))
       (pilish--display-startup-header)
       (goto-char (point-min))
       (search-forward "TAB details")
       (pilish-toggle-tool-section)
-      (let ((text (buffer-string)))
-        (should (string-match-p "^\\[Skills\\] aws-sso, uv$" text))
-        (should-not (string-match-p "skill:" text))
-        (should (string-match-p "^\\[Prompts\\] /create-todo, /fix-tests$" text))
-        (should (string-match-p
-                 "^\\[Context\\] /home/u/.pi/agent/AGENTS.md, /p/AGENTS.md$"
-                 text))))))
+      (let* ((region (pilish--startup-banner-region))
+             (details (buffer-substring-no-properties
+                       (car region) (cdr region))))
+        (should
+         (equal details
+                (concat
+                 "pilish 3.0.0 · TAB collapse · RET opens source\n\n"
+                 "## Context files 📚\n\n"
+                 "- [`/p/AGENTS.md`](</p/AGENTS.md>)\n\n"
+                 "## Skills 🧠\n\n### Project\n\n"
+                 "- [`a-tests`](</p/skills/a-tests/SKILL.md>) — Run tests\n"
+                 "- [`z-tests`](</p/skills/z-tests/SKILL.md>)\n\n"
+                 "### User\n\n"
+                 "- [`uv`](</home/u/skills/uv/SKILL.md>) — Run scripts\n\n"
+                 "## Prompts ✍️\n\n### Project\n\n"
+                 "- [`/commit`](</p/prompts/commit.md>)\n\n"
+                 "### User\n\n- [`/review`](</home/u/prompts/review.md>)\n\n"
+                 "## Extension commands 🧩\n\n### Project\n\n"
+                 "- [`/project-tool`](</p/extensions/tool.ts>)\n\n"
+                 "### User\n\n- [`/user-tool`](</home/u/extensions/tool.ts>)\n\n"
+                 "### Explicit paths\n\n- [`/inspect`](</tmp/inspect.ts>) — Inspect state\n\n"
+                 "### Other\n\n- `/no-source`"))))
+      ;; The formatter must produce actual Markdown structure, not just faces.
+      (let* ((root (treesit-buffer-root-node 'markdown))
+             (headings (treesit-query-capture root '((atx_heading) @heading)))
+             (items (treesit-query-capture root '((list_item) @item))))
+        (should (= 12 (length headings)))
+        (should (= 10 (length items)))))))
+
+(ert-deftest pilish-test-startup-banner-source-links-visit-real-files ()
+  "RET on each kind of source opens its file, including unusual path names."
+  (let ((dir (pilish-test--make-temp-directory "pilish-test-banner-links-"))
+        visited)
+    (unwind-protect
+        (save-window-excursion
+          (with-temp-buffer
+            (switch-to-buffer (current-buffer))
+            (pilish-chat-mode)
+            (pilish--set-chat-session-identity dir)
+            (let* ((paths (mapcar
+                           (lambda (name) (expand-file-name name dir))
+                           '("AGENTS.md" "skills/a [b] (c)#1%/SKILL.md"
+                             "prompts/my prompt.md" "extensions/a&b.ts")))
+                   (names '("AGENTS.md" "browse" "/review" "/inspect")))
+              (dolist (path paths)
+                (make-directory (file-name-directory path) t)
+                (with-temp-file path (insert (file-name-nondirectory path))))
+              (setq pilish--commands
+                    (cl-mapcar
+                     (lambda (source name path)
+                       (list :source source :name name :path path
+                             :location "project"))
+                     '("skill" "prompt" "extension")
+                     '("skill:browse" "review" "inspect") (cdr paths)))
+              (cl-letf (((symbol-function 'pilish--startup-context-files)
+                         (lambda () (list (car paths)))))
+                (pilish--display-startup-header)
+                (let ((compact (buffer-string)))
+                  (goto-char (point-min))
+                  (search-forward "TAB details")
+                  (execute-kbd-macro (kbd "TAB"))
+                  ;; Refontification must preserve source identity.
+                  (font-lock-flush)
+                  (font-lock-ensure)
+                  (cl-mapc
+                   (lambda (name path)
+                     (goto-char (point-min))
+                     (search-forward name)
+                     (backward-char)
+                     (let ((target (pilish--file-target-at-point)))
+                       (should (eq :link (plist-get target :source)))
+                       (should (equal path (plist-get target :emacs-path))))
+                     (save-window-excursion
+                       (execute-kbd-macro (kbd "RET"))
+                       (push (current-buffer) visited)
+                       (should (equal path (buffer-file-name)))
+                       (should (equal (file-name-nondirectory path)
+                                      (buffer-string)))))
+                   names paths)
+                  ;; Collapse from the final item, not only the hint line.
+                  (execute-kbd-macro (kbd "TAB"))
+                  (should (equal compact (buffer-string))))))))
+      (dolist (buffer visited)
+        (when (buffer-live-p buffer) (kill-buffer buffer)))
+      (delete-directory dir t))))
+
+(ert-deftest pilish-test-startup-banner-source-links-keep-remote-host ()
+  "Source links reuse normalized command paths without probing the remote host."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (let ((anchor "/ssh:bastion|sudo:root@pi-host:/home/pi/project/"))
+      (pilish--set-chat-session-identity anchor)
+      (setq pilish--commands
+            (list (pilish--normalize-command
+                   '(:name "skill:remote" :source "skill"
+                     :sourceInfo (:scope "project"
+                                  :path "/home/pi/project/skills/my skill/SKILL.md"))
+                   anchor)))
+      (cl-letf (((symbol-function 'pilish--startup-context-files) #'ignore))
+        (pilish--display-startup-header)
+        (goto-char (point-min))
+        (search-forward "TAB details")
+        (pilish-toggle-tool-section))
+      (goto-char (point-min))
+      (search-forward "remote")
+      (backward-char)
+      (should (equal
+               "/ssh:bastion|sudo:root@pi-host:/home/pi/project/skills/my skill/SKILL.md"
+               (plist-get (pilish--file-target-at-point) :emacs-path))))))
+
+(ert-deftest pilish-test-startup-banner-refresh-preserves-open-source-links ()
+  "A refresh leaves open details alone; reopening uses the new command sources."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (setq pilish--commands
+          '((:name "review" :source "prompt" :location "project"
+             :path "/p/old.md")))
+    (cl-letf (((symbol-function 'pilish--startup-context-files) #'ignore))
+      (pilish--display-session-history
+       (pilish-test--startup-banner-history) (current-buffer))
+      (let* ((region (pilish--startup-banner-region))
+             (history (buffer-substring (cdr region) (point-max))))
+        (goto-char (car region))
+        (pilish-toggle-tool-section)
+        (search-forward "/review")
+        (backward-char)
+        (let ((expanded (buffer-string)))
+          (pilish--set-commands
+           '((:name "review" :source "prompt" :location "project"
+              :path "/p/new.md")))
+          (should (equal-including-properties expanded (buffer-string)))
+          (should (equal "/p/old.md"
+                         (plist-get (pilish--file-target-at-point) :emacs-path))))
+        (pilish-toggle-tool-section)
+        (pilish-toggle-tool-section)
+        (goto-char (car (pilish--startup-banner-region)))
+        (search-forward "/review")
+        (backward-char)
+        (should (equal "/p/new.md"
+                       (plist-get (pilish--file-target-at-point) :emacs-path)))
+        (should (equal history
+                       (buffer-substring
+                        (cdr (pilish--startup-banner-region)) (point-max))))))))
+
+(ert-deftest pilish-test-startup-banner-source-links-require-header-ownership ()
+  "Known-source metadata cannot loosen ordinary chat link parsing."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert (pilish--startup-banner-item "source" "/p/my files/source.md")))
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "source")
+    (backward-char)
+    (should-not (pilish--file-target-at-point))))
+
+(ert-deftest pilish-test-startup-banner-keeps-descriptions-inline ()
+  "Descriptions stay in one list item; names preserve literal punctuation."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (setq pilish--commands
+          '((:name "inspect[all]" :source "extension" :location "user"
+             :path "/p/inspect.ts"
+             :description "Inspect **all**\n\n## Not a heading")))
+    (cl-letf (((symbol-function 'pilish--startup-context-files) #'ignore))
+      (let ((inhibit-read-only t))
+        (insert (pilish--format-startup-banner-expanded))))
+    (font-lock-ensure)
+    (let* ((root (treesit-buffer-root-node 'markdown))
+           (headings (treesit-query-capture root '((atx_heading) @heading)))
+           (items (treesit-query-capture root '((list_item) @item))))
+      (should (= 2 (length headings)))
+      (should (= 1 (length items))))
+    (should (string-match-p
+             (regexp-quote "/inspect[all] — Inspect all ## Not a heading")
+             (pilish--visible-text (point-min) (point-max))))))
+
+(ert-deftest pilish-test-startup-banner-omits-empty-sections ()
+  "Without resources, expansion contains only versions and the key hints."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (cl-letf (((symbol-function 'pilish--startup-context-files) #'ignore))
+      (pilish--display-startup-header)
+      (goto-char (point-min))
+      (search-forward "TAB details")
+      (pilish-toggle-tool-section))
+    (let ((region (pilish--startup-banner-region)))
+      (should (equal "pilish 3.0.0 · TAB collapse · RET opens source"
+                     (buffer-substring-no-properties
+                      (car region) (cdr region)))))))
 
 (ert-deftest pilish-test-display-session-history-includes-startup-summary ()
   "History replay renders the compact startup summary above session messages."
@@ -952,7 +1145,7 @@ joins context files with comma and space."
                (regexp-quote
                 "pi v0.84.2 · pilish 3.0.0 · 2 skills · 2 prompts · TAB details")
                text))
-      (should-not (string-match-p "\\[Skills\\]" text))
+      (should-not (string-match-p "^## Skills" text))
       (should-not (string-match-p "TAB collapse" text)))))
 
 (defun pilish-test--history-with-toggleable-thinking ()

--- a/test/pilish-ui-test.el
+++ b/test/pilish-ui-test.el
@@ -857,7 +857,8 @@ without an input window."
   (let ((header (pilish--format-startup-header)))
     (should (string-match-p "C-c C-c" header))
     (should (string-match-p "send" header))
-    (should (string-match-p "C-c C-r   sessions" header))))
+    (should (string-match-p "C-c C-r   sessions" header))
+    (should (string-match-p "C-c C-p   menu\n\npilish" header))))
 
 (ert-deftest pilish-test-startup-header-shows-label ()
   "Startup header labels the buffer with the project title."


### PR DESCRIPTION
Group skills, prompts, and extension commands by context, with spaced Markdown headings, descriptions, and source links. Press RET on a link to open its file.