### PR TITLE
Show a theme-aware SVG logo in the startup header

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Run
       env:
         LOCAL_REPO: ${{ github.workspace }}
-        RECIPE: (pilish :fetcher github :repo "dnouri/pilish" :old-names (pi-coding-agent))
+        RECIPE: (pilish :fetcher github :repo "dnouri/pilish" :old-names (pi-coding-agent) :files (:defaults ("assets" "assets/pilish-logo.svg")))
         WARN_IS_ERROR: false
         EXIST_OK: false
       run: make -C ~/melpazoid

--- a/pilish-ui.el
+++ b/pilish-ui.el
@@ -2333,11 +2333,97 @@ Stores the result in CHAT-BUF and emits a minibuffer notice when available."
                ;; already re-established the chat-buffer context above.
                (pilish--refresh-startup-banner)))))))))
 
+;;;; Startup Logo
+
+(defconst pilish--logo-file
+  (expand-file-name
+   "assets/pilish-logo.svg"
+   (file-name-directory
+    (or load-file-name
+        (ignore-errors (symbol-file 'pilish--make-separator 'defun))
+        (locate-library "pilish-ui")
+        "pilish-ui.el")))
+  "Absolute path of the canonical Hornbridge logo SVG shipped with Pilish.
+Resolved from the installed pilish-ui library location, never from
+`default-directory', so the logo also works from package installs,
+byte-compiled load paths, and TRAMP chat buffers.")
+
+(defvar pilish--logo-svg-cache nil
+  "Cached adapted SVG source for the startup logo, or nil when unread.
+See `pilish--logo-svg-data'.")
+
+(defun pilish--logo-svg-data ()
+  "Return adapted SVG source text for the startup logo, or nil.
+Reads `pilish--logo-file' and adapts it in memory: the dark backplate
+rectangle is dropped and the three body path fills become `currentColor'
+so the logo body tracks the heading face foreground on every theme.
+The violet horn fills and all path geometry stay identical to the
+shipped asset, which remains the single canonical source.  Returns nil
+when the asset cannot be read; callers then omit the logo silently."
+  (or pilish--logo-svg-cache
+      (setq pilish--logo-svg-cache
+            (ignore-errors
+              (with-temp-buffer
+                (insert-file-contents pilish--logo-file)
+                (goto-char (point-min))
+                (when (re-search-forward
+                       "[ \t]*<rect[^>]*fill=\"#07100F\"[^>]*/>[ \t]*\n?" nil t)
+                  (replace-match ""))
+                (goto-char (point-min))
+                (while (search-forward "#EEF2E8" nil t)
+                  (replace-match "currentColor" t t))
+                (buffer-string))))))
+
+(defun pilish--startup-logo-displayable-p ()
+  "Return non-nil when the display being drawn can show the startup logo.
+Used inside conditional display specifications, where redisplay
+evaluates it for the frame actually being drawn.  Both image-capable
+display and SVG support are required: batch and terminal Emacs can
+report SVG available without being able to display any image."
+  (and (display-images-p) (image-type-available-p 'svg)))
+
+(defun pilish--startup-logo-line-prefix ()
+  "Return the display-only prefix for the startup heading line.
+Contains the logo image glyph and one font-relative gap glyph, both
+carrying the `md-ts-heading-1' face so the body fill (currentColor)
+matches the heading.  Each glyph's display value is a list pairing its
+real spec, wrapped in `(when (pilish--startup-logo-displayable-p)
+...)', with a zero-width space fallback: text terminals and graphical
+displays without SVG render no logo and no gap, while the same buffer
+shows the logo on image-capable frames.  The glyphs never enter the
+buffer text or the kill ring."
+  (when-let* ((data (pilish--logo-svg-data)))
+    (let* ((image (list 'image :type 'svg :data data
+                        :height '(1.5 . em) :scale 1 :ascent 'center))
+           (conditional
+            (lambda (spec)
+              (list (cons 'when
+                          (cons '(pilish--startup-logo-displayable-p) spec))
+                    '(space . (:width 0))))))
+      (propertize
+       (concat (propertize " " 'display (funcall conditional image))
+               (propertize " " 'display
+                           (funcall conditional '(space . (:width 0.75)))))
+       'face 'md-ts-heading-1))))
+
+(defun pilish--startup-heading-with-logo (separator)
+  "Return SEPARATOR with the startup logo prefix on its heading line.
+The label line (through its newline) alone receives the display-only
+`line-prefix'; the returned string content and the setext underline
+stay unchanged.  Returns SEPARATOR as-is when the logo is unavailable."
+  (let* ((newline (string-match "\n" separator))
+         (prefix (and newline (pilish--startup-logo-line-prefix))))
+    (when prefix
+      (put-text-property 0 (1+ newline) 'line-prefix prefix separator))
+    separator))
+
 (defun pilish--format-startup-header ()
   "Format the startup header string with separator and session summary.
-Ends with the compact, toggleable banner line built by
-`pilish--format-startup-banner-compact'."
-  (let ((separator (pilish--make-separator "Pilish")))
+The heading line carries the Hornbridge logo as a display-only prefix
+on image-capable displays.  Ends with the compact, toggleable banner
+line built by `pilish--format-startup-banner-compact'."
+  (let ((separator (pilish--startup-heading-with-logo
+                    (pilish--make-separator "Pilish"))))
     (concat
      separator "\n"
      "C-c C-c   send prompt\n"

--- a/test/pilish-build-test.el
+++ b/test/pilish-build-test.el
@@ -196,5 +196,62 @@
             nil t)
       (should called))))
 
+;;;; Packaging invariants (MELPA recipe / melpazoid CI / shipped asset)
+
+(defconst pilish-test-build--logo-asset "assets/pilish-logo.svg"
+  "Canonical runtime path of the logo, relative to the package root.
+Single source of truth for the packaging tests: the MELPA recipe and the
+melpazoid CI recipe must map this file unflattened so that the installed
+`pilish--logo-file' resolves beside the installed libraries.")
+
+(ert-deftest pilish-test-build-logo-asset-present ()
+  "The logo asset ships at the canonical path with the adaptation contract."
+  (let ((asset (expand-file-name pilish-test-build--logo-asset
+                                 pilish-test-build--repo-root)))
+    (should (file-exists-p asset))
+    (with-temp-buffer
+      (insert-file-contents asset)
+      ;; The runtime adapter (`pilish--logo-svg-data') rewrites exactly
+      ;; these fills; a regenerated asset must keep the same contract.
+      (should (= 1 (how-many "fill=\"#07100F\"" (point-min) (point-max))))
+      (should (= 3 (how-many "fill=\"#EEF2E8\"" (point-min) (point-max))))
+      (should (= 2 (how-many "fill=\"#A970FF\"" (point-min) (point-max)))))))
+
+(ert-deftest pilish-test-build-recipe-files-mapping ()
+  "The melpazoid CI recipe maps the logo unflattened into the install root.
+MELPA's default file set omits `assets/'; the recipe therefore appends a
+files mapping that must keep the subdirectory (a bare glob would flatten
+the directory and break `pilish--logo-file' on package installs)."
+  (let* ((workflow (expand-file-name ".github/workflows/melpazoid.yml"
+                                     pilish-test-build--repo-root))
+         (recipe (with-temp-buffer
+                   (skip-unless (file-exists-p workflow))
+                   (insert-file-contents workflow)
+                   (goto-char (point-min))
+                   (should (re-search-forward "^\\s-*RECIPE:\\s-+" nil t))
+                   (read (current-buffer))))
+         (files (plist-get (cdr recipe) :files))
+         covered)
+    (should (eq (car recipe) 'pilish))
+    ;; `:defaults' must stay the first element of the files spec.
+    (should (eq (car files) :defaults))
+    (dolist (entry (cdr files))
+      (pcase-exhaustive entry
+        ;; A bare string entry is copied to the package root, flattening
+        ;; any subdirectory; the mapping must use (TARGET-DIR SOURCE...).
+        ((pred stringp) (should-not entry))
+        (`(,dest . ,sources)
+         (dolist (src sources)
+           ;; Anti-flatten: the destination directory equals the source
+           ;; file's own directory, so the installed path is unchanged.
+           (should (string-equal (file-name-as-directory dest)
+                                 (or (file-name-directory src) "")))
+           ;; The mapped source must exist in the repository.
+           (should (file-exists-p
+                    (expand-file-name src pilish-test-build--repo-root)))
+           (when (string-equal src pilish-test-build--logo-asset)
+             (setq covered t))))))
+    (should covered)))
+
 (provide 'pilish-build-test)
 ;;; pilish-build-test.el ends here

--- a/test/pilish-gui-tests.el
+++ b/test/pilish-gui-tests.el
@@ -451,6 +451,31 @@ logical block and should not start following later streamed output."
             (should (> (cdr size) 0))))
       (kill-buffer buffer))))
 
+(ert-deftest pilish-gui-test-startup-logo-renders-real-image ()
+  "The startup heading renders the real SVG logo on image-capable displays.
+The 1.5em image glyph makes the heading row taller than a text row and
+pushes the heading text right of the logo box."
+  (unless (and (display-images-p) (image-type-available-p 'svg))
+    (ert-skip "This Emacs display cannot render SVG images"))
+  (let ((buffer (get-buffer-create "*pi-gui-startup-logo*")))
+    (unwind-protect
+        (progn
+          (switch-to-buffer buffer)
+          (pilish-chat-mode)
+          (let ((inhibit-read-only t))
+            (insert (pilish--format-startup-header))
+            (font-lock-ensure)
+            (goto-char (point-min))
+            (set-window-start (selected-window) (point-min))
+            (redisplay)
+            (should (get-text-property 1 'line-prefix))
+            ;; A rendered 1.5em image makes this row taller than a text row.
+            (should (> (line-pixel-height) (frame-char-height)))
+            ;; Heading text starts right of the logo box plus gap.
+            (should (> (car (posn-x-y (posn-at-point (point-min))))
+                       (frame-char-width)))))
+      (kill-buffer buffer))))
+
 (ert-deftest pilish-gui-test-read-svg-has-real-display-property ()
   "A complete standalone SVG returned by read renders graphically."
   (unless (and (display-images-p) (image-type-available-p 'svg))

--- a/test/pilish-render-test.el
+++ b/test/pilish-render-test.el
@@ -847,6 +847,45 @@ agent_end + next section's leading newline must not create triple newlines."
       (should (< first-pos custom-pos))
       (should (< custom-pos second-pos)))))
 
+(ert-deftest pilish-test-session-history-rebuild-keeps-single-logo-decoration ()
+  "A full history rebuild decorates the startup heading exactly once.
+Reloads and resumes reuse `pilish--format-startup-header', so the logo
+prefix must not duplicate or leak image display properties into the
+rendered turns."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (pilish--display-session-history
+     [(:role "user"
+       :content [(:type "text" :text "Question?")]
+       :timestamp 1704067200000)
+      (:role "assistant"
+       :content [(:type "text" :text "Answer.")]
+       :timestamp 1704067201000)]
+     (current-buffer))
+    (should (equal "Pilish\n======"
+                   (buffer-substring-no-properties 1 14)))
+    ;; Heading line decorated, underline and turns plain.
+    (let ((decorated 0) (images 0) (pos (point-min)))
+      (while (< pos (point-max))
+        (when (get-text-property pos 'line-prefix)
+          (cl-incf decorated))
+        (when (and (get-text-property pos 'display)
+                   (not (get-text-property pos 'line-prefix)))
+          (cl-incf images))
+        (setq pos (1+ pos)))
+      (should (= 7 decorated))
+      (should (= 0 images))
+      ;; Rebuilding the same history again stays single.
+      (pilish--display-session-history [] (current-buffer))
+      (goto-char (point-min))
+      (should (get-text-property 1 'line-prefix))
+      (setq decorated 0 pos (point-min))
+      (while (< pos (point-max))
+        (when (get-text-property pos 'line-prefix)
+          (cl-incf decorated))
+        (setq pos (1+ pos)))
+      (should (= 7 decorated)))))
+
 (defun pilish-test--startup-banner-history ()
   "Return a one-turn history used by startup banner tests."
   [(:role "user"

--- a/test/pilish-ui-test.el
+++ b/test/pilish-ui-test.el
@@ -865,6 +865,145 @@ without an input window."
   (let ((header (pilish--format-startup-header)))
     (should (string-equal "Pilish" (car (split-string header "\n"))))))
 
+;;;; Startup Logo
+
+(ert-deftest pilish-test-startup-header-decorates-heading-with-logo ()
+  "Startup heading carries the logo as a display-only line-prefix.
+The raw separator text stays byte-identical; the property covers the
+label line through its newline and never the setext underline."
+  (let ((header (pilish--format-startup-header)))
+    (should (string-equal "Pilish\n======\n"
+                          (substring-no-properties header 0 14)))
+    (should (get-text-property 0 'line-prefix header))
+    (should (get-text-property 6 'line-prefix header))
+    (should-not (get-text-property 7 'line-prefix header))))
+
+(ert-deftest pilish-test-logo-file-form-evaluates-without-load-file-name ()
+  "The `pilish--logo-file' form evaluates when `load-file-name' is nil.
+Covers the eval-buffer/eval-region dev flow over already-loaded
+Pilish: the fallback chain must answer via `symbol-file' without
+signaling, or evaluation of pilish-ui.el aborts at the defconst."
+  (let* ((lib (or (symbol-file 'pilish--make-separator 'defun)
+                  (locate-library "pilish-ui")))
+         (source (and lib
+                      (if (string-suffix-p ".elc" lib)
+                          (concat (substring lib 0 -1))
+                        lib))))
+    (if (not (and source (file-exists-p source)))
+        (ert-skip "pilish-ui.el source not readable")
+      (let ((form (catch 'found
+                    (with-temp-buffer
+                      (insert-file-contents source)
+                      (goto-char (point-min))
+                      (condition-case nil
+                          (while t
+                            (let ((f (read (current-buffer))))
+                              (when (eq (nth 1 f) 'pilish--logo-file)
+                                (throw 'found f))))
+                        (end-of-file)))))
+            (load-file-name nil))
+        (should (eq 'defconst (car-safe form)))
+        (let ((value (eval (nth 2 form))))
+          (should (stringp value))
+          (should (file-name-absolute-p value))
+          (should (string-suffix-p "assets/pilish-logo.svg" value)))))))
+
+(defun pilish-test--startup-logo-glyph-specs (prefix)
+  "Return the two display specs of logo PREFIX for structural checks."
+  (mapcar (lambda (i) (get-text-property i 'display prefix)) '(0 1)))
+
+(ert-deftest pilish-test-startup-logo-prefix-structure ()
+  "Logo prefix glyphs are conditional and collapse on plain displays.
+Each glyph's display value pairs a `(when ...)' spec gated on
+`pilish--startup-logo-displayable-p' with a zero-width space fallback,
+so text terminals and no-SVG displays show neither logo nor gap.  The
+image glyph renders the shipped asset adapted for theme matching: no
+backplate, currentColor body, violet horns kept, 1.5em height."
+  (let* ((header (pilish--format-startup-header))
+         (prefix (get-text-property 0 'line-prefix header))
+         (specs (pilish-test--startup-logo-glyph-specs prefix)))
+    (should (stringp prefix))
+    (should (= 2 (length prefix)))
+    (dolist (i '(0 1))
+      (should (eq 'md-ts-heading-1 (get-text-property i 'face prefix))))
+    ;; Inert decoration: no interactive properties on either glyph.
+    (dolist (i '(0 1))
+      (should-not (get-text-property i 'keymap prefix))
+      (should-not (get-text-property i 'mouse-face prefix))
+      (should-not (get-text-property i 'help-echo prefix)))
+    (pcase-let ((`(,logo-display ,gap-display) specs))
+      (dolist (display (list logo-display gap-display))
+        (let ((conditional (nth 0 display))
+              (fallback (nth 1 display)))
+          (should (eq 'when (car conditional)))
+          (should (equal '(pilish--startup-logo-displayable-p)
+                         (nth 1 conditional)))
+          (should (equal '(space . (:width 0)) fallback))))
+      (let* ((logo-conditional (nth 0 logo-display))
+             (payload (nthcdr 2 logo-conditional)))
+        (should (eq 'image (car payload)))
+        (should (eq 'svg (plist-get (cdr payload) :type)))
+        (should (equal '(1.5 . em) (plist-get (cdr payload) :height)))
+        (should (eq 1 (plist-get (cdr payload) :scale)))
+        (should (eq 'center (plist-get (cdr payload) :ascent)))
+        (let ((data (plist-get (cdr payload) :data)))
+          (should (string-match-p "currentColor" data))
+          (should (string-match-p "#A970FF" data))
+          (should-not (string-match-p "#EEF2E8" data))
+          (should-not (string-match-p "#07100F" data))
+          (should-not (string-match-p "<rect" data))))
+      (should (equal '(space . (:width 0.75))
+                     (nthcdr 2 (nth 0 gap-display)))))))
+
+(ert-deftest pilish-test-startup-logo-displayable-p-gates-both-display-and-svg ()
+  "The predicate needs image display AND SVG support.
+Batch Emacs reports SVG available with no display, so either alone
+must not enable the logo."
+  (cl-letf (((symbol-function 'display-images-p) (lambda (&optional _f) t))
+            ((symbol-function 'image-type-available-p) (lambda (&optional _t) t)))
+    (should (pilish--startup-logo-displayable-p)))
+  (cl-letf (((symbol-function 'display-images-p) (lambda (&optional _f) nil))
+            ((symbol-function 'image-type-available-p) (lambda (&optional _t) t)))
+    (should-not (pilish--startup-logo-displayable-p)))
+  (cl-letf (((symbol-function 'display-images-p) (lambda (&optional _f) t))
+            ((symbol-function 'image-type-available-p) (lambda (&optional _t) nil)))
+    (should-not (pilish--startup-logo-displayable-p))))
+
+(ert-deftest pilish-test-startup-header-omits-logo-when-asset-missing ()
+  "Missing asset means a plain heading: no prefix, no error, no warning."
+  (let ((pilish--logo-file "/nonexistent/pilish-logo.svg")
+        (pilish--logo-svg-cache nil)
+        (warnings nil))
+    (cl-letf (((symbol-function 'display-warning)
+               (lambda (&rest args) (push args warnings))))
+      (let ((header (pilish--format-startup-header)))
+        (should (string-equal "Pilish\n======\n"
+                              (substring-no-properties header 0 14)))
+        (should-not (get-text-property 0 'line-prefix header))
+        (should (null warnings))))))
+
+(ert-deftest pilish-test-startup-header-logo-preserves-copy-and-single-decoration ()
+  "Displayed startup header copies as plain text with one decoration.
+The filtered copy still returns the bare heading; exactly one heading
+carries the prefix; font-lock-ensure keeps the decoration and the
+heading face in place."
+  (with-temp-buffer
+    (pilish-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert (pilish--format-startup-header)))
+    (font-lock-ensure)
+    (should (equal "Pilish\n" (pilish--filter-buffer-substring 1 8)))
+    (should (equal "Pilish\n======"
+                   (buffer-substring-no-properties 1 14)))
+    ;; Exactly the seven heading-line characters carry the prefix.
+    (let ((decorated 0) (pos (point-min)))
+      (while (< pos (point-max))
+        (when (get-text-property pos 'line-prefix)
+          (cl-incf decorated))
+        (setq pos (1+ pos)))
+      (should (= 7 decorated))
+      (should (eq 'md-ts-heading-1 (get-text-property 1 'face))))))
+
 (defun pilish-test--banner-commands ()
   "Return a command fixture with two prompts and two skills."
   (list '(:name "create-todo" :description "New todo" :source "prompt")


### PR DESCRIPTION
## Summary

- The startup header shows the first-party `assets/pilish-logo.svg` next to the "Pilish" heading on image-capable GUI frames. It is a display-only `line-prefix` of two glyphs (image plus a 0.75-space gap); the body fill uses `currentColor`, so it follows the theme's heading colour.
- Terminal frames keep the plain heading: the per-frame display condition is nil there and a zero-width fallback renders, so no gap or broken glyph appears. Raw heading text, the setext underline, and copy/kill output are unchanged.
- The melpazoid workflow RECIPE gains `:files (:defaults ("assets" "assets/pilish-logo.svg"))` so the asset ships at its original path in MELPA builds; two tests in `test/pilish-build-test.el` pin the mapping and the SVG fill adaptation.

## Testing

1. Pre-commit hook (`make check`): compile, checkdoc, package-lint clean; 1708 unit tests, 0 unexpected results, 1 pre-existing skip (`pilish-test-installed-md-ts-03-keeps-link-label-unbuttonized`).
2. GUI lane under Xvfb: real image glyph, 24 px heading row, horns `#A970FF`, body follows the heading face in light and dark themes.
3. Mixed GUI+TTY probe in one process: TTY heading at column 0 with no gap; the GUI keeps the logo through frame switches.
4. Package-build tarball plus isolated install: `pilish--logo-file` resolves inside the installed `assets/` directory, also under a TRAMP `default-directory`.
