### PR TITLE
Fix compaction and queued input for pi 0.85.0+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,19 @@ Cross-module state mutations use accessor functions defined in `ui.el`
 (e.g., `--set-process`, `--set-aborted`, `--push-followup`).  Within a
 module, direct `setq` is fine.
 
+`agent_end` finishes the low-level loop and finalizes tools. `agent_settled`
+releases waiting (`sending`) work, not observably newer streaming/compaction:
+Pi emits it *after* awaited extension hooks, which can start another operation.
+If that newer run has also ended, settlements have no wire identity and cannot
+be distinguished universally (even with `get_state`). Do not invent run IDs or
+timer-based settlement guarantees. Automatic compaction preserves its surrounding
+owner; explicit manual compaction does not inherit an older run's sending state.
+Locally initiated manual compaction reserves submission via the existing pending
+RPC table until its correlated response. Prompt request records separately track
+acceptance and observed start/echo, since an extension's acknowledgment can follow
+its run's settlement. Stop sends `clear_queue` before `abort` and reapplies its
+latch on delayed agent/compaction starts.
+
 ## Source Files
 
 | File | Purpose |

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BATCH = $(EMACS) --batch -Q -L . \
 LOCAL_LOAD_PATH = --eval "(setq load-path (cons (expand-file-name \".\") load-path))"
 
 # Pi CLI version — single source of truth (workflows extract this automatically)
-PI_VERSION ?= 0.84.2
+PI_VERSION ?= 0.85.0
 PI_PACKAGE ?= @earendil-works/pi-coding-agent
 PI_BIN ?= .cache/pi/node_modules/.bin/pi
 PI_BIN_DIR = $(abspath $(dir $(PI_BIN)))

--- a/README.org
+++ b/README.org
@@ -49,16 +49,15 @@ is the shortest path to a usable session.
 
 - Emacs 29.1 or later, built with tree-sitter support
 - Node.js 22.19 or later for the pi CLI
-- [[https://pi.dev][pi coding agent]] =@earendil-works/pi-coding-agent@0.84.2= or later,
+- [[https://pi.dev][pi coding agent]] =@earendil-works/pi-coding-agent@0.85.0= or later,
   installed and in =PATH= on the host where Pi runs
 - Pi CLI authentication: a provider API key, or a one-time =/login= run
   in a terminal (see [[#install-pi-and-authenticate-][Install pi and authenticate]])
 - A C compiler if Emacs needs to compile tree-sitter grammars
 
-The published Pi 0.84.2 CLI omits tool identity metadata from
-=toolcall_start=.  It remains supported: tool blocks appear when the
-corresponding =toolcall_end= arrives.  Newer Pi builds that include =id= and
-=toolName= on the start event also show supported arguments while they stream.
+Upgrade older Pi installations before using Pilish.  Pi 0.85.0 or later is
+required for run settlement, queue clearing, and compaction abort handling;
+older protocol versions are not supported.
 
 ** Install pi and authenticate 🔐
 :PROPERTIES:

--- a/README.org
+++ b/README.org
@@ -186,7 +186,9 @@ Type in the input buffer and press =C-c C-c= to send.  If Pi is
 already working, =C-c C-c= queues the text as a follow-up and sends it
 when the current turn finishes.  Press =C-c C-s= while Pi is busy to
 send a steering message: it is delivered after the current tool call
-and interrupts the remaining queued tools.  Press =C-c C-k= to abort the
+and interrupts the remaining queued tools.  During compaction or while
+waiting for a run to settle, =C-c C-s= queues a local follow-up instead,
+sent when Pi is ready for another prompt.  Press =C-c C-k= to abort the
 current response or compaction.
 
 Press =C-c C-p= for the transient menu which allows you to

--- a/bench/fake-pi-reload-resume.py
+++ b/bench/fake-pi-reload-resume.py
@@ -128,7 +128,7 @@ def session_state(session_file: Path) -> Json:
 def main(argv: list[str] | None = None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     if raw_argv == ["--version"]:
-        print("0.79.1")
+        print("0.85.0")
         return 0
 
     parser = argparse.ArgumentParser()

--- a/bench/fake-pi-tool-update-storm.py
+++ b/bench/fake-pi-tool-update-storm.py
@@ -610,6 +610,7 @@ def run_agent_end_cooling_scenario(
     write_json(
         {"type": "agent_end", "messages": messages, "willRetry": False}
     )
+    write_json({"type": "agent_settled"})
     log_line(
         log_file,
         {"event": "agent-end-cooling-complete", "emitted": emitted},
@@ -763,6 +764,7 @@ def run_scenario(config: JsonDict, log_file: Path | None) -> None:
     write_json(
         {"type": "agent_end", "messages": messages, "willRetry": False}
     )
+    write_json({"type": "agent_settled"})
     log_line(log_file, {"event": "storm-complete", "emitted": emitted})
 
 
@@ -826,7 +828,7 @@ def resolve_config(args: argparse.Namespace) -> JsonDict:
 def main(argv: list[str] | None = None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     if raw_argv == ["--version"]:
-        print("0.84.2")
+        print("0.85.0")
         return 0
 
     args, log_file = parse_args([a for a in raw_argv if a != "--version"])
@@ -865,6 +867,8 @@ def main(argv: list[str] | None = None) -> int:
                 target=target, args=(config, log_file), daemon=True
             )
             storm_thread.start()
+        elif command_type == "clear_queue":
+            respond(command, data={"steering": [], "followUp": []})
         elif command_type in ("abort", "steer", "set_thinking_level"):
             respond(command)
         elif command_type == "new_session":

--- a/bench/pilish-tool-update-bench.el
+++ b/bench/pilish-tool-update-bench.el
@@ -1058,6 +1058,7 @@ Each row is a plist with :type :count :totalMs :meanMs and :maxMs."
             (pilish-tu-bench--route-command-event event))
           (accept-process-output nil 0.005)
           (when (and (pilish-tu-bench--cooling-drained-p chat-buf)
+                     (eq (buffer-local-value 'pilish--status chat-buf) 'idle)
                      (null pilish-tu-bench--command-pending))
             (setq settled t)))
       (setq end (float-time))
@@ -1736,7 +1737,7 @@ Every entry must have a true :ok for the benchmark run to pass."
 (defun pilish-tu-bench--run-session ()
   "Run one fake-backed tool benchmark session and return a metrics plist.
 The cooling scenario waits for production one-shot timers to drain naturally;
-the storm scenarios retain their existing prompt-to-agent_end settle path."
+all scenarios await agent_settled before declaring the session complete."
   (let* ((session-dir (make-temp-file
                        (expand-file-name "session-"
                                          pilish-tu-bench-out-dir)
@@ -1831,12 +1832,13 @@ the storm scenarios retain their existing prompt-to-agent_end settle path."
                              (error
                               "Fake pi process exited before the storm settled"))
                            (and pilish-tu-bench--agent-end-time
+                                (eq (buffer-local-value 'pilish--status chat-buf) 'idle)
                                 (= 0
                                    (pilish-tu-bench--pending-requests-count
                                     proc)))))
                        pilish-tu-bench-timeout-seconds))
                 (unless ok
-                  (error "Timed out waiting for agent_end after %d seconds"
+                  (error "Timed out waiting for agent_settled after %d seconds"
                          pilish-tu-bench-timeout-seconds))))
           (error (setq error-text (error-message-string err))))
       (pilish-tu-bench--stop-command-route)

--- a/pilish-core.el
+++ b/pilish-core.el
@@ -428,6 +428,14 @@ Maps request IDs to command type strings."
         (process-put process 'pilish-pending-command-types table)
         table)))
 
+(defun pilish--command-pending-p (process type)
+  "Return non-nil when PROCESS has a correlated request of command TYPE."
+  (when (processp process)
+    (let ((pending (process-get process 'pilish-pending-command-types)))
+      (and (hash-table-p pending)
+           (cl-loop for command being the hash-values of pending
+                    thereis (equal command type))))))
+
 (defconst pilish--remote-ready-marker
   "__PILISH_RPC_READY_V1__"
   "Exact stdout line that marks a remote Pi process ready for stdin.")
@@ -724,13 +732,13 @@ This is the single source of truth for session activity state.
 
 Runtime status transitions are driven by events from pi:
 - `idle' or `sending' -> `streaming' on agent_start
-- `streaming' -> `sending' on agent_end with willRetry
-- `streaming' -> `idle' on agent_end without retry
-- `idle' -> `compacting' on compaction_start
-- `compacting' -> `sending' on successful compaction_end with willRetry
-- `compacting' -> `sending' on successful compaction_end that resumes
-  prompt preflight
-- `compacting' -> `idle' on compaction_end without retry, failure, or abort
+- `streaming' -> `sending' on agent_end, awaiting session settlement
+- `sending' -> `idle' on agent_settled, unless newer streaming or compaction
+  has already been observed
+- any status -> `compacting' on compaction_start
+- `compacting' -> the surrounding `streaming' or `sending' work on
+  compaction_end, including failure and extension cancellation
+- standalone manual compaction -> `idle' on compaction_end
 
 Local commands may mark a session busy before the first event arrives,
 for example normal prompt submission and manual compaction during the
@@ -738,8 +746,8 @@ RPC pre-event window.")
 
 (defvar-local pilish--pre-compaction-status nil
   "Status that was active before a compaction event sequence.
-Used to restore local prompt submission state when Pi compacts during prompt
-preflight before the agent turn has started.")
+Restores the surrounding run or prompt preflight even when compaction fails
+or an extension cancels it.  Standalone manual compaction has no active run.")
 
 (defvar-local pilish--state nil
   "Current state of the pi session (buffer-local in chat buffer).
@@ -776,26 +784,10 @@ JSON null values, and other non-strings become nil."
                 (pilish--json-null-p result))
       result)))
 
-(defun pilish--compaction-end-success-p (event)
-  "Return non-nil when EVENT reports a completed, non-aborted compaction."
-  (and (not (pilish--normalize-boolean (plist-get event :aborted)))
-       (not (null (pilish--compaction-result-from-event event)))))
-
-(defun pilish--compaction-end-will-retry-p (event)
-  "Return non-nil when EVENT indicates Pi will retry after compaction.
-A retry is only considered pending for a successful compaction result;
-failed or aborted compactions must not leave the session busy."
-  (and (pilish--normalize-boolean (plist-get event :willRetry))
-       (pilish--compaction-end-success-p event)))
-
-(defun pilish--compaction-end-resumes-preflight-p (event)
-  "Return non-nil when EVENT can resume a pre-compaction prompt."
-  (and (eq pilish--pre-compaction-status 'sending)
-       (pilish--compaction-end-success-p event)))
-
 (defun pilish--update-state-from-event (event)
   "Update status and state based on EVENT.
-Handles agent lifecycle, message events, compaction, and error/retry events."
+Handles agent lifecycle, message events, compaction, and error/retry events.
+For agent_settled, return non-nil only when waiting work was released."
   (let ((type (plist-get event :type)))
     (pcase type
       ("agent_start"
@@ -803,12 +795,17 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
        (plist-put pilish--state :is-retrying nil)
        (plist-put pilish--state :last-error nil))
       ("agent_end"
-       (setq pilish--status
-             (if (pilish--normalize-boolean (plist-get event :willRetry))
-                 'sending
-               'idle))
+       (setq pilish--status 'sending)
        (plist-put pilish--state :is-retrying nil)
        (plist-put pilish--state :messages (plist-get event :messages)))
+      ("agent_settled"
+       ;; Pi awaits extension hooks before emitting this event.  A hook can
+       ;; start B before A settles; do not release observably newer work.
+       ;; If B has ALSO ended, A_settled and B_settled are indistinguishable:
+       ;; the wire has no run identity, and get_state cannot resolve all such
+       ;; cases because Pi clears its run flag before awaiting those hooks.
+       (when (eq pilish--status 'sending)
+         (setq pilish--status 'idle)))
       ("message_start"
        (plist-put pilish--state :current-message (plist-get event :message)))
       ("message_end"
@@ -821,18 +818,19 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
        (pilish--handle-tool-end event))
       ("compaction_start"
        (setq pilish--pre-compaction-status
-             (unless (eq pilish--status 'compacting)
-               pilish--status))
+             (if (equal (plist-get event :reason) "manual")
+                 'idle
+               (unless (eq pilish--status 'compacting)
+                 pilish--status)))
        (setq pilish--status 'compacting))
       ("compaction_end"
-       (setq pilish--status
-             (cond
-              ((pilish--compaction-end-will-retry-p event)
-               'sending)
-              ((pilish--compaction-end-resumes-preflight-p event)
-               'sending)
-              (t
-               'idle)))
+       ;; Exhausted overflow recovery emits an end without a start.  It does
+       ;; not release the surrounding sending owner (or newer streaming work).
+       (when (eq pilish--status 'compacting)
+         (setq pilish--status
+               (if (memq pilish--pre-compaction-status '(sending streaming))
+                   pilish--pre-compaction-status
+                 'idle)))
        (setq pilish--pre-compaction-status nil))
       ("auto_retry_start"
        (setq pilish--status 'sending)
@@ -842,8 +840,6 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
       ("auto_retry_end"
        (plist-put pilish--state :is-retrying nil)
        (unless (eq (plist-get event :success) t)
-         (when (eq pilish--status 'sending)
-           (setq pilish--status 'idle))
          (plist-put pilish--state :last-error (plist-get event :finalError))))
       ("extension_error"
        (plist-put pilish--state :last-error (plist-get event :error))))))
@@ -878,6 +874,15 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
     (when tools
       (remhash id tools))))
 
+(defun pilish--merge-state-response-status (remote-status)
+  "Merge REMOTE-STATUS without overwriting an owned busy phase.
+A snapshot may initialize an idle session, but isStreaming also includes
+post-run work and is not evidence of a newer agent_start.  Lifecycle
+events and the explicit no-turn prompt probe own busy-phase transitions."
+  (if (memq pilish--status '(sending streaming compacting))
+      pilish--status
+    remote-status))
+
 (defun pilish--update-state-from-response (response)
   "Update state from a command RESPONSE.
 Only processes successful responses for state-modifying commands."
@@ -896,8 +901,10 @@ Only processes successful responses for state-modifying commands."
            (plist-put pilish--state :thinking-level (plist-get data :level))))
         ("get_state"
          (let ((new-state (pilish--extract-state-from-response response)))
-           (setq pilish--status (plist-get new-state :status)
-                 pilish--state new-state)))))))
+           (setq pilish--status
+                 (pilish--merge-state-response-status
+                  (plist-get new-state :status)))
+           (setq pilish--state (plist-put new-state :status pilish--status))))))))
 
 (defun pilish--extract-state-from-response (response &optional anchor)
   "Extract state plist from a get_state RESPONSE.

--- a/pilish-core.el
+++ b/pilish-core.el
@@ -901,6 +901,10 @@ Only processes successful responses for state-modifying commands."
            (plist-put pilish--state :thinking-level (plist-get data :level))))
         ("get_state"
          (let ((new-state (pilish--extract-state-from-response response)))
+           ;; Retry activity is event-owned, not reported by get_state.
+           (setq new-state
+                 (plist-put new-state :is-retrying
+                            (plist-get pilish--state :is-retrying)))
            (setq pilish--status
                  (pilish--merge-state-response-status
                   (plist-get new-state :status)))

--- a/pilish-input.el
+++ b/pilish-input.el
@@ -459,21 +459,19 @@ sent to pi."
         (pilish--prepare-and-send text))))))
 
 (defun pilish-abort ()
-  "Abort the current pi operation.
-Works while streaming or compacting."
+  "Stop the current pi operation and discard queued continuations.
+Works while sending, streaming or compacting.  A stop during preflight is
+retained if Pi subsequently starts the accepted prompt."
   (interactive)
   (when-let* ((chat-buf (pilish--get-chat-buffer)))
-    (let ((status (buffer-local-value 'pilish--status chat-buf)))
-      (when (memq status '(streaming compacting))
-        (when (eq status 'streaming)
-          (with-current-buffer chat-buf
-            (pilish--set-aborted t)))
-        (when-let* ((proc (pilish--get-process)))
-          (pilish--rpc-async proc
-                         (list :type "abort")
-                         (lambda (_response)
-                           (run-with-timer 2 nil (lambda () (message nil)))
-                           (message "Pi: Aborted"))))))))
+    (with-current-buffer chat-buf
+      (when (or (memq pilish--status '(sending streaming compacting))
+                (pilish--prompt-start-wait-active-p)
+                (pilish--command-pending-p (pilish--get-process) "compact"))
+        (pilish--set-aborted t)
+        (pilish--clear-followup-queue)
+        (pilish--send-abort)
+        (message "Pi: Aborting...")))))
 
 (defun pilish-quit ()
   "Close the current pi session.
@@ -691,8 +689,8 @@ it back via message_start at the correct position (after current
 assistant output completes).
 
 When compaction is in progress, steering text is queued as a local
-follow-up.  It is sent after non-retry compaction, or after Pi's
-automatic overflow retry turn finishes.  Steering refuses a draft image."
+follow-up.  It is sent after the surrounding run and any local command
+reservation finish.  Steering refuses a draft image."
   (interactive)
   (let ((text (string-trim (buffer-string))))
     (if (pilish--get-prompt-image)

--- a/pilish-input.el
+++ b/pilish-input.el
@@ -683,14 +683,15 @@ Shows error message if RPC fails."
 
 (defun pilish-queue-steering ()
   "Send current input as a steering message.
-When pi is sending or streaming, steering interrupts remaining tools.
+During streaming, steering interrupts remaining tools.  It can also queue
+in Pi before a local prompt starts or during an announced retry.
 Unlike normal sends, steering is NOT displayed locally - pi will echo
 it back via message_start at the correct position (after current
 assistant output completes).
 
-When compaction is in progress, steering text is queued as a local
-follow-up.  It is sent after the surrounding run and any local command
-reservation finish.  Steering refuses a draft image."
+During compaction or while awaiting run settlement, steering text is queued
+as a local follow-up.  It is sent after the surrounding run and any local
+command reservation finish.  Steering refuses a draft image."
   (interactive)
   (let ((text (string-trim (buffer-string))))
     (if (pilish--get-prompt-image)
@@ -706,8 +707,8 @@ reservation finish.  Steering refuses a draft image."
                      (not (pilish--session-busy-p chat-buf)))
                 (message "Pi: Nothing to interrupt - use C-c C-c to send"))
                ((or (eq status 'compacting)
-                    (and (eq status 'idle)
-                         (pilish--session-busy-p chat-buf)))
+                    (and (memq status '(idle sending))
+                         (not (pilish--session-steerable-p chat-buf))))
                 (pilish--queue-followup-text chat-buf text)
                 (message "Pi: Steering queued (will send when Pi is ready)"))
                ((memq status '(sending streaming))

--- a/pilish-menu.el
+++ b/pilish-menu.el
@@ -213,14 +213,16 @@ and another transition may not be discarded."
      ((pilish--session-transition-active-p)
       (message "Pi: Cannot start a new session while session is switching")
       nil)
+     ((pilish--command-pending-p (pilish--get-process) "compact")
+      (message "Pi: Cannot start a new session while manual compaction is pending")
+      nil)
      ((pilish--prompt-start-wait-active-p)
       (message "Pi: Cannot start a new session while prompt acceptance is pending")
       nil)
      ((pilish--model-change-pending-p)
       (message "Pi: Cannot start a new session while a model change is pending")
       nil)
-     ((or pilish--followup-queue
-          (pilish--followup-drain-pending-p))
+     (pilish--followup-queue
       (message "Pi: Cannot start a new session with queued follow-ups")
       nil)
      (pilish--local-user-message
@@ -374,7 +376,6 @@ Call this when starting a new session to ensure no stale state persists."
   (pilish--finish-session-transition
    pilish--session-transition-generation)
   ;; Use accessors for cross-module state
-  (pilish--cancel-followup-drain-timer)
   (pilish--invalidate-prompt-start-wait)
   (pilish--clear-followup-queue)
   (pilish--set-aborted nil)
@@ -804,7 +805,7 @@ Optional INITIAL-INPUT pre-fills the completion prompt for filtering."
                            (when (buffer-live-p chat-buf)
                              (with-current-buffer chat-buf
                                (if applied
-                                   (pilish--schedule-followup-queue-processing)
+                                   (pilish--process-followup-queue)
                                  (pilish--restore-followup-queue-to-input))))
                            (cond
                             (applied
@@ -1009,24 +1010,30 @@ Shows PID, status, and session file."
                (or (and session-file (file-name-nondirectory session-file)) "none"))))))
 
 (defun pilish--handle-manual-compaction-response (chat-buf response)
-  "Handle manual compact command RESPONSE for CHAT-BUF.
-Canonical compaction events render success, failure, and queue effects.
-This callback reports only command-level failure seen before any end event."
+  "Finish CHAT-BUF's correlated manual compaction RESPONSE.
+Core dispatch has removed this request's reservation.  Events render results
+and own activity; this callback must not idle independently started work."
   (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
-      (unless (eq (plist-get response :success) t)
-        (when (eq pilish--status 'compacting)
-          (setq pilish--status 'idle)
-          (pilish--set-activity-phase "idle")
-          (pilish--restore-followup-queue-to-input)
+      (let ((success (eq (plist-get response :success) t)))
+        (unless success
           (message "Pi: Compact failed%s"
                    (if-let* ((error-text (plist-get response :error)))
                        (format ": %s" error-text)
-                     "")))))))
+                     "")))
+        (when (and (eq pilish--status 'idle) (not (pilish--session-busy-p)))
+          (pilish--set-activity-phase "idle")
+          (when pilish--aborted (pilish--clear-followup-queue))
+          (pilish--set-aborted nil)
+          (if success
+              (pilish--process-followup-queue)
+            (pilish--restore-followup-queue-to-input)))))))
 
 (defun pilish-compact (&optional custom-instructions)
-  "Compact conversation context to reduce token usage.
-Optional CUSTOM-INSTRUCTIONS provide guidance for the compaction summary."
+  "Compact idle conversation context to reduce token usage.
+Optional CUSTOM-INSTRUCTIONS provide guidance for the compaction summary.
+The pending RPC reserves local submission until its correlated response,
+including the gap after compaction_end while extension failure hooks run."
   (interactive)
   (when-let* ((chat-buf (pilish--get-chat-buffer)))
     (let ((proc (pilish--get-process)))
@@ -1035,18 +1042,19 @@ Optional CUSTOM-INSTRUCTIONS provide guidance for the compaction summary."
         (message "Pi: No process available - try M-x pilish-reload or C-c C-p R"))
        ((not (process-live-p proc))
         (message "Pi: Process died - try M-x pilish-reload or C-c C-p R"))
+       ((not (pilish--session-transition-ready-p chat-buf "compact")))
        (t
         (message "Pi: Compacting...")
-        (with-current-buffer chat-buf
-          (setq pilish--status 'compacting)
-          (pilish--set-activity-phase "compact"))
         (pilish--rpc-async
          proc
          (if custom-instructions
              (list :type "compact" :customInstructions custom-instructions)
            '(:type "compact"))
          (lambda (response)
-           (pilish--handle-manual-compaction-response chat-buf response))))))))
+           (when (and (buffer-live-p chat-buf)
+                      (with-current-buffer chat-buf (eq proc (pilish--get-process)))
+                      (not (plist-get response :processExit)))
+             (pilish--handle-manual-compaction-response chat-buf response)))))))))
 
 (defun pilish-export-html (&optional output-path)
   "Export session to HTML file.

--- a/pilish-render.el
+++ b/pilish-render.el
@@ -1380,7 +1380,7 @@ Updates buffer-local state and renders display updates."
     ("auto_retry_end"
      (pilish--display-retry-end event)
      (unless (eq (plist-get event :success) t)
-       (pilish--restore-followup-queue-to-input)))
+       (pilish--recover-followups-after-retry-failure)))
     ("extension_error"
      (pilish--display-extension-error event))
     ("extension_ui_request"

--- a/pilish-render.el
+++ b/pilish-render.el
@@ -139,7 +139,7 @@ TRACK-REGION is non-nil, return a marker pair bounding the inserted turn."
   "Release speculative local echo state, then process queued follow-ups."
   (unwind-protect
       (pilish--discard-local-user-message)
-    (pilish--schedule-followup-queue-processing)))
+    (pilish--process-followup-queue)))
 
 (defun pilish--content-has-image-p (content)
   "Return non-nil if CONTENT has an image block."
@@ -164,7 +164,6 @@ full content vector, so an authoritative image transformation cannot be lost."
   "Display separator for new agent turn.
 Only shows the Assistant header once per prompt, even during retries.
 Note: status is set to `streaming' by the event handler."
-  (pilish--set-aborted nil)  ; Reset abort flag for new turn
   ;; Only show header if not already shown for this prompt.
   (unless pilish--assistant-header-shown
     (pilish--append-to-chat
@@ -661,81 +660,43 @@ CONTENT is ignored - we use what was already streamed."
                (pilish--adjust-pos-after-region-replacements
                 pos replacements)))))))))
 
-(defconst pilish--followup-drain-delay 0.05
-  "Seconds to wait after agent_end before draining local follow-ups.
-Pi may emit post-run compaction or retry events immediately after agent_end;
-this short delay lets those events claim ordering before Emacs sends a local
-follow-up as a fresh prompt.")
-
-(defun pilish--cancel-followup-drain-timer ()
-  "Cancel any pending local follow-up queue drain timer."
-  (when (timerp pilish--followup-drain-timer)
-    (cancel-timer pilish--followup-drain-timer))
-  (setq pilish--followup-drain-timer nil))
-
 (defun pilish--ready-to-drain-followups-p ()
   "Return non-nil when a queued follow-up may become the next prompt."
   (and pilish--followup-queue
        (eq pilish--status 'idle)
-       (not (pilish--model-change-pending-p))
-       (not (pilish--session-transition-active-p))
-       (not (pilish--prompt-start-wait-active-p))
+       (not pilish--aborted)
+       (not (pilish--session-busy-p))
        (null pilish--local-user-message)))
 
-(defun pilish--drain-followup-queue-if-idle (buffer)
-  "Drain BUFFER's follow-up queue only if the session is still idle."
-  (when (buffer-live-p buffer)
-    (with-current-buffer buffer
-      (setq pilish--followup-drain-timer nil)
-      (when (pilish--ready-to-drain-followups-p)
-        (pilish--process-followup-queue)))))
-
-(defun pilish--schedule-followup-queue-processing ()
-  "Schedule local follow-up queue processing after post-run events settle."
-  (when (pilish--ready-to-drain-followups-p)
-    (pilish--cancel-followup-drain-timer)
-    (setq pilish--followup-drain-timer
-          (run-at-time pilish--followup-drain-delay nil
-                       #'pilish--drain-followup-queue-if-idle
-                       (current-buffer)))))
-
 (defun pilish--display-agent-end ()
-  "Finalize agent turn: normalize whitespace, handle abort, schedule queue."
-  ;; Reset per-turn state for clean next turn.
+  "Finalize the low-level run, leaving queue release to agent_settled."
   (setq pilish--local-user-message nil)
   (pilish--clear-local-user-message-region)
   (setq pilish--in-thinking-block nil)
   (pilish--reset-thinking-state)
-  (let ((was-aborted pilish--aborted))
-    (let ((inhibit-read-only t))
-      (pilish--finalize-live-tool-blocks 'pilish-tool-block-error)
-      (pilish--reset-toolcall-streams)
-      (when pilish--tool-args-cache
-        (clrhash pilish--tool-args-cache))
-      ;; Abort means "stop everything" — discard queued follow-ups too
-      (when pilish--aborted
-        (pilish--with-scroll-preservation
-          (save-excursion
-            (goto-char (point-max))
-            ;; Remove trailing whitespace before adding indicator
-            (skip-chars-backward " \t\n")
-            (delete-region (point) (point-max))
-            (insert "\n\n" (propertize "[Aborted]" 'face 'error) "\n")))
-        (pilish--set-aborted nil)
-        (pilish--clear-followup-queue))
+  (let ((inhibit-read-only t))
+    (pilish--finalize-live-tool-blocks 'pilish-tool-block-error)
+    (pilish--reset-toolcall-streams)
+    (when pilish--tool-args-cache
+      (clrhash pilish--tool-args-cache))
+    ;; Keep stop intent until settlement: Pi may still start a continuation.
+    (when pilish--aborted
       (pilish--with-scroll-preservation
         (save-excursion
           (goto-char (point-max))
-          (skip-chars-backward "\n")
+          (skip-chars-backward " \t\n")
           (delete-region (point) (point-max))
-          (insert "\n"))))
-    (pilish--set-activity-phase
-     (if (eq pilish--status 'sending) "thinking" "idle"))
-    (pilish--refresh-header)
-    ;; Give immediate post-run compaction/retry events a chance to arrive before
-    ;; turning a local follow-up into a new independent prompt.
-    (unless was-aborted
-      (pilish--schedule-followup-queue-processing))))
+          (insert "\n\n" (propertize "[Aborted]" 'face 'error) "\n")))
+      (pilish--clear-followup-queue))
+    (pilish--with-scroll-preservation
+      (save-excursion
+        (goto-char (point-max))
+        (skip-chars-backward "\n")
+        (delete-region (point) (point-max))
+        (insert "\n"))))
+  (pilish--set-activity-phase
+   (if (eq pilish--status 'sending) "thinking" "idle"))
+  (pilish--refresh-header))
 
 (defun pilish--dispatch-builtin-command (text)
   "Try to dispatch TEXT as a built-in slash command.
@@ -758,6 +719,14 @@ Returns non-nil if TEXT matched a built-in command and was handled."
                         (call-interactively handler)))
             (_ (funcall handler)))
           t)))))
+
+(defun pilish--display-accepted-prompt (text &optional content)
+  "Display accepted TEXT and optional CONTENT only before an observed run/echo."
+  (when (pilish--prompt-local-echo-p)
+    (setq pilish--local-user-message-region
+          (pilish--display-user-message text (current-time) content t))
+    (setq pilish--local-user-message (or content text))
+    (setq pilish--assistant-header-shown nil)))
 
 (defun pilish--prepare-and-send (text &optional queued prompt-image)
   "Prepare chat buffer state and send TEXT with optional PROMPT-IMAGE to pi.
@@ -790,7 +759,7 @@ transitions; prompt submission marks the local pre-event window as busy."
      (if queued
          #'pilish--restore-followup-queue-to-input
        (lambda () (pilish--restore-input-text text)))
-     #'pilish--schedule-followup-queue-processing))
+     #'pilish--process-followup-queue))
    ;; Regular text is displayed only after prompt preflight accepts it.  That
    ;; keeps rejected prompts out of the transcript and lets us restore them to
    ;; the input buffer for user recovery.
@@ -801,12 +770,7 @@ transitions; prompt submission marks the local pre-event window as busy."
             (vector (list :type "text" :text text) image-block)))
       (pilish--send-prompt
        text
-       (lambda ()
-         (setq pilish--local-user-message-region
-               (pilish--display-user-message
-                text (current-time) user-content t))
-         (setq pilish--local-user-message user-content)
-         (setq pilish--assistant-header-shown nil))
+       (lambda () (pilish--display-accepted-prompt text user-content))
        (lambda () (pilish--restore-input-text text prompt-image))
        #'pilish--handle-no-turn-local-prompt
        prompt-image)))
@@ -815,22 +779,13 @@ transitions; prompt submission marks the local pre-event window as busy."
      text
      (lambda ()
        (when (pilish--drop-followup text)
-         (setq pilish--local-user-message-region
-               (pilish--display-user-message
-                text (current-time) nil t))
-         (setq pilish--local-user-message text)
-         (setq pilish--assistant-header-shown nil)))
+         (pilish--display-accepted-prompt text)))
      #'pilish--restore-followup-queue-to-input
      #'pilish--handle-no-turn-local-prompt))
    (t
     (pilish--send-prompt
      text
-     (lambda ()
-       (setq pilish--local-user-message-region
-             (pilish--display-user-message
-              text (current-time) nil t))
-       (setq pilish--local-user-message text)
-       (setq pilish--assistant-header-shown nil))
+     (lambda () (pilish--display-accepted-prompt text))
      (lambda () (pilish--restore-input-text text))
      #'pilish--handle-no-turn-local-prompt))))
 
@@ -849,47 +804,30 @@ them."
     (pilish--display-error (format "Compaction failed: %s" error-text))
     (message "Pi: Compaction failed: %s" error-text)))
 
-(defun pilish--post-compaction-activity-phase ()
-  "Return activity phase after a compaction_end event."
-  (if (or (eq pilish--status 'sending)
-          (pilish--prompt-start-wait-active-p))
-      "thinking"
-    "idle"))
-
 (defun pilish--handle-compaction-end-event (event)
-  "Display canonical compaction_end EVENT and manage follow-up queues.
-Status transitions are handled by `pilish--update-state-from-event'."
-  (let ((result (pilish--compaction-result-from-event event)))
+  "Display compaction EVENT without releasing surrounding run ownership.
+Unreserved standalone manual compaction completes here.  Local prompt and
+manual RPC reservations still own FIFO/stop effects until their responses.
+Extension cancellation is not a local stop; core events own status transitions."
+  (let ((result (pilish--compaction-result-from-event event))
+        (cancelled (pilish--normalize-boolean (plist-get event :aborted))))
     (cond
-     ((pilish--normalize-boolean (plist-get event :aborted))
-      (pilish--set-activity-phase
-       (pilish--post-compaction-activity-phase))
-      (message "Pi: Compaction cancelled")
-      ;; Clear queue on abort (user wanted to stop).
-      (pilish--clear-followup-queue))
+     (cancelled (message "Pi: Compaction cancelled"))
      (result
       (pilish--handle-compaction-success
        (plist-get result :tokensBefore)
        (plist-get result :summary)
-       (pilish--ms-to-time (plist-get result :timestamp)))
-      (if (eq pilish--status 'sending)
-          (progn
-            ;; Pi is either retrying automatically or resuming a prompt whose
-            ;; preflight compacted first.  Keep local follow-ups behind that
-            ;; Pi-owned work.
-            (pilish--set-activity-phase "thinking"))
-        (pilish--set-activity-phase "idle")
-        (pilish--schedule-followup-queue-processing)))
-     (t
-      (pilish--set-activity-phase
-       (pilish--post-compaction-activity-phase))
-      (pilish--display-compaction-failure
-       (plist-get event :errorMessage))
-      ;; During prompt preflight, Pi reports compaction failure before the
-      ;; prompt RPC failure that owns the original prompt text.  Restore local
-      ;; follow-ups now; the prompt callback clears the wait and restores the
-      ;; direct prompt if Pi rejects it.
-      (pilish--restore-followup-queue-to-input)))))
+       (pilish--ms-to-time (plist-get result :timestamp))))
+     (t (pilish--display-compaction-failure (plist-get event :errorMessage))))
+    (pilish--set-activity-phase
+     (if (memq pilish--status '(sending streaming)) "thinking" "idle"))
+    (when (and (eq pilish--status 'idle) (not (pilish--session-busy-p)))
+      (cond
+       (pilish--aborted
+        (pilish--clear-followup-queue)
+        (pilish--set-aborted nil))
+       ((and result (not cancelled)) (pilish--process-followup-queue))
+       (t (pilish--restore-followup-queue-to-input))))))
 
 (defun pilish--display-retry-start (event)
   "Display retry notice from auto_retry_start EVENT.
@@ -1165,7 +1103,6 @@ Note: This runs from `kill-buffer-hook', which executes AFTER the kill
 decision is made.  For proper cancellation support, use `pilish-quit'
 which asks upfront before any buffers are touched."
   (when (derived-mode-p 'pilish-chat-mode)
-    (pilish--cancel-followup-drain-timer)
     (pilish--cancel-tool-update-flush)
     (pilish--cancel-tool-cooling)
     (pilish--invalidate-prompt-start-wait)
@@ -1253,7 +1190,7 @@ which asks upfront before any buffers are touched."
         (setq pilish--local-user-message nil)
         (pilish--clear-local-user-message-region)
         (setq pilish--pre-compaction-status nil)
-        (pilish--cancel-followup-drain-timer)
+        (pilish--set-aborted nil)
         (pilish--invalidate-prompt-start-wait)
         (pilish--restore-followup-queue-to-input)
         (force-mode-line-update t)))))
@@ -1271,14 +1208,17 @@ which asks upfront before any buffers are touched."
 (defun pilish--handle-display-event (event)
   "Handle EVENT for display purposes.
 Updates buffer-local state and renders display updates."
-  ;; Update state first (now buffer-local)
-  (pilish--update-state-from-event event)
+  ;; Most events update state first.  Settlement's return value gates its
+  ;; completion effects below, since it may belong to an older run.
+  (unless (equal (plist-get event :type) "agent_settled")
+    (pilish--update-state-from-event event))
   ;; Then handle display
   (pcase (plist-get event :type)
     ("agent_start"
-     (pilish--invalidate-prompt-start-wait)
-     (pilish--cancel-followup-drain-timer)
-     (pilish--display-agent-start))
+     (pilish--note-prompt-start)
+     (pilish--display-agent-start)
+     (when pilish--aborted
+       (pilish--send-abort)))
     ("message_start"
      (let* ((message (plist-get event :message))
             (role (plist-get message :role)))
@@ -1289,6 +1229,7 @@ Updates buffer-local state and renders display updates."
          (pilish--reset-toolcall-streams))
        (pcase role
          ("user"
+          (pilish--note-prompt-echo)
           ;; User message from pi - check if we displayed it locally
           (let* ((content (plist-get message :content))
                  (timestamp (plist-get message :timestamp))
@@ -1410,13 +1351,13 @@ Updates buffer-local state and renders display updates."
          ;; No toolCallId: render through the legacy compatibility block.
          (pilish--display-tool-update partial-result nil))))
     ("compaction_start"
-     (pilish--cancel-followup-drain-timer)
+     (when pilish--aborted
+       (pilish--send-abort))
      (pilish--set-activity-phase "compact")
      (message (if (equal (plist-get event :reason) "overflow")
                   "Pi: Context overflow, compacting..."
                 "Pi: Compacting...")))
     ("compaction_end"
-     (pilish--cancel-followup-drain-timer)
      (pilish--handle-compaction-end-event event))
     ("agent_end"
      ;; Defensively drop pending previews and cancel the flush timer; any
@@ -1427,13 +1368,18 @@ Updates buffer-local state and renders display updates."
      (pilish--display-agent-end)
      (pilish--update-hot-tail-boundary)
      (pilish--queue-tool-cooling-outside-hot-tail))
+    ("agent_settled"
+     (when (pilish--update-state-from-event event)
+       (when pilish--aborted
+         (pilish--clear-followup-queue))
+       (pilish--set-aborted nil)
+       (pilish--set-activity-phase "idle")
+       (pilish--process-followup-queue)))
     ("auto_retry_start"
-     (pilish--cancel-followup-drain-timer)
      (pilish--display-retry-start event))
     ("auto_retry_end"
      (pilish--display-retry-end event)
      (unless (eq (plist-get event :success) t)
-       (pilish--set-activity-phase "idle")
        (pilish--restore-followup-queue-to-input)))
     ("extension_error"
      (pilish--display-extension-error event))
@@ -6559,6 +6505,7 @@ TIMESTAMP is optional time when compaction occurred."
                          'face 'pilish-tool-name)
              (pilish--render-safe-string summary) "\n"))
     (with-current-buffer (pilish--get-chat-buffer)
+      (setq pilish--assistant-header-shown nil)
       (pilish--decorate-tables-unless-deferred start (point-max)))))
 
 (defun pilish--display-branch-summary (summary &optional timestamp)

--- a/pilish-ui.el
+++ b/pilish-ui.el
@@ -58,6 +58,7 @@
 (declare-function pilish-visit-file "pilish-render")
 (declare-function pilish--dispatch-button "pilish-render")
 (declare-function pilish--cleanup-on-kill "pilish-render")
+(declare-function pilish--process-followup-queue "pilish-render")
 (declare-function pilish--restore-tool-properties "pilish-render")
 (declare-function pilish--maybe-refresh-hot-tail-tables "pilish-table")
 
@@ -1159,7 +1160,8 @@ CHAT-BUFFER defaults to the current buffer."
 Resets cached process version and starts a delayed version probe for
 new live processes in interactive sessions."
   (unless (eq process pilish--process)
-    (pilish--invalidate-model-change))
+    (pilish--invalidate-model-change)
+    (pilish--invalidate-prompt-start-wait))
   (setq pilish--process process
         pilish--process-version nil)
   (when (and (processp process)
@@ -1383,7 +1385,9 @@ Returns non-nil when the phase changed."
 Updated after each agent turn completes.")
 
 (defvar-local pilish--aborted nil
-  "Non-nil if the current/last request was aborted.")
+  "Non-nil while an explicit local stop still owns the current operation.
+Retained across compaction and delayed agent_start until settlement, prompt
+rejection, no-turn completion, or process exit.")
 
 (defun pilish--set-aborted (value)
   "Set the aborted flag to VALUE."
@@ -1471,7 +1475,7 @@ Used to avoid duplicate headers during retry sequences.")
 (defvar-local pilish--followup-queue nil
   "List of follow-up messages queued while agent is busy.
 Messages are added when the user sends while streaming, compacting, or
-waiting for local prompt preflight, post-run drain, or automatic retry.  The
+waiting for local prompt preflight, run settlement, or automatic retry.  The
 oldest message is sent after the session settles, and dropped only after
 prompt preflight accepts it.  This is simpler than using pi's RPC follow_up
 command.")
@@ -1538,13 +1542,6 @@ prompt preflight succeeds, so rejected queued prompts remain available."
     (pilish--dequeue-followup)
     t))
 
-(defvar-local pilish--followup-drain-timer nil
-  "Timer waiting to drain the local follow-up queue after Pi settles.")
-
-(defun pilish--followup-drain-pending-p ()
-  "Return non-nil when a local follow-up drain is pending."
-  (and pilish--followup-drain-timer t))
-
 (defvar-local pilish--local-user-message nil
   "Locally displayed user turn awaiting pi's authoritative echo.
 A string records an existing text-only turn.  An image turn stores its full
@@ -1563,24 +1560,38 @@ example, after prompt or image transformation).")
     (set-marker (cdr pilish--local-user-message-region) nil))
   (setq pilish--local-user-message-region nil))
 
-(defvar-local pilish--prompt-start-wait-active nil
-  "Non-nil while a prompt is waiting for response, agent_start, or fallback.")
+(cl-defstruct (pilish--prompt-wait (:constructor pilish--make-prompt-wait))
+  "Ownership of one prompt request, separate from observed run activity."
+  process accepted started echoed)
+
+(defvar-local pilish--prompt-wait nil
+  "Current prompt request record, or nil after acceptance and observed start.
+An unacknowledged extension command retains this record even after its run
+settles.  Record identity and process identity invalidate stale callbacks.")
 
 (defun pilish--prompt-start-wait-active-p ()
-  "Return non-nil when local prompt preflight still owns the next turn."
-  (and pilish--prompt-start-wait-active t))
+  "Return non-nil when a current prompt request still owns local submission."
+  (and pilish--prompt-wait
+       (eq (pilish--prompt-wait-process pilish--prompt-wait)
+           (pilish--get-process))))
+
+(defun pilish--prompt-local-echo-p ()
+  "Return non-nil when acceptance may still display a speculative user turn."
+  (not (and pilish--prompt-wait
+            (or (pilish--prompt-wait-started pilish--prompt-wait)
+                (pilish--prompt-wait-echoed pilish--prompt-wait)))))
 
 (defun pilish--session-busy-p (&optional chat-buf)
   "Return non-nil when CHAT-BUF has active or locally pending work.
 When CHAT-BUF is nil, inspect the current buffer.  This includes Pi-owned
 activity from `pilish--status' plus model changes, session
-transitions, prompt preflight, and follow-up drain waits."
+transitions, prompt requests and correlated manual compaction requests."
   (with-current-buffer (or chat-buf (current-buffer))
     (or (memq pilish--status '(sending streaming compacting))
         (pilish--model-change-pending-p)
         (pilish--session-transition-active-p)
         (pilish--prompt-start-wait-active-p)
-        (pilish--followup-drain-pending-p))))
+        (pilish--command-pending-p (pilish--get-process) "compact"))))
 
 (defun pilish--canonical-rerender-safe-p ()
   "Return non-nil when the chat buffer may rebuild from canonical messages.
@@ -1588,7 +1599,7 @@ A locally displayed user prompt awaiting pi's echo is newer than the cached
 canonical history, so rebuilding now would erase that visible turn."
   (and (eq pilish--status 'idle)
        (not (pilish--prompt-start-wait-active-p))
-       (not (pilish--followup-drain-pending-p))
+       (not (pilish--command-pending-p (pilish--get-process) "compact"))
        (null pilish--local-user-message)))
 
 (defvar-local pilish--extension-status nil
@@ -2084,7 +2095,7 @@ Returns nil if MS is nil."
 (defconst pilish--pi-package "@earendil-works/pi-coding-agent"
   "Npm package name for the pi CLI supported by Pilish.")
 
-(defconst pilish--minimum-pi-version "0.84.2"
+(defconst pilish--minimum-pi-version "0.85.0"
   "Minimum supported pi CLI version.")
 
 (defun pilish--pi-install-command ()
@@ -2752,14 +2763,6 @@ Accesses state from the linked chat buffer."
                              (with-selected-window win
                                (force-mode-line-update))))))))))
 
-(defun pilish--merge-state-response-status (remote-status)
-  "Return status after merging REMOTE-STATUS with local pending work."
-  (if (and (eq remote-status 'idle)
-           (pilish--prompt-start-wait-active-p)
-           (memq pilish--status '(sending streaming compacting)))
-      pilish--status
-    remote-status))
-
 (defun pilish--apply-state-response (chat-buf response)
   "Apply get_state RESPONSE to CHAT-BUF.
 Updates buffer-local state variables and refreshes mode-line.
@@ -2786,6 +2789,14 @@ Safely handles dead buffers by checking liveness first."
 
 ;;;; Sending Infrastructure
 
+(defun pilish--send-abort ()
+  "Clear backend queues before aborting the current operation.
+Send both commands in wire order.  Their acknowledgments must not release
+local ownership or mutate a later operation on the same process."
+  (when-let* ((proc (pilish--get-process)))
+    (pilish--rpc-async proc '(:type "clear_queue") #'ignore)
+    (pilish--rpc-async proc '(:type "abort") #'ignore)))
+
 (defconst pilish--prompt-start-timeout 0.5
   "Seconds to wait for agent_start after a successful prompt response.
 Some extension commands can complete without a visible agent turn; this timeout
@@ -2794,9 +2805,6 @@ returns the frontend to idle for that no-turn success path.")
 (defvar-local pilish--prompt-start-timer nil
   "Timer waiting for agent_start after prompt preflight success.")
 
-(defvar-local pilish--prompt-start-generation 0
-  "Generation used to match prompt-start fallback timers to their prompt.")
-
 (defun pilish--cancel-prompt-start-timer ()
   "Cancel any pending prompt-start fallback timer."
   (when (timerp pilish--prompt-start-timer)
@@ -2804,110 +2812,116 @@ returns the frontend to idle for that no-turn success path.")
   (setq pilish--prompt-start-timer nil))
 
 (defun pilish--invalidate-prompt-start-wait ()
-  "Cancel and invalidate any pending wait for agent_start."
+  "Cancel the prompt probe and invalidate the current request record."
   (pilish--cancel-prompt-start-timer)
-  (setq pilish--prompt-start-wait-active nil)
-  (setq pilish--prompt-start-generation
-        (1+ pilish--prompt-start-generation)))
+  (setq pilish--prompt-wait nil))
 
 (defun pilish--begin-prompt-start-wait ()
-  "Mark the current prompt as waiting for agent_start and return its token."
+  "Reserve local submission for a prompt and return its opaque request record."
   (pilish--invalidate-prompt-start-wait)
-  (setq pilish--prompt-start-wait-active t)
-  pilish--prompt-start-generation)
+  (setq pilish--prompt-wait
+        (pilish--make-prompt-wait :process (pilish--get-process))))
 
-(defun pilish--prompt-start-current-p (generation)
-  "Return non-nil when GENERATION is still the active prompt-start wait."
-  (and generation
-       (pilish--prompt-start-wait-active-p)
-       (= generation pilish--prompt-start-generation)))
+(defun pilish--prompt-start-current-p (wait)
+  "Return non-nil when WAIT still owns the current process's prompt request."
+  (and wait (eq wait pilish--prompt-wait)
+       (pilish--prompt-start-wait-active-p)))
+
+(defun pilish--prompt-start-needed-p (wait)
+  "Return non-nil when accepted WAIT has not produced an observed start."
+  (and (pilish--prompt-start-current-p wait)
+       (pilish--prompt-wait-accepted wait)
+       (not (pilish--prompt-wait-started wait))))
+
+(defun pilish--note-prompt-start ()
+  "Record an observed agent_start without losing an unacknowledged request."
+  (pilish--cancel-prompt-start-timer)
+  (when (pilish--prompt-start-wait-active-p)
+    (setf (pilish--prompt-wait-started pilish--prompt-wait) t)
+    (when (pilish--prompt-wait-accepted pilish--prompt-wait)
+      (pilish--invalidate-prompt-start-wait))))
+
+(defun pilish--note-prompt-echo ()
+  "Record an authoritative user echo so late acceptance cannot duplicate it."
+  (when (pilish--prompt-start-wait-active-p)
+    (setf (pilish--prompt-wait-echoed pilish--prompt-wait) t)))
 
 (defun pilish--finish-prompt-without-agent-start
-    (chat-buf generation on-no-agent-start)
-  "Finish CHAT-BUF prompt GENERATION after Pi confirms no agent turn.
+    (chat-buf wait on-no-agent-start)
+  "Finish CHAT-BUF prompt WAIT after Pi confirms no agent turn.
 Call ON-NO-AGENT-START after releasing local ownership."
-  (when (and (buffer-live-p chat-buf)
-             (with-current-buffer chat-buf
-               (pilish--prompt-start-current-p generation)))
+  (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
-      (setq pilish--prompt-start-wait-active nil)
-      (setq pilish--prompt-start-generation
-            (1+ pilish--prompt-start-generation))
-      (when (eq pilish--status 'sending)
-        (setq pilish--status 'idle)
-        (pilish--set-activity-phase "idle"))
-      (when on-no-agent-start
-        (funcall on-no-agent-start)))))
+      (when (and (pilish--prompt-start-needed-p wait)
+                 (not (memq pilish--status '(streaming compacting))))
+        (pilish--invalidate-prompt-start-wait)
+        (when (eq pilish--status 'sending)
+          (setq pilish--status 'idle)
+          (pilish--set-activity-phase "idle"))
+        (when pilish--aborted
+          (pilish--clear-followup-queue))
+        (setq pilish--aborted nil)
+        (when on-no-agent-start
+          (funcall on-no-agent-start))))))
 
-(defun pilish--probe-prompt-start-state
-    (chat-buf generation on-no-agent-start)
-  "Ask Pi whether CHAT-BUF prompt GENERATION started an agent turn.
-Call ON-NO-AGENT-START only after Pi authoritatively reports idle."
-  (let ((proc (and (buffer-live-p chat-buf)
-                   (with-current-buffer chat-buf
-                     pilish--process))))
+(defun pilish--probe-prompt-start-state (chat-buf wait on-no-agent-start)
+  "Ask whether CHAT-BUF's accepted WAIT produced no agent turn.
+Call ON-NO-AGENT-START only after Pi reports idle with no newer local start."
+  (let ((proc (pilish--prompt-wait-process wait)))
     (when (and proc (process-live-p proc))
       (condition-case nil
           (pilish--rpc-async
            proc '(:type "get_state")
            (lambda (response)
-             (when (and (buffer-live-p chat-buf)
-                        (with-current-buffer chat-buf
-                          (pilish--prompt-start-current-p generation)))
-               (let* ((data (plist-get response :data))
-                      (active
-                       (and (eq (plist-get response :success) t)
-                            (or (pilish--normalize-boolean
-                                 (plist-get data :isStreaming))
-                                (pilish--normalize-boolean
-                                 (plist-get data :isCompacting))))))
-                 (if (or active (not (eq (plist-get response :success) t)))
-                     (pilish--schedule-prompt-start-fallback
-                      chat-buf generation on-no-agent-start)
-                   (pilish--finish-prompt-without-agent-start
-                    chat-buf generation on-no-agent-start))))))
+             (when (buffer-live-p chat-buf)
+               (with-current-buffer chat-buf
+                 (when (pilish--prompt-start-needed-p wait)
+                   (let ((data (plist-get response :data)))
+                     (if (or (memq pilish--status '(streaming compacting))
+                             (not (eq (plist-get response :success) t))
+                             (pilish--normalize-boolean (plist-get data :isStreaming))
+                             (pilish--normalize-boolean (plist-get data :isCompacting)))
+                         (pilish--schedule-prompt-start-fallback
+                          chat-buf wait on-no-agent-start)
+                       (pilish--finish-prompt-without-agent-start
+                        chat-buf wait on-no-agent-start))))))))
         (error
-         (pilish--schedule-prompt-start-fallback
-          chat-buf generation on-no-agent-start))))))
+         (pilish--schedule-prompt-start-fallback chat-buf wait on-no-agent-start))))))
 
 (defun pilish--clear-sending-if-no-agent-start
-    (chat-buf generation &optional on-no-agent-start)
-  "Check whether CHAT-BUF prompt GENERATION produced no agent_start.
-Elapsed time alone is not authoritative: query Pi before releasing local prompt
-ownership or invoking ON-NO-AGENT-START."
+    (chat-buf wait &optional on-no-agent-start)
+  "Probe accepted WAIT in CHAT-BUF when no agent_start was observed.
+Elapsed time alone does not release ownership or invoke ON-NO-AGENT-START."
   (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
-      (when (pilish--prompt-start-current-p generation)
+      (when (pilish--prompt-start-needed-p wait)
         (setq pilish--prompt-start-timer nil)
         (if (memq pilish--status '(streaming compacting))
-            (pilish--schedule-prompt-start-fallback
-             chat-buf generation on-no-agent-start)
-          (pilish--probe-prompt-start-state
-           chat-buf generation on-no-agent-start))))))
+            (pilish--schedule-prompt-start-fallback chat-buf wait on-no-agent-start)
+          (pilish--probe-prompt-start-state chat-buf wait on-no-agent-start))))))
 
 (defun pilish--schedule-prompt-start-fallback
-    (chat-buf generation &optional on-no-agent-start)
-  "Schedule idle fallback for CHAT-BUF after success with no agent_start.
-GENERATION ties the fallback to the prompt response that scheduled it.
-ON-NO-AGENT-START is called if the fallback actually fires."
+    (chat-buf wait &optional on-no-agent-start)
+  "Schedule a probe for CHAT-BUF's accepted WAIT with no observed agent_start.
+ON-NO-AGENT-START is called only if the probe confirms no turn."
   (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
-      (when (pilish--prompt-start-current-p generation)
+      (when (pilish--prompt-start-needed-p wait)
         (pilish--cancel-prompt-start-timer)
         (setq pilish--prompt-start-timer
               (run-at-time pilish--prompt-start-timeout nil
                            #'pilish--clear-sending-if-no-agent-start
-                           chat-buf generation on-no-agent-start))))))
+                           chat-buf wait on-no-agent-start))))))
 
 (defun pilish--handle-prompt-send-failure
-    (chat-buf generation on-failure &optional error-text)
-  "Finish the current failed prompt send owned by GENERATION.
-Restore user input through ON-FAILURE, reset CHAT-BUF, and report ERROR-TEXT.
-Return non-nil only when GENERATION still owned the prompt-start wait."
+    (chat-buf wait on-failure &optional error-text)
+  "Finish the current failed prompt request owned by WAIT.
+Restore input through ON-FAILURE in CHAT-BUF and report ERROR-TEXT without
+idling independently observed work.  Return non-nil only for the current WAIT."
   (let ((current-failure
          (and (buffer-live-p chat-buf)
               (with-current-buffer chat-buf
-                (pilish--prompt-start-current-p generation)))))
+                (pilish--prompt-start-current-p wait)))))
     (when current-failure
       (pilish--abort-send chat-buf on-failure)
       (message "Pi: Send failed%s"
@@ -2918,14 +2932,12 @@ Return non-nil only when GENERATION still owned the prompt-start wait."
     (text &optional on-success on-failure on-no-agent-start prompt-image)
   "Send TEXT and optional PROMPT-IMAGE to the pi process.
 Slash commands are sent literally - pi handles expansion.
-Shows an error message if process is unavailable.
-ON-SUCCESS is called in the chat buffer after prompt preflight accepts TEXT.
-ON-FAILURE is called in the chat buffer if preflight rejects TEXT or scheduling
-fails synchronously.  ON-NO-AGENT-START is called if success is not followed
-by agent_start."
+ON-SUCCESS runs in the chat buffer upon acceptance, which may follow a run.
+ON-FAILURE restores a rejected request or synchronous scheduling failure.
+ON-NO-AGENT-START runs only for accepted requests confirmed to have no turn."
   (let ((proc (pilish--get-process))
         (chat-buf (pilish--get-chat-buffer))
-        (prompt-generation nil))
+        wait)
     (cond
      ((null proc)
       (pilish--abort-send chat-buf on-failure)
@@ -2936,7 +2948,7 @@ by agent_start."
      (t
       (when (buffer-live-p chat-buf)
         (with-current-buffer chat-buf
-          (setq prompt-generation (pilish--begin-prompt-start-wait))
+          (setq wait (pilish--begin-prompt-start-wait))
           (setq pilish--status 'sending)
           (pilish--set-activity-phase "thinking")))
       (condition-case err
@@ -2945,48 +2957,62 @@ by agent_start."
            (append (list :type "prompt" :message text)
                    (when prompt-image
                      (list :images
-                           (vector
-                            (pilish--prompt-image-content-block
-                             prompt-image)))))
+                           (vector (pilish--prompt-image-content-block prompt-image)))))
            (lambda (response)
              (if (eq (plist-get response :success) t)
                  (when (buffer-live-p chat-buf)
                    (with-current-buffer chat-buf
-                     (when (pilish--prompt-start-current-p
-                            prompt-generation)
-                       (when on-success
-                         (funcall on-success))
-                       (pilish--schedule-prompt-start-fallback
-                        chat-buf prompt-generation on-no-agent-start))))
+                     (when (pilish--prompt-start-current-p wait)
+                       (setf (pilish--prompt-wait-accepted wait) t)
+                       (unwind-protect
+                           (when on-success (funcall on-success))
+                         (when (pilish--prompt-start-current-p wait)
+                           (if (pilish--prompt-wait-started wait)
+                               (progn
+                                 (pilish--invalidate-prompt-start-wait)
+                                 (unless (pilish--session-busy-p)
+                                   (when pilish--aborted (pilish--clear-followup-queue))
+                                   (setq pilish--aborted nil))
+                                 (pilish--process-followup-queue))
+                             (pilish--schedule-prompt-start-fallback
+                              chat-buf wait on-no-agent-start)))))))
                (pilish--handle-prompt-send-failure
-                chat-buf prompt-generation on-failure
-                (plist-get response :error)))))
+                chat-buf wait on-failure (plist-get response :error)))))
         ((error quit)
          (if (eq (car err) 'quit)
              (unwind-protect
                  (pilish--handle-prompt-send-failure
-                  chat-buf prompt-generation on-failure
-                  (error-message-string err))
+                  chat-buf wait on-failure (error-message-string err))
                (signal (car err) (cdr err)))
            (pilish--handle-prompt-send-failure
-            chat-buf prompt-generation on-failure
-            (error-message-string err)))))))))
+            chat-buf wait on-failure (error-message-string err)))))))))
 
 (defun pilish--abort-send (chat-buf &optional on-failure)
-  "Clean up after a failed send attempt in CHAT-BUF.
-Call ON-FAILURE once after invalidating the prompt wait, then reset activity,
-local echo state, and status to idle even if restoration signals."
+  "Release a failed request in CHAT-BUF and restore input through ON-FAILURE.
+Only its unstarted sending window becomes idle; independently observed runs
+or compaction retain their activity and stop intent, even if restoration fails."
   (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
-      (pilish--invalidate-prompt-start-wait)
-      (unwind-protect
-          (when on-failure
-            (funcall on-failure))
-        (setq pilish--local-user-message nil)
-        (pilish--clear-local-user-message-region)
-        (setq pilish--pre-compaction-status nil)
-        (setq pilish--status 'idle)
-        (pilish--set-activity-phase "idle")))))
+      (let ((started (and pilish--prompt-wait
+                          (pilish--prompt-wait-started pilish--prompt-wait))))
+        (pilish--invalidate-prompt-start-wait)
+        (unwind-protect
+            (progn
+              ;; Restore FIFO first so the direct owner can prepend its text.
+              (if pilish--aborted
+                  (pilish--clear-followup-queue)
+                (pilish--restore-followup-queue-to-input))
+              (when on-failure (funcall on-failure)))
+          (setq pilish--local-user-message nil)
+          (pilish--clear-local-user-message-region)
+          (unless started
+            (when (eq pilish--pre-compaction-status 'sending)
+              (setq pilish--pre-compaction-status 'idle))
+            (when (eq pilish--status 'sending)
+              (setq pilish--status 'idle)))
+          (when (eq pilish--status 'idle)
+            (setq pilish--pre-compaction-status nil pilish--aborted nil)
+            (pilish--set-activity-phase "idle")))))))
 
 
 (provide 'pilish-ui)

--- a/pilish-ui.el
+++ b/pilish-ui.el
@@ -1562,7 +1562,7 @@ example, after prompt or image transformation).")
 
 (cl-defstruct (pilish--prompt-wait (:constructor pilish--make-prompt-wait))
   "Ownership of one prompt request, separate from observed run activity."
-  process accepted started echoed)
+  process accepted started echoed restore-followups)
 
 (defvar-local pilish--prompt-wait nil
   "Current prompt request record, or nil after acceptance and observed start.
@@ -1592,6 +1592,29 @@ transitions, prompt requests and correlated manual compaction requests."
         (pilish--session-transition-active-p)
         (pilish--prompt-start-wait-active-p)
         (pilish--command-pending-p (pilish--get-process) "compact"))))
+
+(defun pilish--session-steerable-p (&optional chat-buf)
+  "Return non-nil when CHAT-BUF has a run that can receive backend steering.
+When CHAT-BUF is nil, inspect the current buffer.  An unstarted local prompt
+or an announced retry can receive steering for its upcoming run.  A bare
+sending status may instead be waiting for settlement after Pi stopped
+checking its backend queues."
+  (with-current-buffer (or chat-buf (current-buffer))
+    (or (eq pilish--status 'streaming)
+        (and (eq pilish--status 'sending)
+             (or (plist-get pilish--state :is-retrying)
+                 (and (pilish--prompt-start-wait-active-p)
+                      (not (pilish--prompt-wait-started pilish--prompt-wait))))))))
+
+(defun pilish--recover-followups-after-retry-failure ()
+  "Restore unsent follow-ups without recovering an unresolved FIFO owner.
+An extension may have started a run before acknowledging its prompt.  Keep
+that request's text out of the editor until the correlated response decides
+whether to accept or restore it."
+  (if (and (pilish--prompt-start-wait-active-p)
+           (not (pilish--prompt-wait-accepted pilish--prompt-wait)))
+      (setf (pilish--prompt-wait-restore-followups pilish--prompt-wait) t)
+    (pilish--restore-followup-queue-to-input)))
 
 (defun pilish--canonical-rerender-safe-p ()
   "Return non-nil when the chat buffer may rebuild from canonical messages.
@@ -2775,6 +2798,10 @@ Safely handles dead buffers by checking liveness first."
                          response
                          (pilish--chat-session-directory chat-buf)))
              (new-session-id (plist-get new-state :session-id)))
+        ;; Retry activity is event-owned, not reported by get_state.
+        (setq new-state
+              (plist-put new-state :is-retrying
+                         (plist-get pilish--state :is-retrying)))
         (when (and old-session-id
                    new-session-id
                    (not (equal old-session-id new-session-id)))
@@ -2967,6 +2994,12 @@ ON-NO-AGENT-START runs only for accepted requests confirmed to have no turn."
                        (unwind-protect
                            (when on-success (funcall on-success))
                          (when (pilish--prompt-start-current-p wait)
+                           ;; Acceptance has now removed any FIFO owner.  A
+                           ;; retry failure restores only its unsent successors.
+                           (when (pilish--prompt-wait-restore-followups wait)
+                             (if pilish--aborted
+                                 (pilish--clear-followup-queue)
+                               (pilish--restore-followup-queue-to-input)))
                            (if (pilish--prompt-wait-started wait)
                                (progn
                                  (pilish--invalidate-prompt-start-wait)

--- a/pilish.el
+++ b/pilish.el
@@ -38,7 +38,7 @@
 ;;
 ;; Requirements:
 ;;   - Emacs 29.1 or later (tree-sitter support required)
-;;   - pi coding agent @earendil-works/pi-coding-agent 0.84.2 or later,
+;;   - pi coding agent @earendil-works/pi-coding-agent 0.85.0 or later,
 ;;     installed and in PATH on the host where Pi runs
 ;;   - tree-sitter grammars for markdown and markdown-inline
 ;;

--- a/test/fixtures/fake-pi/README.md
+++ b/test/fixtures/fake-pi/README.md
@@ -82,7 +82,7 @@ Example:
 Emits the current delta-only lifecycle: `toolcall_start`, argument
 `toolcall_delta` events, authoritative `toolcall_end` and assistant
 `message_end`, tool execution events, a correlated tool-result message, and the
-final streamed assistant message before `agent_end`.
+final streamed assistant message before `agent_end`, followed by `agent_settled`.
 
 Example:
 

--- a/test/pilish-core-test.el
+++ b/test/pilish-core-test.el
@@ -758,12 +758,16 @@
     (pilish--update-state-from-event '(:type "agent_start"))
     (should (eq pilish--status 'streaming))))
 
-(ert-deftest pilish-test-event-agent-end-clears-streaming ()
-  "agent_end event sets pilish--status to idle."
-  (let ((pilish--status 'streaming)
-        (pilish--state nil))
-    (pilish--update-state-from-event '(:type "agent_end" :messages []))
-    (should (eq pilish--status 'idle))))
+(ert-deftest pilish-test-lifecycle-agent-end-waits-for-settled ()
+  "Only agent_settled releases a completed run, regardless of willRetry."
+  (dolist (retry '(nil :false t))
+    (let ((pilish--status 'streaming)
+          (pilish--state nil))
+      (pilish--update-state-from-event
+       `(:type "agent_end" :messages [] :willRetry ,retry))
+      (should (eq pilish--status 'sending))
+      (pilish--update-state-from-event '(:type "agent_settled"))
+      (should (eq pilish--status 'idle)))))
 
 (ert-deftest pilish-test-event-agent-end-will-retry-keeps-sending ()
   "agent_end with willRetry keeps the session busy for Pi's retry."
@@ -846,17 +850,40 @@ Display is handled by the display handler, not by state updates."
     (pilish--update-state-from-event '(:type "compaction_start" :reason "threshold"))
     (should (eq pilish--status 'compacting))))
 
-(ert-deftest pilish-test-event-compaction-end-sets-idle ()
-  "compaction_end event sets pilish--status to idle."
-  (let ((pilish--status 'compacting)
+(ert-deftest pilish-test-review-fixes-unpaired-overflow-keeps-sending ()
+  "Exhausted overflow recovery can end compaction without a start event."
+  (let ((pilish--status 'streaming)
+        (pilish--pre-compaction-status nil)
         (pilish--state nil))
-    (pilish--update-state-from-event '(:type "compaction_end" :reason "threshold" :aborted :false))
+    (pilish--update-state-from-event '(:type "agent_end" :messages []))
+    (pilish--update-state-from-event
+     '(:type "compaction_end" :reason "overflow" :aborted :false :willRetry :false
+       :result :null :errorMessage "Context overflow recovery failed after one retry"))
+    (should (eq pilish--status 'sending))
+    (pilish--update-state-from-event '(:type "agent_settled"))
     (should (eq pilish--status 'idle))))
 
+(ert-deftest pilish-test-lifecycle-manual-compaction-returns-idle ()
+  "Standalone manual compaction is terminal even on failure or cancellation."
+  (dolist (outcome '((:aborted :false :result (:summary "Summary"))
+                     (:aborted :false :result :null :errorMessage "quota")
+                     (:aborted t :result :null)))
+    (let ((pilish--status 'idle)
+          (pilish--pre-compaction-status nil)
+          (pilish--state nil))
+      (pilish--update-state-from-event
+       '(:type "compaction_start" :reason "manual"))
+      (pilish--update-state-from-event
+       (append '(:type "compaction_end" :willRetry :false) outcome))
+      (should (eq pilish--status 'idle))
+      (should-not pilish--pre-compaction-status))))
+
 (ert-deftest pilish-test-event-compaction-end-will-retry-sets-sending ()
-  "Successful compaction_end with willRetry keeps the session busy."
-  (let ((pilish--status 'compacting)
+  "Overflow recovery after agent_end keeps the session busy."
+  (let ((pilish--status 'sending)
+        (pilish--pre-compaction-status nil)
         (pilish--state nil))
+    (pilish--update-state-from-event '(:type "compaction_start" :reason "overflow"))
     (pilish--update-state-from-event
      '(:type "compaction_end"
        :reason "overflow"
@@ -879,6 +906,28 @@ Display is handled by the display handler, not by state updates."
        :errorMessage "recovery failed"))
     (should (eq pilish--status 'idle))))
 
+(ert-deftest pilish-test-lifecycle-interturn-compaction-restores-streaming ()
+  "Compaction between turns continues the same run without agent_start."
+  (dolist (outcome '((:aborted :false :result (:summary "Summary"))
+                     (:aborted :false :result :null :errorMessage "quota")
+                     (:aborted t :result :null)))
+    (ert-info ((format "Compaction outcome: %S" outcome))
+      (let ((pilish--status 'idle)
+            (pilish--pre-compaction-status nil)
+            (pilish--state nil))
+        (dolist (event '((:type "agent_start")
+                         (:type "turn_start")
+                         (:type "turn_end")
+                         (:type "compaction_start" :reason "threshold")))
+          (pilish--update-state-from-event event))
+        (should (eq pilish--status 'compacting))
+        (pilish--update-state-from-event
+         (append '(:type "compaction_end" :willRetry :false) outcome))
+        (should (eq pilish--status 'streaming))
+        (pilish--update-state-from-event '(:type "turn_start"))
+        (should (eq pilish--status 'streaming))
+        (should-not pilish--pre-compaction-status)))))
+
 (ert-deftest pilish-test-event-compaction-preserves-prompt-preflight-sending ()
   "Successful compaction during prompt preflight resumes that prompt."
   (let ((pilish--status 'sending)
@@ -897,8 +946,8 @@ Display is handled by the display handler, not by state updates."
     (should (eq pilish--status 'sending))
     (should (null pilish--pre-compaction-status))))
 
-(ert-deftest pilish-test-event-failed-compaction-does-not-resume-preflight-sending ()
-  "Failed compaction during prompt preflight settles instead of faking retry."
+(ert-deftest pilish-test-lifecycle-failed-compaction-resumes-preflight-sending ()
+  "Failed preflight compaction can still continue the original prompt."
   (let ((pilish--status 'sending)
         (pilish--pre-compaction-status nil)
         (pilish--state nil))
@@ -911,11 +960,11 @@ Display is handled by the display handler, not by state updates."
        :willRetry :false
        :result :null
        :errorMessage "quota exceeded"))
-    (should (eq pilish--status 'idle))
+    (should (eq pilish--status 'sending))
     (should (null pilish--pre-compaction-status))))
 
-(ert-deftest pilish-test-event-aborted-compaction-does-not-resume-preflight-sending ()
-  "Aborted compaction during prompt preflight is stop-everything, not sending."
+(ert-deftest pilish-test-lifecycle-cancelled-compaction-resumes-preflight-sending ()
+  "An extension cancelling preflight compaction does not cancel the prompt."
   (let ((pilish--status 'sending)
         (pilish--pre-compaction-status nil)
         (pilish--state nil))
@@ -927,7 +976,7 @@ Display is handled by the display handler, not by state updates."
        :aborted t
        :willRetry :false
        :result nil))
-    (should (eq pilish--status 'idle))
+    (should (eq pilish--status 'sending))
     (should (null pilish--pre-compaction-status))))
 
 (ert-deftest pilish-test-ensure-active-tools-from-nil ()
@@ -984,6 +1033,22 @@ Display is handled by the display handler, not by state updates."
       (delete-process fake-proc))))
 
 ;;;; State Management Tests
+
+(ert-deftest pilish-test-lifecycle-state-response-preserves-busy-status ()
+  "All snapshots preserve busy phases; idle initialization adopts remote status."
+  (dolist (status '(idle sending streaming compacting))
+    (dolist (snapshot '((:false :false idle) (t :false streaming)
+                        (:false t compacting) (t t streaming)))
+      (let ((pilish--status status)
+            (pilish--state nil)
+            (expected (if (eq status 'idle) (nth 2 snapshot) status)))
+        (pilish--update-state-from-response
+         (list :type "response" :command "get_state" :success t
+               :data (list :isStreaming (car snapshot)
+                           :isCompacting (cadr snapshot) :thinkingLevel "high")))
+        (should (equal (plist-get pilish--state :thinking-level) "high"))
+        (should (eq pilish--status expected))
+        (should (eq (plist-get pilish--state :status) expected))))))
 
 (ert-deftest pilish-test-state-from-get-state-response ()
   "State is initialized from get_state response data."
@@ -1133,7 +1198,7 @@ Display is handled by the display handler, not by state updates."
   (let ((pilish--status 'streaming)
         (pilish--state (list :is-retrying t)))
     (pilish--update-state-from-event '(:type "agent_end" :messages []))
-    (should (eq pilish--status 'idle))
+    (should (eq pilish--status 'sending))
     (should (eq (plist-get pilish--state :is-retrying) nil))))
 
 ;;;; Test Utilities

--- a/test/pilish-fake-pi-test.el
+++ b/test/pilish-fake-pi-test.el
@@ -674,7 +674,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                          :message prompt))))
         (should (eq (plist-get response :success) t)))
       (pilish-fake-pi-test--collect-until
-       proc (lambda (object) (equal (plist-get object :type) "agent_end")))
+       proc (lambda (object) (equal (plist-get object :type) "agent_settled")))
       (let* ((state-response
               (pilish-fake-pi-test--rpc
                proc '(:id "generated-state" :type "get_state")))
@@ -1277,6 +1277,24 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
       (should (equal (plist-get response :command) "get_state"))
       (should (eq (plist-get response :success) t)))))
 
+(ert-deftest pilish-fake-pi-test-lifecycle-emits-settled-after-final-run ()
+  "The fake backend emits agent_settled after agent_end and is then idle."
+  (pilish-fake-pi-test-with-process (proc "prompt-lifecycle")
+    (pilish-fake-pi-test--send proc '(:type "prompt" :message "finish this run"))
+    (let ((events (pilish-fake-pi-test--collect-until
+                   proc (lambda (obj) (equal (plist-get obj :type) "agent_end")))))
+      (should (member "agent_start" (pilish-fake-pi-test--event-types events)))
+      (should (pilish-test-wait-until
+               (lambda () (process-get proc 'fake-pi-objects))
+               pilish-test-short-wait 0.01 proc))
+      (should (equal (plist-get (pilish-fake-pi-test--pop-object proc) :type)
+                     "agent_settled"))
+      (let* ((response (pilish-fake-pi-test--rpc proc '(:type "get_state")))
+             (data (plist-get response :data)))
+        (should (eq (plist-get response :success) t))
+        (should (eq (plist-get data :isStreaming) :false))
+        (should (eq (plist-get data :isCompacting) :false))))))
+
 (ert-deftest pilish-fake-pi-test-prompt-response-precedes-stream-events ()
   "prompt returns success first, then streams lifecycle events."
   (pilish-fake-pi-test-with-process (proc "prompt-lifecycle")
@@ -1284,7 +1302,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
     (let* ((response (pilish-fake-pi-test--pop-object proc))
            (events (pilish-fake-pi-test--collect-until
                     proc
-                    (lambda (obj) (equal (plist-get obj :type) "agent_end"))))
+                    (lambda (obj) (equal (plist-get obj :type) "agent_settled"))))
            (assistant-start (seq-find
                              (lambda (obj)
                                (and (equal (plist-get obj :type) "message_start")
@@ -1306,8 +1324,8 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
         (should-not (plist-member update :message))
         (should-not (plist-member (plist-get update :assistantMessageEvent)
                                   :partial)))
-      (should (equal (car (last (pilish-fake-pi-test--event-types events)))
-                     "agent_end")))))
+      (should (equal (last (pilish-fake-pi-test--event-types events) 2)
+                     '("agent_end" "agent_settled"))))))
 
 (ert-deftest pilish-fake-pi-test-tool-stream-emits-tool-events ()
   "tool_stream emits an ordered, correlated, delta-only RPC lifecycle."
@@ -1317,7 +1335,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                    "prompt"))
     (let* ((events (pilish-fake-pi-test--collect-until
                     proc
-                    (lambda (obj) (equal (plist-get obj :type) "agent_end"))))
+                    (lambda (obj) (equal (plist-get obj :type) "agent_settled"))))
            (assistant-starts
             (pilish-fake-pi-test--message-events
              events "message_start" "assistant"))
@@ -1351,7 +1369,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
            (tool-execution-end
             (car (pilish-fake-pi-test--events-of-type
                   events "tool_execution_end")))
-           (agent-end (car (last events)))
+           (agent-end (car (pilish-fake-pi-test--events-of-type events "agent_end")))
            (lifecycle
             (mapcar
              (lambda (obj)
@@ -1379,7 +1397,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                 "message_start:assistant"
                 "text_delta" "text_delta"
                 "message_end:assistant"
-                "agent_end")))
+                "agent_end" "agent_settled")))
       (should (> (length toolcall-delta-updates) 1))
       (should (> (length text-delta-updates) 0))
       (dolist (update message-updates)
@@ -1468,6 +1486,37 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                        (plist-get tool-assistant-message :content)))
         (should (equal (plist-get (aref agent-messages 2) :toolCallId) call-id))
         (should (equal (plist-get agent-end :willRetry) :false))))))
+
+(ert-deftest pilish-fake-pi-test-clear-queue-before-abort-stops-continuation ()
+  "Only clear_queue discards steering; abort acknowledges after final settlement."
+  (dolist (clear '(t nil))
+    (pilish-fake-pi-test-with-process (proc "prompt-lifecycle")
+      (pilish-fake-pi-test--send proc '(:type "prompt" :message "first"))
+      (pilish-fake-pi-test--collect-until
+       proc (lambda (obj)
+              (equal (plist-get (plist-get obj :assistantMessageEvent) :type)
+                     "text_delta")))
+      (pilish-fake-pi-test--send proc '(:type "steer" :message "queued"))
+      (when clear
+        (pilish-fake-pi-test--send proc '(:id "clear" :type "clear_queue")))
+      (pilish-fake-pi-test--send proc '(:type "abort"))
+      (let* ((events (pilish-fake-pi-test--collect-until
+                      proc (lambda (obj) (equal (plist-get obj :command) "abort"))))
+             (types (pilish-fake-pi-test--event-types events))
+             (clear-response (seq-find (lambda (obj) (equal (plist-get obj :id) "clear"))
+                                       events)))
+        (should (eq (plist-get (car (last events)) :success) t))
+        (should (equal (last types 2) '("agent_settled" "response")))
+        (should (= 1 (cl-count "agent_settled" types :test #'equal)))
+        (should (= (if clear 1 2) (cl-count "agent_end" types :test #'equal)))
+        (should (= (if clear 0 1) (cl-count "agent_start" types :test #'equal)))
+        (when clear
+          (should (equal (plist-get clear-response :data)
+                         '(:steering ["queued"] :followUp [])))
+          (should (equal (pilish-fake-pi-test--events-of-type events "queue_update")
+                         '((:type "queue_update" :steering [] :followUp []))))))
+      (let ((state (pilish-fake-pi-test--rpc proc '(:type "get_state"))))
+        (should (eq (plist-get (plist-get state :data) :isStreaming) :false))))))
 
 (ert-deftest pilish-fake-pi-test-abort-stops-streaming ()
   "abort stops an in-flight prompt and leaves the fake idle."
@@ -1583,7 +1632,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                    "prompt"))
     (let ((seen-first-delta nil)
           (saw-steer-response nil)
-          (saw-agent-end nil)
+          (saw-agent-settled nil)
           (user-starts 0)
           (steered-reply nil))
       (while (not seen-first-delta)
@@ -1596,7 +1645,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                      (equal (plist-get msg-event :type) "text_delta"))
             (setq seen-first-delta t))))
       (pilish-fake-pi-test--send proc '(:type "steer" :message "second turn"))
-      (while (not saw-agent-end)
+      (while (not saw-agent-settled)
         (let ((obj (pilish-fake-pi-test--pop-object proc)))
           (pcase (plist-get obj :type)
             ("response"
@@ -1613,10 +1662,10 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
                                                          :text)
                                               "")))
                  (setq steered-reply t))))
-            ("agent_end"
-             (setq saw-agent-end t)))))
+            ("agent_settled"
+             (setq saw-agent-settled t)))))
       (should saw-steer-response)
-      (should saw-agent-end)
+      (should saw-agent-settled)
       (should (= user-starts 2))
       (should steered-reply)
       (pilish-fake-pi-test--send proc '(:type "get_fork_messages"))
@@ -1632,7 +1681,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
     (should (equal (plist-get (pilish-fake-pi-test--pop-object proc) :command)
                    "prompt"))
     (pilish-fake-pi-test--collect-until
-     proc (lambda (obj) (equal (plist-get obj :type) "agent_end")))
+     proc (lambda (obj) (equal (plist-get obj :type) "agent_settled")))
     (pilish-fake-pi-test--send proc '(:type "get_state"))
     (let* ((before-state (pilish-fake-pi-test--pop-object proc))
            (before-data (plist-get before-state :data))
@@ -1685,7 +1734,7 @@ SPEC is (SESSION SCENARIO &rest EXTRA-ARGS)."
     (should (equal (plist-get (pilish-fake-pi-test--pop-object proc) :command)
                    "prompt"))
     (pilish-fake-pi-test--collect-until
-     proc (lambda (obj) (equal (plist-get obj :type) "agent_end")))
+     proc (lambda (obj) (equal (plist-get obj :type) "agent_settled")))
     (pilish-fake-pi-test--send proc '(:type "get_state"))
     (let* ((state (pilish-fake-pi-test--pop-object proc))
            (session-file (plist-get (plist-get state :data) :sessionFile)))

--- a/test/pilish-input-test.el
+++ b/test/pilish-input-test.el
@@ -638,6 +638,99 @@ not claim to distinguish those otherwise identical sending-state traces."
                          '("clear_queue" "abort")))
           (should pilish--aborted))))))
 
+(ert-deftest pilish-test-adversarial-steering-after-agent-end-stays-local ()
+  "Steering after agent_end waits locally, including before a late prompt ack."
+  (dolist (late-ack '(nil t))
+    (pilish-test-with-rpc-session (chat input proc commands)
+      (let (notice)
+        (cl-letf (((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq notice (apply #'format fmt args)))))
+          (with-current-buffer chat
+            (pilish--prepare-and-send "/extension-run")
+            (let ((request (car commands)))
+              (unless late-ack
+                (pilish--dispatch-response
+                 proc (list :type "response" :id (plist-get request :id)
+                            :command "prompt" :success t)))
+              (pilish--handle-display-event '(:type "agent_start"))
+              (pilish--handle-display-event '(:type "agent_end" :messages []))
+              ;; Pi may now be awaiting agent_settled hooks with its backend
+              ;; queue drain already finished.  No steer RPC is safe here.
+              (with-current-buffer input
+                (insert "after the run")
+                (pilish-queue-steering)
+                (should (string-empty-p (buffer-string))))
+              (should (= 1 (length commands)))
+              (should (equal notice "Pi: Steering queued (will send when Pi is ready)"))
+              (should (equal pilish--followup-queue '("after the run")))
+              (pilish--handle-display-event '(:type "agent_settled"))
+              (when late-ack
+                (should (= 1 (length commands)))
+                (pilish--dispatch-response
+                 proc (list :type "response" :id (plist-get request :id)
+                            :command "prompt" :success t)))
+              (should (equal (mapcar (lambda (cmd) (plist-get cmd :type))
+                                    (reverse commands))
+                             '("prompt" "prompt")))
+              (let ((followup (car commands)))
+                (should (equal (plist-get followup :message) "after the run"))
+                (pilish--dispatch-response
+                 proc (list :type "response" :id (plist-get followup :id)
+                            :command "prompt" :success t)))
+              (should-not pilish--followup-queue))))))))
+
+(defun pilish-test--retry-failure-with-late-ack (success)
+  "Check retry exhaustion before a FIFO owner's late SUCCESS response."
+  (pilish-test-with-rpc-session (chat input proc commands)
+    (let (notice)
+      (cl-letf (((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq notice (apply #'format fmt args)))))
+        (with-current-buffer input (insert "new draft"))
+        (with-current-buffer chat
+          (setq pilish--followup-queue '("next" "/extension-run"))
+          (pilish--process-followup-queue)
+          (let ((request (car commands)))
+            (dolist (event '((:type "agent_start")
+                             (:type "agent_end" :messages [] :willRetry t)
+                             (:type "auto_retry_start" :attempt 1 :maxAttempts 1)
+                             (:type "agent_start")
+                             (:type "agent_end" :messages [])
+                             (:type "auto_retry_end" :success :false :attempt 1
+                              :finalError "overloaded")))
+              (pilish--handle-display-event event))
+            (should (string-match-p "Retry failed" (buffer-string)))
+            (with-current-buffer input
+              (should (equal (buffer-string) "new draft")))
+            (should (equal pilish--followup-queue '("next" "/extension-run")))
+            (pilish--handle-display-event '(:type "agent_settled"))
+            (should (pilish--session-busy-p))
+            (should (= 1 (length commands)))
+            (pilish--dispatch-response
+             proc (list :type "response" :id (plist-get request :id)
+                        :command "prompt" :success success :error "command rejected"))
+            (should-not (pilish--session-busy-p))
+            (should-not pilish--followup-queue)
+            ;; Exhaustion recovers only unsent work; accepting the owner must
+            ;; neither restore that command nor automatically run its successor.
+            (should (= 1 (length commands)))
+            (with-current-buffer input
+              (should (equal (buffer-string)
+                             (if (eq success t)
+                                 "next\n\nnew draft"
+                               "/extension-run\n\nnext\n\nnew draft"))))
+            (unless (eq success t)
+              (should (equal notice "Pi: Send failed: command rejected")))))))))
+
+(ert-deftest pilish-test-adversarial-retry-failure-before-late-success ()
+  "Late acceptance removes a submitted FIFO owner before restoring its successor."
+  (pilish-test--retry-failure-with-late-ack t))
+
+(ert-deftest pilish-test-adversarial-retry-failure-before-late-rejection ()
+  "Late rejection restores the unresolved FIFO owner and successor exactly once."
+  (pilish-test--retry-failure-with-late-ack :false))
+
 (ert-deftest pilish-test-review-fixes-queued-extension-ack-after-run ()
   "An extension awaiting waitForIdle accepts late, without resending its FIFO item."
   (pilish-test-with-rpc-session (chat _input proc commands)
@@ -1115,31 +1208,91 @@ When user aborts, they want to stop everything - including queued messages."
       (kill-buffer input-buf))))
 
 (ert-deftest pilish-test-queue-steering-when-sending-sends-steer ()
-  "Queue steering sends steer RPC while waiting for agent_start."
-  (let ((chat-buf (get-buffer-create "*pilish-test-queue-steer-sending*"))
-        (input-buf (get-buffer-create "*pilish-test-queue-steer-sending-input*"))
-        (sent-command nil))
-    (unwind-protect
-        (progn
-          (with-current-buffer chat-buf
-            (pilish-chat-mode)
-            (setq pilish--status 'sending)
-            (setq pilish--input-buffer input-buf))
-          (with-current-buffer input-buf
-            (pilish-input-mode)
-            (setq pilish--chat-buffer chat-buf)
-            (insert "Steer the pending retry")
-            (cl-letf (((symbol-function 'pilish--get-process) (lambda () 'mock-proc))
-                      ((symbol-function 'process-live-p) (lambda (_) t))
-                      ((symbol-function 'pilish--rpc-async)
-                       (lambda (_proc cmd _cb) (setq sent-command cmd))))
-              (pilish-queue-steering))
-            (should sent-command)
-            (should (equal (plist-get sent-command :type) "steer"))
-            (should (equal (plist-get sent-command :message) "Steer the pending retry"))
-            (should (string-empty-p (buffer-string)))))
-      (kill-buffer chat-buf)
-      (kill-buffer input-buf))))
+  "Steer an unstarted prompt or an announced retry, not a bare sending status."
+  (dolist (phase '(preflight accepted retry))
+    (pilish-test-with-rpc-session (chat input proc commands)
+      (let (notice)
+        (cl-letf (((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq notice (apply #'format fmt args)))))
+          (with-current-buffer chat
+            (setq pilish--state (list :status 'idle))
+            (pilish--prepare-and-send "original")
+            (unless (eq phase 'preflight)
+              (pilish--dispatch-response
+               proc (list :type "response" :id (plist-get (car commands) :id)
+                          :command "prompt" :success t)))
+            (when (eq phase 'retry)
+              (pilish--handle-display-event '(:type "agent_start"))
+              (pilish--handle-display-event '(:type "agent_end" :messages []))
+              (pilish--handle-display-event
+               '(:type "auto_retry_start" :attempt 1 :maxAttempts 3))))
+          (with-current-buffer input
+            (insert "Steer the upcoming run")
+            (pilish-queue-steering)
+            (should (string-empty-p (buffer-string))))
+          (should (= 2 (length commands)))
+          (should (equal (plist-get (car commands) :type) "steer"))
+          (should (equal (plist-get (car commands) :message) "Steer the upcoming run"))
+          (should (equal notice "Pi: Steering message sent")))))))
+
+(defun pilish-test--retry-steering-after-state-refresh (path)
+  "Check retry steering across correlated state refreshes through PATH."
+  (pilish-test-with-rpc-session (chat input proc commands)
+    (let (notice)
+      (cl-letf (((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq notice (apply #'format fmt args)))))
+        (with-current-buffer chat
+          (setq pilish--state (list :thinking-level "low"))
+          (dolist (event '((:type "agent_start")
+                           (:type "agent_end" :messages [] :willRetry t)
+                           (:type "auto_retry_start" :attempt 1 :maxAttempts 3)))
+            (pilish--handle-display-event event))
+          (should (pilish--session-steerable-p))
+          (dolist (retrying '(t nil))
+            ;; Reuse the actual core response callback or the thinking-level
+            ;; refresh's UI callback, with production request correlation.
+            (if (eq path 'core)
+                (pilish--rpc-async proc '(:type "get_state")
+                                   #'pilish--update-state-from-response)
+              (pilish--refresh-thinking-level-state proc chat))
+            (let ((request (car commands)))
+              (unless retrying
+                ;; Events may finish the retry after a refresh is requested.
+                ;; Its delayed snapshot must not resurrect that retry either.
+                (pilish--handle-display-event '(:type "agent_start"))
+                (pilish--handle-display-event '(:type "agent_end" :messages [])))
+              (pilish--dispatch-response
+               proc (list :type "response" :id (plist-get request :id)
+                          :command "get_state" :success t
+                          :data '(:isStreaming t :isCompacting :false
+                                  :thinkingLevel "high"))))
+            (should (equal (plist-get pilish--state :thinking-level) "high"))
+            (should (eq pilish--status 'sending))
+            (with-current-buffer input
+              (insert (if retrying "steer the retry" "after the run"))
+              (pilish-queue-steering)
+              (should (string-empty-p (buffer-string))))
+            (if retrying
+                (progn
+                  (should (equal (plist-get (car commands) :type) "steer"))
+                  (should (equal (plist-get (car commands) :message) "steer the retry"))
+                  (should (equal notice "Pi: Steering message sent"))
+                  (should (= 2 (length commands)))
+                  (should-not pilish--followup-queue))
+              (should (= 3 (length commands)))
+              (should (equal pilish--followup-queue '("after the run")))
+              (should (equal notice "Pi: Steering queued (will send when Pi is ready)")))
+            (should (eq (plist-get pilish--state :is-retrying) retrying))))))))
+
+(ert-deftest pilish-test-retry-steering-survives-core-state-refresh ()
+  "A core get_state response cannot erase event-owned retry steering."
+  (pilish-test--retry-steering-after-state-refresh 'core))
+
+(ert-deftest pilish-test-retry-steering-survives-thinking-state-refresh ()
+  "A thinking-level get_state callback cannot erase event-owned retry steering."
+  (pilish-test--retry-steering-after-state-refresh 'ui))
 
 (ert-deftest pilish-test-queue-steering-refuses-during-session-transition ()
   "Steering must not bypass the session-transition send guard."

--- a/test/pilish-input-test.el
+++ b/test/pilish-input-test.el
@@ -266,235 +266,61 @@
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pilish-test-compaction-success-without-retry-sends-queued-message ()
-  "Successful non-retry compaction schedules the oldest queued follow-up.
-Uses :false (JSON false representation) to verify boolean normalization."
+(ert-deftest pilish-test-manual-compaction-success-preserves-fifo ()
+  "Standalone manual compaction releases exactly the oldest follow-up."
   (with-temp-buffer
     (pilish-chat-mode)
-    (let ((sent-text nil)
-          drain-callback
-          drain-args)
-      (setq pilish--status 'compacting)
-      (setq pilish--followup-queue '("queued message"))
+    (let (sent-prompts shown-message)
       (cl-letf (((symbol-function 'pilish--send-prompt)
                  (lambda (text &optional on-success &rest _)
-                   (setq sent-text text)
-                   (when on-success (funcall on-success))))
-                ((symbol-function 'run-at-time)
-                 (lambda (_secs _repeat fn &rest args)
-                   (setq drain-callback fn
-                         drain-args args)
-                   'fake-drain-timer)))
+                   (push text sent-prompts)
+                   (setq pilish--status 'sending)
+                   (funcall on-success)))
+                ((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (pilish--handle-display-event '(:type "compaction_start" :reason "manual"))
+        (dolist (text '("First" "Second" "Third"))
+          (pilish--push-followup text))
         (pilish--handle-display-event
-         '(:type "compaction_end"
-           :reason "threshold"
-           :aborted :false
-           :willRetry :false
-           :result (:tokensBefore 1000 :summary "Summary" :timestamp 1234567890000)))
-        (should (eq pilish--status 'idle))
-        (should (functionp drain-callback))
-        (should (equal pilish--followup-queue '("queued message")))
-        (should (null sent-text))
-        (apply drain-callback drain-args))
-      ;; Queue should be empty after processing.
-      (should (null pilish--followup-queue))
-      ;; The queued message should have been sent.
-      (should (equal sent-text "queued message")))))
-
-(ert-deftest pilish-test-compaction-success-without-retry-preserves-fifo ()
-  "Successful non-retry compaction schedules one follow-up in FIFO order."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (let ((sent-text nil)
-          drain-callback
-          drain-args)
-      (setq pilish--status 'compacting)
-      (dolist (text '("First" "Second" "Third"))
-        (pilish--push-followup text))
-      (cl-letf (((symbol-function 'pilish--send-prompt)
-                 (lambda (text &optional on-success &rest _)
-                   (setq sent-text text)
-                   (when on-success (funcall on-success))))
-                ((symbol-function 'run-at-time)
-                 (lambda (_secs _repeat fn &rest args)
-                   (setq drain-callback fn
-                         drain-args args)
-                   'fake-drain-timer)))
-        (pilish--handle-display-event
-         '(:type "compaction_end"
-           :reason "manual"
-           :aborted :false
-           :willRetry :false
+         '(:type "compaction_end" :reason "manual" :aborted :false :willRetry :false
            :result (:tokensBefore 1000 :summary "Summary")))
-        (should (equal pilish--followup-queue '("Third" "Second" "First")))
-        (should (null sent-text))
-        (apply drain-callback drain-args))
-      (should (equal sent-text "First"))
-      (should (equal pilish--followup-queue '("Third" "Second"))))))
+        (should (equal shown-message "Pi: Compacted from 1,000 tokens"))
+        (should (equal sent-prompts '("First")))
+        (should (equal pilish--followup-queue '("Third" "Second")))))))
 
-(ert-deftest pilish-test-overflow-compaction-will-retry-preserves-followup-queue ()
-  "Overflow compaction with automatic retry keeps local follow-ups queued."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (let ((sent-text nil))
-      (setq pilish--status 'compacting)
-      (setq pilish--followup-queue '("queued behind retry"))
-      (cl-letf (((symbol-function 'pilish--send-prompt)
-                 (lambda (text &optional on-success &rest _)
-                   (setq sent-text text)
-                   (when on-success (funcall on-success)))))
-        (pilish--handle-display-event
-         '(:type "compaction_end"
-           :reason "overflow"
-           :aborted :false
-           :willRetry t
-           :result (:tokensBefore 1000 :summary "Summary"))))
-      (should (eq pilish--status 'sending))
-      (should (equal pilish--followup-queue '("queued behind retry")))
-      (should (null sent-text)))))
-
-(ert-deftest pilish-test-overflow-compaction-retry-drains-queue-after-agent-end ()
-  "Queued follow-ups wait for Pi's automatic retry turn to finish."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (let ((sent-prompts nil)
-          drain-callback
-          drain-args)
-      (setq pilish--status 'compacting)
+(ert-deftest pilish-test-overflow-compaction-retry-drains-queue-after-settled ()
+  "Overflow recovery and its retry stay ahead of local FIFO until settlement."
+  (pilish-test--with-streaming-assistant
+    (let (sent-prompts)
       (setq pilish--followup-queue '("queued behind retry"))
       (cl-letf (((symbol-function 'pilish--send-prompt)
                  (lambda (text &optional on-success &rest _)
                    (push text sent-prompts)
-                   (when on-success (funcall on-success))))
+                   (setq pilish--status 'sending)
+                   (funcall on-success)))
                 ((symbol-function 'pilish--refresh-header) #'ignore)
-                ((symbol-function 'run-at-time)
-                 (lambda (_secs _repeat fn &rest args)
-                   (setq drain-callback fn
-                         drain-args args)
-                   'fake-drain-timer)))
+                ((symbol-function 'message) #'ignore))
+        (pilish--handle-display-event '(:type "agent_end" :messages []))
+        (pilish--handle-display-event '(:type "compaction_start" :reason "overflow"))
         (pilish--handle-display-event
-         '(:type "compaction_end"
-           :reason "overflow"
-           :aborted :false
-           :willRetry t
+         '(:type "compaction_end" :reason "overflow" :aborted :false :willRetry t
            :result (:tokensBefore 1000 :summary "Summary")))
-        (should (null sent-prompts))
+        (should (eq pilish--status 'sending))
+        (should-not sent-prompts)
         (should (equal pilish--followup-queue '("queued behind retry")))
-        (should (null drain-callback))
         (pilish--handle-display-event '(:type "agent_start"))
-        (should (eq pilish--status 'streaming))
         (pilish--handle-display-event '(:type "agent_end" :messages []))
-        (should (functionp drain-callback))
-        (apply drain-callback drain-args))
-      (should (equal (reverse sent-prompts) '("queued behind retry")))
-      (should (null pilish--followup-queue)))))
-
-(ert-deftest pilish-test-compaction-end-before-agent-start-defers-followup-drain ()
-  "Queued follow-ups do not overtake Pi work that starts after compaction_end."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (let ((sent-prompts nil)
-          first-drain-callback
-          first-drain-args
-          second-drain-callback
-          second-drain-args)
-      (setq pilish--status 'compacting
-            pilish--followup-queue '("local follow-up after Pi queue"))
-      (cl-letf (((symbol-function 'pilish--send-prompt)
-                 (lambda (text &optional on-success &rest _)
-                   (push text sent-prompts)
-                   (when on-success (funcall on-success))))
-                ((symbol-function 'pilish--refresh-header) #'ignore)
-                ((symbol-function 'run-at-time)
-                 (lambda (_secs _repeat fn &rest args)
-                   (if first-drain-callback
-                       (setq second-drain-callback fn
-                             second-drain-args args)
-                     (setq first-drain-callback fn
-                           first-drain-args args))
-                   'fake-drain-timer)))
-        ;; Pi can emit compaction_end and then immediately begin work it already
-        ;; owns.  Local follow-ups must wait for that visible agent turn.
-        (pilish--handle-display-event
-         '(:type "compaction_end"
-           :reason "threshold"
-           :aborted :false
-           :willRetry :false
-           :result (:tokensBefore 1000 :summary "Summary")))
-        (should (eq pilish--status 'idle))
-        (should (functionp first-drain-callback))
-        (should (null sent-prompts))
-        (should (equal pilish--followup-queue
-                       '("local follow-up after Pi queue")))
-        (pilish--handle-display-event '(:type "agent_start"))
-        ;; A stale scheduled drain may still fire, but streaming status makes it
-        ;; a no-op.
-        (apply first-drain-callback first-drain-args)
-        (should (null sent-prompts))
-        (should (equal pilish--followup-queue
-                       '("local follow-up after Pi queue")))
-        (pilish--handle-display-event '(:type "agent_end" :messages []))
-        (should (functionp second-drain-callback))
-        (apply second-drain-callback second-drain-args))
-      (should (equal (reverse sent-prompts)
-                     '("local follow-up after Pi queue")))
-      (should (null pilish--followup-queue)))))
-
-(ert-deftest pilish-test-agent-end-before-compaction-defers-followup-drain ()
-  "Queued follow-ups do not overtake compaction that starts after agent_end."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (let ((sent-prompts nil)
-          drain-callback
-          drain-args)
-      (setq pilish--status 'streaming
-            pilish--followup-queue '("queued until compaction settles"))
-      (cl-letf (((symbol-function 'pilish--send-prompt)
-                 (lambda (text &optional on-success &rest _)
-                   (push text sent-prompts)
-                   (when on-success (funcall on-success))))
-                ((symbol-function 'pilish--refresh-header) #'ignore)
-                ((symbol-function 'run-at-time)
-                 (lambda (_secs _repeat fn &rest args)
-                   (setq drain-callback fn
-                         drain-args args)
-                   'fake-drain-timer)))
-        ;; Pi emits agent_end before post-run compaction_start.  The local
-        ;; queue must wait long enough for that compaction event to claim the
-        ;; next ordering slot.
-        (pilish--handle-display-event '(:type "agent_end" :messages []))
-        (should (eq pilish--status 'idle))
-        (should (functionp drain-callback))
-        (should (null sent-prompts))
-        (should (equal pilish--followup-queue
-                       '("queued until compaction settles")))
-        (pilish--handle-display-event '(:type "compaction_start" :reason "threshold"))
-        ;; A stale scheduled drain may still fire, but compacting status makes
-        ;; it a no-op.
-        (apply drain-callback drain-args)
-        (should (null sent-prompts))
-        (should (equal pilish--followup-queue
-                       '("queued until compaction settles")))
-        (setq drain-callback nil
-              drain-args nil)
-        (pilish--handle-display-event
-         '(:type "compaction_end"
-           :reason "threshold"
-           :aborted :false
-           :willRetry :false
-           :result (:tokensBefore 1000 :summary "Summary")))
-        (should (functionp drain-callback))
-        (apply drain-callback drain-args))
-      (should (equal (reverse sent-prompts)
-                     '("queued until compaction settles")))
-      (should (null pilish--followup-queue)))))
+        (should-not sent-prompts)
+        (pilish--handle-display-event '(:type "agent_settled"))
+        (should (equal sent-prompts '("queued behind retry")))
+        (should-not pilish--followup-queue)))))
 
 (ert-deftest pilish-test-preflight-compaction-keeps-followups-behind-prompt ()
   "Compaction during prompt preflight must not drain local follow-ups."
   (with-temp-buffer
     (pilish-chat-mode)
-    (let ((sent-prompts nil)
-          drain-callback)
+    (let ((sent-prompts nil))
       (setq pilish--status 'sending
             pilish--pre-compaction-status nil
             pilish--followup-queue '("queued behind original prompt"))
@@ -502,10 +328,7 @@ Uses :false (JSON false representation) to verify boolean normalization."
                  (lambda (text &optional on-success &rest _)
                    (push text sent-prompts)
                    (when on-success (funcall on-success))))
-                ((symbol-function 'run-at-time)
-                 (lambda (_secs _repeat fn &rest _args)
-                   (setq drain-callback fn)
-                   'fake-drain-timer)))
+                ((symbol-function 'message) #'ignore))
         (pilish--handle-display-event
          '(:type "compaction_start" :reason "threshold"))
         (pilish--handle-display-event
@@ -515,13 +338,12 @@ Uses :false (JSON false representation) to verify boolean normalization."
            :willRetry :false
            :result (:tokensBefore 1000 :summary "Summary")))
         (should (eq pilish--status 'sending))
-        (should (null drain-callback))
         (should (null sent-prompts))
         (should (equal pilish--followup-queue
                        '("queued behind original prompt")))))))
 
-(ert-deftest pilish-test-failed-preflight-compaction-restores-followups-before-prompt-failure ()
-  "Failed preflight compaction restores follow-ups while prompt failure is pending."
+(ert-deftest pilish-test-failed-preflight-compaction-keeps-followups-until-prompt-result ()
+  "Failed compaction leaves prompt and follow-up ownership with preflight."
   (let ((chat-buf (get-buffer-create "*pilish-test-preflight-compaction-failure-chat*"))
         (input-buf (get-buffer-create "*pilish-test-preflight-compaction-failure-input*"))
         (sent-text nil))
@@ -551,18 +373,18 @@ Uses :false (JSON false representation) to verify boolean normalization."
                    :willRetry :false
                    :result :null
                    :errorMessage "quota exceeded")))
-              (should (eq pilish--status 'idle))
+              (should (eq pilish--status 'sending))
               (should (equal pilish--activity-phase "thinking"))
               (should (pilish--prompt-start-current-p generation))
-              (should (null pilish--followup-queue))
+              (should (equal pilish--followup-queue '("follow-up after prompt")))
               (should (null sent-text))))
           (with-current-buffer input-buf
-            (should (equal (buffer-string) "follow-up after prompt"))))
+            (should (string-empty-p (buffer-string)))))
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pilish-test-aborted-preflight-compaction-clears-followups-before-prompt-failure ()
-  "Aborted preflight compaction clears follow-ups while prompt failure is pending."
+(ert-deftest pilish-test-extension-cancelled-preflight-compaction-keeps-followups ()
+  "Extension cancellation is not a local stop and may continue preflight."
   (with-temp-buffer
     (pilish-chat-mode)
     (let ((sent-text nil))
@@ -583,9 +405,9 @@ Uses :false (JSON false representation) to verify boolean normalization."
            :aborted t
            :willRetry :false
            :result nil)))
-      (should (eq pilish--status 'idle))
+      (should (eq pilish--status 'sending))
       (should (equal pilish--activity-phase "thinking"))
-      (should (null pilish--followup-queue))
+      (should (equal pilish--followup-queue '("discarded follow-up")))
       (should (null sent-text)))))
 
 (ert-deftest pilish-test-failed-preflight-compaction-prompt-failure-restores-original ()
@@ -636,38 +458,28 @@ Uses :false (JSON false representation) to verify boolean normalization."
       (kill-buffer input-buf))))
 
 (ert-deftest pilish-test-agent-end-will-retry-preserves-followup-queue ()
-  "agent_end with willRetry keeps local follow-ups behind Pi's retry."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (let ((sent-prompts nil)
-          drain-callback
-          drain-args)
-      (setq pilish--status 'streaming
-            pilish--followup-queue '("queued behind transient retry"))
+  "Transient retry does not release FIFO until the retried run settles."
+  (pilish-test--with-streaming-assistant
+    (let (sent-prompts)
+      (setq pilish--followup-queue '("queued behind transient retry"))
       (cl-letf (((symbol-function 'pilish--send-prompt)
                  (lambda (text &optional on-success &rest _)
                    (push text sent-prompts)
-                   (when on-success (funcall on-success))))
-                ((symbol-function 'pilish--refresh-header) #'ignore)
-                ((symbol-function 'run-at-time)
-                 (lambda (_secs _repeat fn &rest args)
-                   (setq drain-callback fn
-                         drain-args args)
-                   'fake-drain-timer)))
+                   (funcall on-success)))
+                ((symbol-function 'pilish--refresh-header) #'ignore))
+        (pilish--handle-display-event '(:type "agent_end" :messages [] :willRetry t))
         (pilish--handle-display-event
-         '(:type "agent_end" :messages [] :willRetry t))
+         '(:type "auto_retry_start" :attempt 1 :maxAttempts 3 :delayMs 1000))
         (should (eq pilish--status 'sending))
-        (should (null drain-callback))
-        (should (null sent-prompts))
-        (should (equal pilish--followup-queue
-                       '("queued behind transient retry")))
+        (should-not sent-prompts)
+        (should (equal pilish--followup-queue '("queued behind transient retry")))
+        (pilish--handle-display-event '(:type "auto_retry_end" :success t))
         (pilish--handle-display-event '(:type "agent_start"))
         (pilish--handle-display-event '(:type "agent_end" :messages []))
-        (should (functionp drain-callback))
-        (apply drain-callback drain-args))
-      (should (equal (reverse sent-prompts)
-                     '("queued behind transient retry")))
-      (should (null pilish--followup-queue)))))
+        (should-not sent-prompts)
+        (pilish--handle-display-event '(:type "agent_settled"))
+        (should (equal sent-prompts '("queued behind transient retry")))
+        (should-not pilish--followup-queue)))))
 
 (ert-deftest pilish-test-compaction-failure-restores-queued-followups ()
   "Failed compaction surfaces queued follow-ups for user recovery."
@@ -724,6 +536,9 @@ Uses :false (JSON false representation) to verify boolean normalization."
                :success :false
                :attempt 3
                :finalError "overloaded"))
+            (should (eq pilish--status 'sending))
+            (should (equal pilish--activity-phase "thinking"))
+            (pilish--handle-display-event '(:type "agent_settled"))
             (should (eq pilish--status 'idle))
             (should (equal pilish--activity-phase "idle"))
             (should (null pilish--followup-queue))
@@ -733,8 +548,8 @@ Uses :false (JSON false representation) to verify boolean normalization."
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pilish-test-compaction-end-aborted-clears-queue ()
-  "compaction_end when aborted clears followup queue without sending."
+(ert-deftest pilish-test-cancelled-manual-compaction-keeps-queue-without-input ()
+  "Extension cancellation cannot discard text when its editor is unavailable."
   (with-temp-buffer
     (pilish-chat-mode)
     (let ((sent-text nil))
@@ -749,40 +564,470 @@ Uses :false (JSON false representation) to verify boolean normalization."
          '(:type "compaction_end"
            :reason "threshold"
            :aborted t)))
-      ;; Queue should be cleared (user cancelled)
-      (should (null pilish--followup-queue))
+      ;; No explicit stop occurred, and there is nowhere to restore the text.
+      (should (equal pilish--followup-queue '("queued message")))
       ;; No message should have been sent
       (should (null sent-text)))))
 
-;;; Abort Command
+;;; Run Settlement
 
-(ert-deftest pilish-test-abort-sends-command ()
-  "pilish-abort sends abort command while streaming."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (let ((sent-command nil)
-          (pilish--status 'streaming))
+(ert-deftest pilish-test-review-fixes-settled-reentry-keeps-new-run ()
+  "A's delayed settlement cannot release observably newer streaming work B.
+If B has also ended, A/B settlements have no wire identity; this guard does
+not claim to distinguish those otherwise identical sending-state traces."
+  (dolist (stop '(nil t))
+    (pilish-test-with-rpc-session (chat _input _proc commands)
+      (with-current-buffer chat
+        (cl-letf (((symbol-function 'message) #'ignore))
+          (dolist (event '((:type "agent_start")
+                           (:type "agent_end" :messages [])
+                           (:type "agent_start")
+                           (:type "message_start" :message (:role "assistant"))
+                           (:type "message_update"
+                            :assistantMessageEvent (:type "text_delta" :delta "B"))))
+            (pilish--handle-display-event event))
+          (setq pilish--followup-queue '("next"))
+          (when stop (pilish-abort))
+          (setq commands nil)
+          (pilish--handle-display-event '(:type "agent_settled")) ; A
+          (should-not commands)
+          (should (eq pilish--status 'streaming))
+          (should (eq pilish--aborted stop))
+          (should (equal pilish--activity-phase "replying"))
+          (pilish--handle-display-event '(:type "agent_end" :messages [])) ; B
+          (pilish--handle-display-event '(:type "agent_settled"))
+          (should-not pilish--aborted)
+          (should (= (if stop 0 1) (length commands))))))))
+
+(ert-deftest pilish-test-review-fixes-settled-manual-reentry-keeps-compaction ()
+  "A's settlement neither ends extension-started manual B nor resurrects A."
+  (pilish-test-with-rpc-session (chat input _proc commands)
+    (with-current-buffer chat
+      (cl-letf (((symbol-function 'message) #'ignore))
+        (pilish--handle-display-event '(:type "agent_start"))
+        (pilish--handle-display-event '(:type "agent_end" :messages []))
+        (setq pilish--followup-queue '("next"))
+        (pilish--handle-display-event '(:type "compaction_start" :reason "manual"))
+        (pilish--handle-display-event '(:type "agent_settled"))
+        (should (eq pilish--status 'compacting))
+        (should (equal pilish--activity-phase "compact"))
+        (should-not commands)
+        (pilish--handle-display-event
+         '(:type "compaction_end" :reason "manual" :aborted :false :willRetry :false
+           :result :null :errorMessage "stub auth failure"))
+        (should (eq pilish--status 'idle))
+        (should-not (pilish--session-busy-p))
+        (should (string-match-p "stub auth failure" (buffer-string)))))
+    (with-current-buffer input (should (equal (buffer-string) "next")))))
+
+(ert-deftest pilish-test-review-fixes-stop-before-delayed-compaction-start ()
+  "Reapply Stop when manual or automatic compaction finally creates a controller."
+  (dolist (reason '("manual" "threshold"))
+    (pilish-test-with-rpc-session (chat _input _proc commands)
+      (with-current-buffer chat
+        (cl-letf (((symbol-function 'message) #'ignore))
+          (if (equal reason "manual")
+              (pilish-compact)
+            (pilish--prepare-and-send "prompt preflight"))
+          (pilish-abort)
+          (should pilish--aborted)
+          (setq commands nil)
+          (pilish--handle-display-event (list :type "compaction_start" :reason reason))
+          (should (equal (mapcar (lambda (cmd) (plist-get cmd :type))
+                                (reverse commands))
+                         '("clear_queue" "abort")))
+          (should pilish--aborted))))))
+
+(ert-deftest pilish-test-review-fixes-queued-extension-ack-after-run ()
+  "An extension awaiting waitForIdle accepts late, without resending its FIFO item."
+  (pilish-test-with-rpc-session (chat _input proc commands)
+    (with-current-buffer chat
+      (setq pilish--followup-queue '("next" "/extension-run"))
+      (pilish--process-followup-queue)
+      (let ((request (car commands)))
+        (dolist (event '((:type "agent_start")
+                         (:type "agent_end" :messages [])
+                         (:type "agent_settled")))
+          (pilish--handle-display-event event))
+        (should (= 1 (length commands)))
+        (should (pilish--session-busy-p)) ; request still unacknowledged
+        (should (equal pilish--followup-queue '("next" "/extension-run")))
+        (pilish--dispatch-response
+         proc (list :type "response" :id (plist-get request :id)
+                    :command "prompt" :success t))
+        (should (equal (mapcar (lambda (cmd) (plist-get cmd :message))
+                              (reverse commands))
+                       '("/extension-run" "next")))
+        (should (equal pilish--followup-queue '("next")))))))
+
+(ert-deftest pilish-test-review-fixes-stop-while-awaiting-late-acceptance ()
+  "Stopping a settled but unacknowledged command does not poison the next prompt."
+  (pilish-test-with-rpc-session (chat _input proc commands)
+    (with-current-buffer chat
+      (cl-letf (((symbol-function 'message) #'ignore))
+        (pilish--prepare-and-send "/extension-run")
+        (let ((request (car commands)))
+          (dolist (event '((:type "agent_start") (:type "agent_end" :messages [])
+                           (:type "agent_settled")))
+            (pilish--handle-display-event event))
+          (pilish-abort)
+          (should pilish--aborted)
+          (pilish--dispatch-response
+           proc (list :type "response" :id (plist-get request :id)
+                      :command "prompt" :success t))
+          (should-not pilish--aborted)
+          (should-not (pilish--session-busy-p)))))))
+
+(ert-deftest pilish-test-review-fixes-manual-reentry-retains-unacknowledged-fifo ()
+  "Extension manual failure cannot restore a FIFO request still awaiting acceptance."
+  (pilish-test-with-rpc-session (chat input proc commands)
+    (with-current-buffer chat
+      (cl-letf (((symbol-function 'message) #'ignore))
+        (setq pilish--followup-queue '("next" "/extension-run"))
+        (pilish--process-followup-queue)
+        (let ((request (car commands)))
+          (dolist (event '((:type "agent_start") (:type "agent_end" :messages [])
+                           (:type "compaction_start" :reason "manual")
+                           (:type "agent_settled")
+                           (:type "compaction_end" :reason "manual" :aborted :false
+                            :result :null :errorMessage "manual failed")))
+            (pilish--handle-display-event event))
+          (should (equal pilish--followup-queue '("next" "/extension-run")))
+          (with-current-buffer input (should (string-empty-p (buffer-string))))
+          (pilish--dispatch-response
+           proc (list :type "response" :id (plist-get request :id)
+                      :command "prompt" :success t))
+          (should (= 2 (length commands)))
+          (should (equal (plist-get (car commands) :message) "next")))))))
+
+(ert-deftest pilish-test-review-fixes-late-prompt-ack-does-not-append-user-echo ()
+  "Acceptance after an authoritative echo or run never appends a late user turn."
+  (dolist (timing '(echo-only streaming settled))
+    (pilish-test-with-rpc-session (chat _input proc commands)
+      (with-current-buffer chat
+        (pilish--prepare-and-send "original")
+        (let ((request (car commands)))
+          (unless (eq timing 'echo-only)
+            (pilish--handle-display-event '(:type "agent_start")))
+          (pilish--handle-display-event
+           '(:type "message_start"
+             :message (:role "user" :content [(:type "text" :text "original")])))
+          (when (eq timing 'settled)
+            (pilish--handle-display-event '(:type "agent_end" :messages []))
+            (pilish--handle-display-event '(:type "agent_settled")))
+          (pilish--dispatch-response
+           proc (list :type "response" :id (plist-get request :id)
+                      :command "prompt" :success t))
+          (should (= 1 (pilish-test--count-matches "original" (buffer-string))))
+          (should-not pilish--local-user-message)
+          (when (eq timing 'echo-only)
+            (pilish--handle-display-event '(:type "agent_start"))))))))
+
+(ert-deftest pilish-test-review-fixes-late-rejection-preserves-active-work ()
+  "A rejected command restores its text without idling independently started work."
+  (pilish-test-with-rpc-session (chat input proc commands)
+    (with-current-buffer chat
+      (cl-letf (((symbol-function 'message) #'ignore))
+        (pilish--prepare-and-send "rejected request")
+        (let ((request (car commands)))
+          (pilish--handle-display-event '(:type "agent_start"))
+          (pilish-abort)
+          (pilish--dispatch-response
+           proc (list :type "response" :id (plist-get request :id)
+                      :command "prompt" :success :false :error "extension failed"))
+          (with-current-buffer input
+            (should (equal (buffer-string) "rejected request")))
+          (should (eq pilish--status 'streaming))
+          (should pilish--aborted))))))
+
+(ert-deftest pilish-test-review-fixes-prompt-response-after-process-replacement ()
+  "Old acceptance or rejection cannot mutate replacement-process state or drafts."
+  (dolist (success '(t :false))
+    (pilish-test-with-rpc-session (chat input proc commands)
+      (with-current-buffer chat
+        (cl-letf (((symbol-function 'message) #'ignore))
+          (pilish--prepare-and-send "old request")
+          (let ((request (car commands)))
+            (pilish--set-process (start-process "replacement" nil "cat"))
+            (setq pilish--status 'streaming pilish--aborted t
+                  pilish--followup-queue '("replacement work"))
+            (with-current-buffer input (insert "new draft"))
+            (pilish--dispatch-response
+             proc (list :type "response" :id (plist-get request :id)
+                        :command "prompt" :success success :error "old failure"))
+            (should-not (string-match-p "old request" (buffer-string)))
+            (should (eq pilish--status 'streaming))
+            (should pilish--aborted)
+            (should (equal pilish--followup-queue '("replacement work")))
+            (with-current-buffer input
+              (should (equal (buffer-string) "new draft")))))))))
+
+(ert-deftest pilish-test-lifecycle-interturn-compaction-keeps-guard-and-abort ()
+  "A resumed turn remains guarded and stoppable without another agent_start."
+  (pilish-test--with-streaming-assistant
+    (let (commands shown-message)
       (cl-letf (((symbol-function 'pilish--get-process) (lambda () 'mock-proc))
-                ((symbol-function 'pilish--get-chat-buffer) (lambda () (current-buffer)))
+                ((symbol-function 'process-live-p) (lambda (_) t))
+                ((symbol-function 'pilish--refresh-header) #'ignore)
                 ((symbol-function 'pilish--rpc-async)
-                 (lambda (_proc cmd _cb) (setq sent-command cmd))))
+                 (lambda (_proc command callback)
+                   (push (plist-get command :type) commands)
+                   (when (equal (plist-get command :type) "clear_queue")
+                     (funcall callback '(:success t)))))
+                ((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (dolist (event '((:type "message_end" :message (:role "assistant"))
+                         (:type "turn_end")
+                         (:type "compaction_start" :reason "threshold")
+                         (:type "compaction_end" :aborted :false :willRetry :false
+                          :result (:tokensBefore 1000 :summary "Summary"))
+                         (:type "turn_start")
+                         (:type "message_start" :message (:role "assistant"))))
+          (pilish--handle-display-event event))
+        ;; No queue or prompt-start wait may accidentally mask an idle status.
+        (should-not (pilish--session-transition-ready-p (current-buffer) "reload"))
+        (should (string-match-p "Cannot reload" shown-message))
+        (should (pilish--session-busy-p))
         (pilish-abort)
-        (should (equal (plist-get sent-command :type) "abort"))
+        (should (equal (reverse commands) '("clear_queue" "abort")))
         (should pilish--aborted)))))
 
-(ert-deftest pilish-test-abort-sends-command-while-compacting ()
-  "pilish-abort sends abort command while compacting."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (let ((sent-command nil)
-          (pilish--status 'compacting))
+(ert-deftest pilish-test-lifecycle-interturn-unsuccessful-compaction-keeps-followups ()
+  "Compaction failure or extension cancellation neither restores nor drops FIFO."
+  (dolist (outcome '((:aborted :false :result :null :errorMessage "quota exceeded")
+                     (:aborted t :result :null)))
+    (ert-info ((format "Compaction outcome: %S" outcome))
+      (pilish-test-with-mock-session "/tmp/pilish-test-lifecycle-compaction-queue/"
+        (let ((chat-buf (get-buffer "*pilish-chat:/tmp/pilish-test-lifecycle-compaction-queue/*"))
+              (input-buf (get-buffer "*pilish-input:/tmp/pilish-test-lifecycle-compaction-queue/*"))
+              sent-prompts shown-message)
+          (with-current-buffer input-buf
+            (insert "new draft"))
+          (with-current-buffer chat-buf
+            (cl-letf (((symbol-function 'pilish--send-prompt)
+                       (lambda (text &rest _) (push text sent-prompts)))
+                      ((symbol-function 'message)
+                       (lambda (fmt &rest args)
+                         (setq shown-message (apply #'format fmt args)))))
+              (pilish--handle-display-event '(:type "agent_start"))
+              (setq pilish--followup-queue '("second" "first"))
+              (pilish--handle-display-event '(:type "turn_end"))
+              (pilish--handle-display-event
+               '(:type "compaction_start" :reason "threshold"))
+              (pilish--handle-display-event
+               (append '(:type "compaction_end" :willRetry :false) outcome))
+              (should (equal pilish--followup-queue '("second" "first")))
+              (should-not sent-prompts)
+              (should-not pilish--aborted)
+              (should (eq pilish--status 'streaming))
+              (should-not (equal pilish--activity-phase "idle"))
+              (should (equal shown-message
+                             (if (eq (plist-get outcome :aborted) t)
+                                 "Pi: Compaction cancelled"
+                               "Pi: Compaction failed: quota exceeded")))
+              (pilish--handle-display-event '(:type "turn_start"))
+              (should (pilish--session-busy-p))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "new draft"))))))))
+
+(ert-deftest pilish-test-lifecycle-delayed-post-run-work-waits-for-settled ()
+  "Elapsed time, post-run compaction and extra work cannot release FIFO early."
+  (pilish-test--with-streaming-assistant
+    (let (sent-prompts prompt-callback notices)
+      (setq pilish--followup-queue '("second" "first"))
       (cl-letf (((symbol-function 'pilish--get-process) (lambda () 'mock-proc))
-                ((symbol-function 'pilish--get-chat-buffer) (lambda () (current-buffer)))
+                ((symbol-function 'process-live-p) (lambda (_) t))
+                ((symbol-function 'pilish--refresh-header) #'ignore)
                 ((symbol-function 'pilish--rpc-async)
-                 (lambda (_proc cmd _cb) (setq sent-command cmd))))
+                 (lambda (_proc command callback)
+                   (when (equal (plist-get command :type) "prompt")
+                     (push (plist-get command :message) sent-prompts)
+                     (setq prompt-callback callback))))
+                ((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (when fmt (push (apply #'format fmt args) notices)))))
+        (pilish--handle-display-event
+         '(:type "agent_end" :messages [] :willRetry :false))
+        ;; Deliberately deliver post-run events later than the old 50ms drain.
+        (sleep-for 0.1)
+        (should-not sent-prompts)
+        (should (eq pilish--status 'sending))
+        (pilish--handle-display-event
+         '(:type "compaction_start" :reason "threshold"))
+        (pilish--handle-display-event
+         '(:type "compaction_end" :aborted :false :willRetry :false
+           :result (:tokensBefore 1000 :summary "Summary")))
+        (sleep-for 0.1)
+        (should-not sent-prompts)
+        (should (eq pilish--status 'sending))
+        (should (member "Pi: Compacted from 1,000 tokens" notices))
+        ;; Extension-owned work may start before the session finally settles.
+        (pilish--handle-display-event '(:type "agent_start"))
+        (pilish--handle-display-event '(:type "agent_end" :messages []))
+        (sleep-for 0.1)
+        (should-not sent-prompts)
+        (pilish--handle-display-event '(:type "agent_settled"))
+        (should (equal sent-prompts '("first")))
+        ;; Sending is not acceptance: the oldest item still owns its text.
+        (should (equal pilish--followup-queue '("second" "first")))
+        (funcall prompt-callback '(:success t))
+        (should (equal pilish--followup-queue '("second")))
+        (pilish--handle-display-event '(:type "agent_start"))
+        (pilish--handle-display-event '(:type "agent_end" :messages []))
+        (should (equal sent-prompts '("first")))
+        (pilish--handle-display-event '(:type "agent_settled"))
+        (should (equal (reverse sent-prompts) '("first" "second")))
+        (funcall prompt-callback '(:success t))
+        (should-not pilish--followup-queue)
+        (pilish--handle-display-event '(:type "agent_start"))
+        (pilish--handle-display-event '(:type "agent_end" :messages []))
+        (pilish--handle-display-event '(:type "agent_settled"))
+        (should-not (pilish--session-busy-p))
+        (should (pilish--session-transition-ready-p (current-buffer) "reload"))
+        (should (equal (reverse sent-prompts) '("first" "second")))))))
+
+(ert-deftest pilish-test-lifecycle-idle-header-response-cannot-unlock-active-work ()
+  "Header refresh cannot make active work idle when no prompt wait exists."
+  (dolist (status '(sending streaming compacting))
+    (with-temp-buffer
+      (pilish-chat-mode)
+      (setq pilish--status status)
+      (pilish--apply-state-response
+       (current-buffer)
+       '(:success t :data (:isStreaming :false :isCompacting :false
+                          :thinkingLevel "high")))
+      (should (equal (plist-get pilish--state :thinking-level) "high"))
+      (should (eq pilish--status status))
+      (should (pilish--session-busy-p)))))
+
+;;; Abort Command
+
+(ert-deftest pilish-test-lifecycle-abort-clears-backend-before-stopping ()
+  "Stop clears backend steering and local FIFO in every busy phase."
+  (dolist (status '(streaming sending compacting))
+    (with-temp-buffer
+      (pilish-chat-mode)
+      (setq pilish--status status
+            pilish--followup-queue '("must not continue"))
+      (let (commands shown-message)
+        (cl-letf (((symbol-function 'pilish--get-process) (lambda () 'mock-proc))
+                  ((symbol-function 'process-live-p) (lambda (_) t))
+                  ((symbol-function 'pilish--rpc-async)
+                   (lambda (_proc command callback)
+                     (push (plist-get command :type) commands)
+                     (when (equal (plist-get command :type) "clear_queue")
+                       (funcall callback '(:success t)))))
+                  ((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (pilish-abort)
+          (should (equal shown-message "Pi: Aborting..."))
+          (should (equal (reverse commands) '("clear_queue" "abort")))
+          (should-not pilish--followup-queue)
+          (should pilish--aborted))))))
+
+(ert-deftest pilish-test-lifecycle-abort-preflight-stops-eventual-agent-start ()
+  "Stop during preflight compaction survives a later accepted prompt and run."
+  (pilish-test-with-mock-session "/tmp/pilish-test-lifecycle-abort-preflight/"
+    (let ((chat-buf (get-buffer "*pilish-chat:/tmp/pilish-test-lifecycle-abort-preflight/*"))
+          (input-buf (get-buffer "*pilish-input:/tmp/pilish-test-lifecycle-abort-preflight/*"))
+          commands prompts prompt-callback shown-message)
+      (cl-letf (((symbol-function 'pilish--get-process) (lambda () 'mock-proc))
+                ((symbol-function 'process-live-p) (lambda (_) t))
+                ((symbol-function 'pilish--refresh-header) #'ignore)
+                ((symbol-function 'pilish--rpc-async)
+                 (lambda (_proc command callback)
+                   (push (plist-get command :type) commands)
+                   (pcase (plist-get command :type)
+                     ("prompt"
+                      (push (plist-get command :message) prompts)
+                      (setq prompt-callback callback))
+                     ("clear_queue" (funcall callback '(:success t))))))
+                ((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (when fmt (setq shown-message (apply #'format fmt args))))))
+        (with-current-buffer input-buf
+          (insert "original prompt")
+          (pilish-send)
+          (insert "unwanted follow-up")
+          (pilish-send))
+        (with-current-buffer chat-buf
+          (pilish--handle-display-event
+           '(:type "compaction_start" :reason "threshold"))
+          (pilish-abort)
+          (pilish--handle-display-event
+           '(:type "compaction_end" :aborted t :willRetry :false :result :null))
+          (should (equal shown-message "Pi: Compaction cancelled"))
+          (funcall prompt-callback '(:success t))
+          (setq commands nil)
+          (pilish--handle-display-event '(:type "agent_start"))
+          (should (member "abort" commands))
+          (should pilish--aborted)
+          (should-not pilish--followup-queue)
+          (pilish--handle-display-event '(:type "agent_end" :messages []))
+          (pilish--handle-display-event '(:type "agent_settled"))
+          (should-not (pilish--session-busy-p))
+          (should (equal prompts '("original prompt")))
+          (should-not (string-match-p "unwanted follow-up" (buffer-string))))))))
+
+(ert-deftest pilish-test-lifecycle-late-abort-acknowledgments-do-not-touch-new-work ()
+  "Old clear_queue and abort acknowledgments cannot stop or release a new run."
+  (pilish-test--with-streaming-assistant
+    (let (callbacks)
+      (setq pilish--process 'mock-proc)
+      (cl-letf (((symbol-function 'pilish--rpc-async)
+                 (lambda (_proc _command callback) (push callback callbacks)))
+                ((symbol-function 'pilish--refresh-header) #'ignore)
+                ((symbol-function 'message) #'ignore))
         (pilish-abort)
-        (should (equal (plist-get sent-command :type) "abort"))
-        (should-not pilish--aborted)))))
+        (let ((old-callbacks callbacks))
+          (pilish--handle-display-event '(:type "agent_end" :messages []))
+          (should pilish--aborted)
+          (pilish--handle-display-event '(:type "agent_settled"))
+          (pilish--handle-display-event '(:type "agent_start"))
+          (setq pilish--followup-queue '("new work"))
+          (dolist (callback old-callbacks)
+            (funcall callback '(:success t)))
+          (should (eq pilish--status 'streaming))
+          (should-not pilish--aborted)
+          (should (equal pilish--followup-queue '("new work")))
+          (should (equal pilish--activity-phase "thinking")))))))
+
+(ert-deftest pilish-test-lifecycle-abort-preflight-rejection-or-no-turn-releases-stop ()
+  "A stopped prompt that never starts releases intent at its owned completion."
+  (dolist (accepted '(nil t))
+    (with-temp-buffer
+      (pilish-chat-mode)
+      (setq pilish--process 'mock-proc)
+      (let (prompt-callback restored commands)
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                  ((symbol-function 'pilish--rpc-async)
+                   (lambda (_proc command callback)
+                     (push (plist-get command :type) commands)
+                     (pcase (plist-get command :type)
+                       ("prompt" (setq prompt-callback callback))
+                       ("get_state"
+                        (funcall callback
+                                 '(:success t :data (:isStreaming :false
+                                                    :isCompacting :false)))))))
+                  ((symbol-function 'run-at-time) (lambda (&rest _) 'fake-timer))
+                  ((symbol-function 'pilish--refresh-header) #'ignore)
+                  ((symbol-function 'message) #'ignore))
+          (pilish--send-prompt "original" nil (lambda () (setq restored t)))
+          (pilish-abort)
+          (should pilish--aborted)
+          (funcall prompt-callback (list :success (if accepted t :false)))
+          (when accepted
+            (pilish--clear-sending-if-no-agent-start
+             (current-buffer) pilish--prompt-wait))
+          (should (eq restored (not accepted)))
+          (should-not (pilish--session-busy-p))
+          (should-not pilish--aborted)
+          (pilish--send-prompt "new prompt")
+          (pilish--handle-display-event '(:type "agent_start"))
+          (should (= 1 (cl-count "abort" commands :test #'equal)))
+          (should (eq pilish--status 'streaming)))))))
 
 (ert-deftest pilish-test-abort-noop-when-idle ()
   "pilish-abort does nothing when idle."
@@ -1024,31 +1269,20 @@ When user aborts, they want to stop everything - including queued messages."
           (with-current-buffer chat-buf
             (should (equal pilish--followup-queue
                            '("Normal send second" "Steering first")))
-            (let (drain-callback
-                  drain-args)
-              (cl-letf (((symbol-function 'pilish--send-prompt)
-                         (lambda (text &optional on-success &rest _)
-                           (push text sent-prompts)
-                           (when on-success (funcall on-success))))
-                        ((symbol-function 'pilish--refresh-header) #'ignore)
-                        ((symbol-function 'run-at-time)
-                         (lambda (_secs _repeat fn &rest args)
-                           (setq drain-callback fn
-                                 drain-args args)
-                           'fake-drain-timer)))
-                (pilish--handle-display-event
-                 '(:type "compaction_end"
-                   :reason "threshold"
-                   :aborted :false
-                   :willRetry :false
-                   :result (:tokensBefore 1000 :summary "Summary")))
-                (should (functionp drain-callback))
-                (apply drain-callback drain-args)
-                (setq drain-callback nil
-                      drain-args nil)
-                (pilish--handle-display-event '(:type "agent_end" :messages []))
-                (should (functionp drain-callback))
-                (apply drain-callback drain-args)))
+            (cl-letf (((symbol-function 'pilish--send-prompt)
+                       (lambda (text &optional on-success &rest _)
+                         (push text sent-prompts)
+                         (setq pilish--status 'sending)
+                         (funcall on-success)))
+                      ((symbol-function 'pilish--refresh-header) #'ignore))
+              (pilish--handle-display-event
+               '(:type "compaction_end" :reason "manual" :aborted :false
+                 :willRetry :false :result (:tokensBefore 1000 :summary "Summary")))
+              (should (equal sent-prompts '("Steering first")))
+              (pilish--handle-display-event '(:type "agent_start"))
+              (pilish--handle-display-event '(:type "agent_end" :messages []))
+              (should (equal sent-prompts '("Steering first")))
+              (pilish--handle-display-event '(:type "agent_settled")))
             (should (equal (reverse sent-prompts)
                            '("Steering first" "Normal send second")))
             (should (null pilish--followup-queue))))
@@ -1056,7 +1290,7 @@ When user aborts, they want to stop everything - including queued messages."
       (kill-buffer input-buf))))
 
 (ert-deftest pilish-test-queued-builtin-command-restores-input-without-running ()
-  "Stale queued built-in commands are surfaced instead of run from a timer."
+  "Stale queued built-in commands are surfaced instead of run automatically."
   (let ((chat-buf (get-buffer-create "*pilish-test-queued-builtin-chat*"))
         (input-buf (get-buffer-create "*pilish-test-queued-builtin-input*"))
         (new-session-called nil)
@@ -1651,16 +1885,11 @@ echoes it back via message_start, we should NOT display it again."
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pilish-test-agent-end-sends-queued-followup ()
-  "agent_end schedules the queued follow-up after post-run events settle.
-When user queues a follow-up (busy state), it goes to the local queue.
-After an agent_end with no retry or compaction, the scheduled drain pops
-from the queue and sends it as a normal prompt."
+(ert-deftest pilish-test-agent-settled-sends-queued-followup ()
+  "A locally queued prompt is sent and displayed only after agent_settled."
   (let ((chat-buf (get-buffer-create "*pilish-test-agent-end-queue*"))
         (input-buf (get-buffer-create "*pilish-test-agent-end-queue-input*"))
-        (sent-prompt nil)
-        drain-callback
-        drain-args)
+        (sent-prompt nil))
     (unwind-protect
         (progn
           (with-current-buffer chat-buf
@@ -1682,9 +1911,7 @@ from the queue and sends it as a normal prompt."
           (with-current-buffer chat-buf
             (should (equal pilish--followup-queue '("My follow-up question")))
             (should-not (string-match-p "My follow-up question" (buffer-string))))
-          ;; Now simulate agent_end.  It should not drain synchronously, so an
-          ;; immediately following compaction_start would still be able to
-          ;; preserve ordering.
+          ;; Low-level completion does not release the queued prompt.
           (with-current-buffer chat-buf
             (cl-letf (((symbol-function 'pilish--get-process) (lambda () 'mock-proc))
                       ((symbol-function 'process-live-p) (lambda (_) t))
@@ -1692,17 +1919,11 @@ from the queue and sends it as a normal prompt."
                        (lambda (text &optional on-success &rest _)
                          (setq sent-prompt text)
                          (when on-success (funcall on-success))))
-                      ((symbol-function 'pilish--refresh-header) #'ignore)
-                      ((symbol-function 'run-at-time)
-                       (lambda (_secs _repeat fn &rest args)
-                         (setq drain-callback fn
-                               drain-args args)
-                         'fake-drain-timer)))
+                      ((symbol-function 'pilish--refresh-header) #'ignore))
               (pilish--handle-display-event '(:type "agent_end"))
-              (should (functionp drain-callback))
               (should (equal pilish--followup-queue '("My follow-up question")))
               (should (null sent-prompt))
-              (apply drain-callback drain-args))
+              (pilish--handle-display-event '(:type "agent_settled")))
             ;; Queue should be empty now
             (should (null pilish--followup-queue))
             ;; Should have sent the queued message
@@ -1712,8 +1933,8 @@ from the queue and sends it as a normal prompt."
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pilish-test-send-queues-while-followup-drain-pending ()
-  "New input waits behind an older queued follow-up drain."
+(ert-deftest pilish-test-send-queues-while-awaiting-settlement ()
+  "New input cannot overtake an older follow-up before run settlement."
   (let ((chat-buf (get-buffer-create "*pilish-test-drain-pending-send*"))
         (input-buf (get-buffer-create "*pilish-test-drain-pending-send-input*"))
         (sent-prompt nil))
@@ -1721,10 +1942,10 @@ from the queue and sends it as a normal prompt."
         (progn
           (with-current-buffer chat-buf
             (pilish-chat-mode)
-            (setq pilish--status 'idle
-                  pilish--input-buffer input-buf
-                  pilish--followup-queue '("older queued follow-up")
-                  pilish--followup-drain-timer 'fake-drain-timer))
+            (setq pilish--input-buffer input-buf
+                  pilish--followup-queue '("older queued follow-up"))
+            (pilish--handle-display-event '(:type "agent_start"))
+            (pilish--handle-display-event '(:type "agent_end")))
           (with-current-buffer input-buf
             (pilish-input-mode)
             (setq pilish--chat-buffer chat-buf)
@@ -1818,9 +2039,7 @@ from the queue and sends it as a normal prompt."
   "Multiple follow-ups are processed in FIFO order."
   (let ((chat-buf (get-buffer-create "*pilish-test-fifo*"))
         (input-buf (get-buffer-create "*pilish-test-fifo-input*"))
-        (sent-prompts nil)
-        drain-callback
-        drain-args)
+        (sent-prompts nil))
     (unwind-protect
         (progn
           (with-current-buffer chat-buf
@@ -1839,7 +2058,7 @@ from the queue and sends it as a normal prompt."
           ;; All three should be in queue
           (with-current-buffer chat-buf
             (should (= 3 (length pilish--followup-queue))))
-          ;; Simulate each completed queued turn and then run the scheduled drain.
+          ;; Each completed queued run releases one prompt at settlement.
           (with-current-buffer chat-buf
             (cl-letf (((symbol-function 'pilish--get-process) (lambda () 'mock-proc))
                       ((symbol-function 'process-live-p) (lambda (_) t))
@@ -1847,18 +2066,12 @@ from the queue and sends it as a normal prompt."
                        (lambda (text &optional on-success &rest _)
                    (push text sent-prompts)
                    (when on-success (funcall on-success))))
-                      ((symbol-function 'pilish--refresh-header) #'ignore)
-                      ((symbol-function 'run-at-time)
-                       (lambda (_secs _repeat fn &rest args)
-                         (setq drain-callback fn
-                               drain-args args)
-                         'fake-drain-timer)))
-              (dotimes (_ 3)
-                (setq drain-callback nil
-                      drain-args nil)
+                      ((symbol-function 'pilish--refresh-header) #'ignore))
+              (dotimes (i 3)
+                (pilish--handle-display-event '(:type "agent_start"))
                 (pilish--handle-display-event '(:type "agent_end"))
-                (should (functionp drain-callback))
-                (apply drain-callback drain-args))))
+                (should (= i (length sent-prompts)))
+                (pilish--handle-display-event '(:type "agent_settled")))))
           ;; Should have sent all three in FIFO order (sent-prompts is reversed)
           (should (equal (reverse sent-prompts)
                          '("First message" "Second message" "Third message")))
@@ -2925,9 +3138,8 @@ Pi handles command expansion on the server side."
   (pilish-test-with-prompt-image-session (_dir chat-buf _input-buf)
     (let (rpc-called feedback)
       (with-current-buffer chat-buf
-        (setq pilish--process 'image-process
-              pilish--status 'sending
-              pilish--prompt-start-wait-active t))
+        (setq pilish--process 'image-process pilish--status 'sending)
+        (pilish--begin-prompt-start-wait))
       (cl-letf (((symbol-function 'pilish--get-process)
                  (lambda () 'image-process))
                 ((symbol-function 'pilish--get-chat-buffer)
@@ -3131,6 +3343,7 @@ Pi handles command expansion on the server side."
                   (expand-file-name "restored.png" dir) 'png))
            (data (pilish-test--prompt-image-base64 'png))
            rpc-message rpc-callback attached-image)
+      (with-current-buffer chat-buf (setq pilish--process 'image-process))
       (with-current-buffer input-buf
         (pilish-test--attach-image path)
         (setq attached-image (pilish--get-prompt-image))
@@ -3185,6 +3398,7 @@ Pi handles command expansion on the server side."
            (text "Inspect this image")
            (jpeg-data (pilish-test--prompt-image-base64 'jpeg))
            rpc-callback)
+      (with-current-buffer chat-buf (setq pilish--process 'image-process))
       (with-current-buffer input-buf
         (pilish-test--attach-image path)
         (insert text)
@@ -3236,7 +3450,7 @@ Pi handles command expansion on the server side."
                            'pilish--clear-sending-if-no-agent-start)
                        (setq fallback-callback function
                              fallback-args args)
-                     'fake-drain-timer)
+                     'fake-timer)
                    'fake-prompt-start-timer))
                 ((symbol-function 'display-images-p) (lambda (&rest _) nil))
                 ((symbol-function 'message) #'ignore))
@@ -3275,6 +3489,7 @@ Pi handles command expansion on the server side."
                 (pilish--display-user-message
                  "slow prompt" (current-time) nil t))
           (let ((generation (pilish--begin-prompt-start-wait)))
+            (setf (pilish--prompt-wait-accepted generation) t)
             (cl-letf (((symbol-function 'pilish--rpc-async)
                        (lambda (_process command callback)
                          (should (equal (plist-get command :type) "get_state"))
@@ -3326,7 +3541,7 @@ Pi handles command expansion on the server side."
                                'pilish--clear-sending-if-no-agent-start)
                            (setq fallback-callback function
                                  fallback-args args)
-                         'fake-drain-timer)
+                         'fake-timer)
                        'fake-prompt-start-timer))
                     ((symbol-function 'message) #'ignore))
             (with-current-buffer input-buf
@@ -3377,79 +3592,27 @@ Pi handles command expansion on the server side."
             (should (equal pilish--activity-phase "idle"))))
       (delete-process fake-proc))))
 
-(ert-deftest pilish-test-normal-send-preflight-failure-restores-input ()
-  "Rejected normal sends do not leave ghost chat text or lose input."
-  (let ((chat-buf (get-buffer-create "*pilish-test-send-fail-echo*"))
-        (input-buf (get-buffer-create "*pilish-test-send-fail-echo-input*"))
-        (rpc-callback nil)
-        (fake-proc (start-process "test" nil "cat")))
-    (unwind-protect
-        (progn
-          (with-current-buffer chat-buf
-            (pilish-chat-mode)
-            (setq pilish--status 'idle
-                  pilish--activity-phase "idle"
-                  pilish--input-buffer input-buf))
-          (with-current-buffer input-buf
-            (pilish-input-mode)
-            (setq pilish--chat-buffer chat-buf)
-            (insert "this send will fail")
-            (cl-letf (((symbol-function 'pilish--get-process)
-                       (lambda () fake-proc))
-                      ((symbol-function 'pilish--get-chat-buffer)
-                       (lambda () chat-buf))
-                      ((symbol-function 'pilish--rpc-async)
-                       (lambda (_proc _msg cb) (setq rpc-callback cb)))
-                      ((symbol-function 'message) #'ignore))
-              (pilish-send)))
-          (with-current-buffer chat-buf
-            (should (null pilish--local-user-message))
-            (should-not (string-match-p "this send will fail" (buffer-string)))
-            (funcall rpc-callback '(:success :false :error "preflight failed"))
-            (should (eq pilish--status 'idle))
-            (should (equal pilish--activity-phase "idle"))
-            (should (null pilish--local-user-message))
-            (should-not (string-match-p "this send will fail" (buffer-string))))
-          (with-current-buffer input-buf
-            (should (equal (buffer-string) "this send will fail"))))
-      (delete-process fake-proc)
-      (kill-buffer chat-buf)
-      (kill-buffer input-buf))))
-
-(ert-deftest pilish-test-slash-prompt-preflight-failure-restores-input ()
-  "Rejected slash prompts are restored instead of being lost silently."
-  (let ((chat-buf (get-buffer-create "*pilish-test-slash-fail-chat*"))
-        (input-buf (get-buffer-create "*pilish-test-slash-fail-input*"))
-        (rpc-callback nil)
-        (fake-proc (start-process "test" nil "cat")))
-    (unwind-protect
-        (progn
-          (with-current-buffer chat-buf
-            (pilish-chat-mode)
-            (setq pilish--status 'idle
-                  pilish--activity-phase "idle"
-                  pilish--input-buffer input-buf))
-          (with-current-buffer input-buf
-            (pilish-input-mode)
-            (setq pilish--chat-buffer chat-buf)
-            (insert "/unknown command")
-            (cl-letf (((symbol-function 'pilish--get-process)
-                       (lambda () fake-proc))
-                      ((symbol-function 'pilish--get-chat-buffer)
-                       (lambda () chat-buf))
-                      ((symbol-function 'pilish--rpc-async)
-                       (lambda (_proc _msg cb) (setq rpc-callback cb)))
-                      ((symbol-function 'message) #'ignore))
-              (pilish-send)))
-          (with-current-buffer chat-buf
-            (should-not (string-match-p "/unknown command" (buffer-string)))
-            (funcall rpc-callback '(:success :false :error "preflight failed"))
-            (should (eq pilish--status 'idle)))
-          (with-current-buffer input-buf
-            (should (equal (buffer-string) "/unknown command"))))
-      (delete-process fake-proc)
-      (kill-buffer chat-buf)
-      (kill-buffer input-buf))))
+(ert-deftest pilish-test-rejected-prompts-restore-input ()
+  "Rejected regular and slash requests restore drafts without ghost transcript turns."
+  (dolist (text '("this send will fail" "/unknown command"))
+    (pilish-test-with-rpc-session (chat input proc commands)
+      (with-current-buffer input (insert text) (pilish-send))
+      (with-current-buffer chat
+        (let (shown-message)
+          (should-not (string-match-p (regexp-quote text) (buffer-string)))
+          (cl-letf (((symbol-function 'message)
+                     (lambda (fmt &rest args)
+                       (setq shown-message (apply #'format fmt args)))))
+            (pilish--dispatch-response
+             proc (list :type "response" :id (plist-get (car commands) :id)
+                        :command "prompt" :success :false :error "preflight failed")))
+          (should (equal shown-message "Pi: Send failed: preflight failed"))
+          (should (eq pilish--status 'idle))
+          (should (equal pilish--activity-phase "idle"))
+          (should-not pilish--prompt-wait)
+          (should-not pilish--local-user-message)
+          (should-not (string-match-p (regexp-quote text) (buffer-string)))))
+      (with-current-buffer input (should (equal (buffer-string) text))))))
 
 (ert-deftest pilish-test-normal-send-without-process-restores-input ()
   "Direct sends without a process do not create ghost chat text."
@@ -3583,8 +3746,6 @@ Pi handles command expansion on the server side."
   (let* ((rpc-callbacks nil)
          (prompt-fallback-callback nil)
          (prompt-fallback-args nil)
-         (drain-callback nil)
-         (drain-args nil)
          (sent-messages nil)
          (chat-buf (get-buffer-create "*pilish-test-no-turn-drain*"))
          (input-buf (get-buffer-create "*pilish-test-no-turn-drain-input*"))
@@ -3622,10 +3783,6 @@ Pi handles command expansion on the server side."
                          (setq prompt-fallback-callback fn
                                prompt-fallback-args args)
                          'fake-prompt-start-timer)
-                        ((eq fn 'pilish--drain-followup-queue-if-idle)
-                         (setq drain-callback fn
-                               drain-args args)
-                         'fake-drain-timer)
                         (t 'fake-timer))))
                     ((symbol-function 'message) #'ignore))
             (with-current-buffer chat-buf
@@ -3640,8 +3797,6 @@ Pi handles command expansion on the server side."
             (funcall (car rpc-callbacks) '(:success t))
             (should (functionp prompt-fallback-callback))
             (apply prompt-fallback-callback prompt-fallback-args)
-            (should (functionp drain-callback))
-            (apply drain-callback drain-args)
             (should (equal (reverse sent-messages)
                            '("/test-noop" "follow-up after noop")))))
       (delete-process fake-proc)
@@ -3678,8 +3833,8 @@ Pi handles command expansion on the server side."
               (should (equal pilish--activity-phase "thinking")))))
       (delete-process fake-proc))))
 
-(ert-deftest pilish-test-agent-start-invalidates-prompt-success-fallback ()
-  "A prompt response arriving after agent_start cannot schedule stale idle reset."
+(ert-deftest pilish-test-agent-start-makes-late-success-skip-fallback ()
+  "Acceptance after an observed start cannot schedule a no-turn idle reset."
   (let ((rpc-callback nil)
         (fallback-scheduled nil)
         (fake-proc (start-process "test" nil "cat")))
@@ -3850,7 +4005,8 @@ Pi handles command expansion on the server side."
                   pilish--input-buffer input-buf
                   pilish--local-user-message "pending echo"
                   pilish--followup-queue '("queued after crash")
-                  pilish--prompt-start-generation 7)
+                  pilish--aborted t
+                  pilish--prompt-wait (pilish--make-prompt-wait :process proc))
             (pilish--handle-process-exit proc
                                                   "exited abnormally with code 1\n")
             (should (eq pilish--status 'idle))
@@ -3858,7 +4014,8 @@ Pi handles command expansion on the server side."
             (should (null pilish--process))
             (should (null pilish--local-user-message))
             (should (null pilish--followup-queue))
-            (should (> pilish--prompt-start-generation 7))
+            (should-not pilish--prompt-wait)
+            (should-not pilish--aborted)
             (should (equal (plist-get pilish--state :last-error)
                            "Process exited: exited abnormally with code 1"))
             (let ((chat-text (buffer-string)))
@@ -3931,7 +4088,7 @@ Pi handles command expansion on the server side."
                   pilish--local-user-message "pending echo"
                   pilish--pre-compaction-status 'streaming
                   pilish--followup-queue '("restore after error")
-                  pilish--prompt-start-generation 11)
+                  pilish--prompt-wait (pilish--make-prompt-wait :process proc))
             (cl-letf (((symbol-function
                         'pilish--display-process-exit-error)
                        (lambda (&rest _)
@@ -3951,7 +4108,7 @@ Pi handles command expansion on the server side."
               (should (null pilish--local-user-message))
               (should (null pilish--pre-compaction-status))
               (should (null pilish--followup-queue))
-              (should (> pilish--prompt-start-generation 11))
+              (should-not pilish--prompt-wait)
               (should (>= mode-line-updates 2))))
           (with-current-buffer input-buf
             (should (equal (buffer-string) "restore after error"))))
@@ -4009,8 +4166,7 @@ Pi handles command expansion on the server side."
             (pilish-chat-mode)
             (setq pilish--status 'idle
                   pilish--process proc
-                  pilish--input-buffer input-buf
-                  pilish--prompt-start-generation 3))
+                  pilish--input-buffer input-buf))
           (with-current-buffer input-buf
             (pilish-input-mode)
             (setq pilish--chat-buffer chat-buf)
@@ -4032,15 +4188,16 @@ Pi handles command expansion on the server side."
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pilish-test-abort-send-resets-activity-phase ()
-  "Abort send resets activity phase and status to idle in CHAT-BUF."
+(ert-deftest pilish-test-abort-send-resets-unstarted-activity-phase ()
+  "Failed unstarted submission resets activity and status in its chat buffer."
   (let ((chat-buf (generate-new-buffer "*pilish-chat:test-abort-send/*")))
     (unwind-protect
         (progn
           (with-current-buffer chat-buf
             (pilish-chat-mode)
-            (setq pilish--activity-phase "running"
-                  pilish--status 'streaming))
+            (setq pilish--activity-phase "thinking"
+                  pilish--status 'sending)
+            (pilish--begin-prompt-start-wait))
           ;; Simulate callback/sentinel context by calling from other buffer
           (with-temp-buffer
             (pilish--abort-send chat-buf))

--- a/test/pilish-integration-prompt-contract-test.el
+++ b/test/pilish-integration-prompt-contract-test.el
@@ -18,7 +18,7 @@
                                                    pilish-test-rpc-timeout))
          (initial-count (plist-get (plist-get initial-state :data) :messageCount))
          (events nil)
-         (got-agent-end nil)
+         (got-agent-settled nil)
          (assistant-start nil)
          (assistant-end nil)
          (prompt-response nil))
@@ -31,8 +31,8 @@
               ("message_end"
                (when (equal (plist-get (plist-get event :message) :role) "assistant")
                  (setq assistant-end event)))
-              ("agent_end"
-               (setq got-agent-end t))))
+              ("agent_settled"
+               (setq got-agent-settled t))))
           pilish--event-handlers)
     (setq prompt-response
           (pilish--rpc-sync
@@ -45,7 +45,7 @@
     (should (equal (plist-get prompt-response :command) "prompt"))
     (with-timeout (pilish-test-integration-timeout
                    (ert-fail "Timeout waiting for prompt lifecycle to finish"))
-      (while (not got-agent-end)
+      (while (not got-agent-settled)
         (accept-process-output proc pilish-test-poll-interval)))
     (setq events (nreverse events))
     (ert-info ("agent_start should be emitted")
@@ -62,8 +62,10 @@
                         events)))
     (ert-info ("assistant message_end should be emitted")
       (should assistant-end))
-    (ert-info ("agent_end should be emitted")
-      (should (equal (plist-get (car (last events)) :type) "agent_end")))
+    (ert-info ("agent_end is followed by final agent_settled")
+      (should (seq-find (lambda (event) (equal (plist-get event :type) "agent_end"))
+                        events))
+      (should (equal (plist-get (car (last events)) :type) "agent_settled")))
     (let* ((final-state (pilish--rpc-sync proc '(:type "get_state")
                                                    pilish-test-rpc-timeout))
            (final-data (plist-get final-state :data))
@@ -77,14 +79,14 @@
     (prompt-contract-abort-stops-streaming)
   "Aborting a running prompt leaves the backend idle again."
   (let ((got-agent-start nil)
-        (got-agent-end nil)
+        (got-agent-settled nil)
         (prompt-response nil))
     (push (lambda (event)
             (pcase (plist-get event :type)
               ("agent_start"
                (setq got-agent-start t))
-              ("agent_end"
-               (setq got-agent-end t))))
+              ("agent_settled"
+               (setq got-agent-settled t))))
           pilish--event-handlers)
     (setq prompt-response
           (pilish--rpc-sync
@@ -103,8 +105,8 @@
       (should (eq (plist-get abort-response :success) t))
       (should (equal (plist-get abort-response :command) "abort")))
     (with-timeout (pilish-test-rpc-timeout
-                   (ert-fail "Timeout waiting for agent_end after abort"))
-      (while (not got-agent-end)
+                   (ert-fail "Timeout waiting for agent_settled after abort"))
+      (while (not got-agent-settled)
         (accept-process-output proc pilish-test-poll-interval)))
     (let* ((state (pilish--rpc-sync proc '(:type "get_state")
                                              pilish-test-rpc-timeout))

--- a/test/pilish-integration-session-contract-test.el
+++ b/test/pilish-integration-session-contract-test.el
@@ -13,10 +13,10 @@
 (pilish-integration-deftest
     (session-contract-name-persists-across-session-file)
   "Setting a session name persists backend-visible session metadata."
-  (let ((got-agent-end nil))
+  (let ((got-agent-settled nil))
     (push (lambda (event)
-            (when (equal (plist-get event :type) "agent_end")
-              (setq got-agent-end t)))
+            (when (equal (plist-get event :type) "agent_settled")
+              (setq got-agent-settled t)))
           pilish--event-handlers)
     (let ((prompt-response (pilish--rpc-sync
                             proc
@@ -59,15 +59,15 @@
         (should (equal (plist-get data-after :sessionFile) session-file))
         (should (equal (plist-get data-after :sessionName)
                        "Integration Test Session")))
-      (unless got-agent-end
+      (unless got-agent-settled
         (let ((abort-response (pilish--rpc-sync proc '(:type "abort")
                                                          pilish-test-rpc-timeout)))
           (should abort-response)
           (should (eq (plist-get abort-response :success) t))
           (should (equal (plist-get abort-response :command) "abort")))
         (with-timeout (pilish-test-rpc-timeout
-                       (ert-fail "Timeout waiting for agent_end after session abort"))
-          (while (not got-agent-end)
+                       (ert-fail "Timeout waiting for agent_settled after session abort"))
+          (while (not got-agent-settled)
             (accept-process-output proc pilish-test-poll-interval))))
       (let* ((final-state (pilish--rpc-sync proc '(:type "get_state")
                                                      pilish-test-rpc-timeout))

--- a/test/pilish-integration-steering-contract-test.el
+++ b/test/pilish-integration-steering-contract-test.el
@@ -15,7 +15,7 @@
     (steering-contract-queues-and-delivers)
   "A steer command queued during streaming is delivered visibly later on."
   (let ((got-agent-start nil)
-        (got-agent-end nil)
+        (got-agent-settled nil)
         (queued-delivered nil)
         (user-message-events nil))
     (push (lambda (event)
@@ -28,8 +28,8 @@
                                     (pilish-integration--message-text
                                      (plist-get event :message)))
                 (setq queued-delivered t)))
-            (when (equal (plist-get event :type) "agent_end")
-              (setq got-agent-end t)))
+            (when (equal (plist-get event :type) "agent_settled")
+              (setq got-agent-settled t)))
           pilish--event-handlers)
     (let ((prompt-response (pilish--rpc-sync
                             proc
@@ -62,8 +62,8 @@
       (should (eq (plist-get abort-response :success) t))
       (should (equal (plist-get abort-response :command) "abort")))
     (with-timeout (pilish-test-rpc-timeout
-                   (ert-fail "Timeout waiting for agent_end after steering abort"))
-      (while (not got-agent-end)
+                   (ert-fail "Timeout waiting for agent_settled after steering abort"))
+      (while (not got-agent-settled)
         (accept-process-output proc pilish-test-poll-interval)))
     (setq user-message-events (nreverse user-message-events))
     (should (= (length user-message-events) 2))

--- a/test/pilish-integration-tool-contract-test.el
+++ b/test/pilish-integration-tool-contract-test.el
@@ -18,7 +18,7 @@
   (let* ((tool-path "/tmp/fake-tool.txt")
          (tool-marker "TOOL_CONTRACT_MARKER")
          (events nil)
-         (got-agent-end nil)
+         (got-agent-settled nil)
          (tool-execution-end nil))
     (unwind-protect
         (progn
@@ -29,8 +29,8 @@
                   (pcase (plist-get event :type)
                     ("tool_execution_end"
                      (setq tool-execution-end event))
-                    ("agent_end"
-                     (setq got-agent-end t))))
+                    ("agent_settled"
+                     (setq got-agent-settled t))))
                 pilish--event-handlers)
           (let ((prompt-response
                  (pilish--rpc-sync
@@ -71,15 +71,15 @@
                            tool-path))
             (should result-text)
             (should (string-match-p tool-marker result-text)))
-          (unless got-agent-end
+          (unless got-agent-settled
             (let ((abort-response (pilish--rpc-sync proc '(:type "abort")
                                                              pilish-test-rpc-timeout)))
               (should abort-response)
               (should (eq (plist-get abort-response :success) t))
               (should (equal (plist-get abort-response :command) "abort")))
             (with-timeout (pilish-test-rpc-timeout
-                           (ert-fail "Timeout waiting for agent_end after tool-contract abort"))
-              (while (not got-agent-end)
+                           (ert-fail "Timeout waiting for agent_settled after tool-contract abort"))
+              (while (not got-agent-settled)
                 (accept-process-output proc pilish-test-poll-interval))))
           (let* ((state (pilish--rpc-sync proc '(:type "get_state")
                                                    pilish-test-rpc-timeout))

--- a/test/pilish-menu-test.el
+++ b/test/pilish-menu-test.el
@@ -200,9 +200,8 @@ Also verifies that the new session-file is stored in state for reload to work."
   "New session cannot discard a prompt whose acceptance is unresolved."
   (with-temp-buffer
     (pilish-chat-mode)
-    (setq pilish--process 'mock-proc
-          pilish--status 'sending
-          pilish--prompt-start-wait-active t)
+    (setq pilish--process 'mock-proc pilish--status 'sending)
+    (pilish--begin-prompt-start-wait)
     (let (rpc-called feedback)
       (cl-letf (((symbol-function 'pilish--get-process)
                  (lambda () 'mock-proc))
@@ -1720,118 +1719,128 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
                             (buffer-string)))))))
       (kill-buffer chat-buf))))
 
-(ert-deftest pilish-test-compact-completion-event-processes-queued-followup ()
-  "Manual compact queues local input until the compaction_end success event."
-  (let ((chat-buf (get-buffer-create "*pilish-test-compact-status*"))
-        (input-buf (get-buffer-create "*pilish-test-compact-status-input*"))
-        (compact-callback nil)
-        (prepared-texts nil)
-        (prompt-sent nil)
-        drain-callback
-        drain-args)
-    (unwind-protect
-        (progn
-          (with-current-buffer chat-buf
-            (pilish-chat-mode)
-            (setq pilish--status 'idle)
-            (setq pilish--process nil)
-            (setq pilish--input-buffer input-buf)
-            (setq pilish--followup-queue nil))
-          (with-current-buffer input-buf
-            (pilish-input-mode)
-            (setq pilish--chat-buffer chat-buf))
-          (cl-letf (((symbol-function 'pilish--get-process)
-                     (lambda () 'mock-proc))
-                    ((symbol-function 'process-live-p)
-                     (lambda (_proc) t))
-                    ((symbol-function 'pilish--rpc-async)
-                     (lambda (_proc cmd cb)
-                       (if (equal (plist-get cmd :type) "compact")
-                           (setq compact-callback cb)
-                         (setq prompt-sent t))))
-                    ((symbol-function 'pilish--handle-compaction-success) #'ignore)
-                    ((symbol-function 'pilish--prepare-and-send)
-                     (lambda (text &optional queued)
-                       (push text prepared-texts)
-                       (when queued
-                         (pilish--drop-followup text))))
-                    ((symbol-function 'run-at-time)
-                     (lambda (_secs _repeat fn &rest args)
-                       (setq drain-callback fn
-                             drain-args args)
-                       'fake-drain-timer))
-                    ((symbol-function 'message) #'ignore))
-            (with-current-buffer chat-buf
-              (pilish-compact)
-              (should (eq pilish--status 'compacting)))
+(ert-deftest pilish-test-review-fixes-manual-reservation-until-correlated-response ()
+  "Compaction end does not free its local RPC reservation or unlock a second command."
+  (pilish-test-with-rpc-session (chat _input proc commands)
+    (with-current-buffer chat
+      (let (shown-message)
+        (cl-letf (((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (pilish-compact)
+          (let ((request (car commands)))
+            (pilish--handle-display-event '(:type "compaction_start" :reason "manual"))
+            (pilish--handle-display-event
+             '(:type "compaction_end" :reason "manual" :aborted :false
+               :result :null :errorMessage "old failure"))
+            (should (pilish--session-busy-p))
+            (should-not (pilish--canonical-rerender-safe-p))
+            (pilish-compact)
+            (should (= 1 (length commands)))
+            (should-not (pilish--new-session-ready-p chat))
+            ;; An extension can still start independent B while A's RPC awaits
+            ;; session_compact_failed handlers.  A's reply must not idle B.
+            (pilish--handle-display-event '(:type "agent_start"))
+            (pilish-abort)
+            (pilish--dispatch-response
+             proc (list :type "response" :id (plist-get request :id)
+                        :command "compact" :success :false :error "old failure"))
+            (should (eq pilish--status 'streaming))
+            (should pilish--aborted)
+            (should (string-match-p "old failure" shown-message))
+            (pilish--handle-display-event '(:type "agent_end" :messages []))
+            (pilish--handle-display-event '(:type "agent_settled"))
+            (should-not (pilish--session-busy-p))
+            (pilish-compact)
+            (pilish-abort)
+            ;; Duplicate old replies cannot release the new correlated request.
+            (pilish--dispatch-response
+             proc (list :type "response" :id (plist-get request :id)
+                        :command "compact" :success :false :error "old failure"))
+            (should (pilish--session-busy-p))
+            (should pilish--aborted)))))))
 
-            (with-current-buffer input-buf
-              (insert "queued during compaction")
-              (pilish-send)
-              (should (string-empty-p (buffer-string))))
+(ert-deftest pilish-test-review-fixes-manual-success-releases-fifo-on-response ()
+  "Manual compaction's correlated response, not its end event, releases local FIFO."
+  (pilish-test-with-rpc-session (chat input proc commands)
+    (with-current-buffer chat
+      (cl-letf (((symbol-function 'message) #'ignore))
+        (pilish-compact)
+        (let ((request (car commands)))
+          (pilish--handle-display-event '(:type "compaction_start" :reason "manual"))
+          (with-current-buffer input (insert "next") (pilish-send))
+          (pilish--handle-display-event
+           '(:type "compaction_end" :reason "manual" :aborted :false
+             :result (:tokensBefore 1000 :summary "Done")))
+          (should (= 1 (length commands)))
+          (should (equal pilish--followup-queue '("next")))
+          (pilish--dispatch-response
+           proc (list :type "response" :id (plist-get request :id)
+                      :command "compact" :success t))
+          (should (equal (plist-get (car commands) :message) "next"))
+          (should (equal pilish--followup-queue '("next"))))))))
 
-            (with-current-buffer chat-buf
-              (should-not prompt-sent)
-              (should (equal pilish--followup-queue '("queued during compaction"))))
+(ert-deftest pilish-test-compact-refuses-unsettled-work ()
+  "Manual compact cannot overtake prompt preflight, a run or its settlement."
+  (dolist (status '(sending streaming compacting))
+    (with-temp-buffer
+      (pilish-chat-mode)
+      (setq pilish--status status
+            pilish--process 'mock-proc
+            pilish--followup-queue '("keep queued"))
+      (let (commands shown-message)
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                  ((symbol-function 'pilish--rpc-async)
+                   (lambda (_proc command _callback) (push command commands)))
+                  ((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (pilish-compact)
+          (should-not commands)
+          (should (string-match-p "Cannot compact" shown-message))
+          (should (eq pilish--status status))
+          (should (equal pilish--followup-queue '("keep queued"))))))))
 
-            (with-current-buffer chat-buf
-              (pilish--handle-display-event
-               '(:type "compaction_end"
-                 :reason "manual"
-                 :aborted :false
-                 :willRetry :false
-                 :result (:tokensBefore 1234
-                          :summary "Done"
-                          :firstKeptEntryId "entry-1"
-                          :details nil)))
-              (should (eq pilish--status 'idle))
-              (should (functionp drain-callback))
-              (should (equal pilish--followup-queue
-                             '("queued during compaction")))
-              (apply drain-callback drain-args)
-              (should (null pilish--followup-queue)))
-            (should (equal (reverse prepared-texts) '("queued during compaction")))
-
-            (should (functionp compact-callback))
-            (funcall compact-callback
-                     '(:success t :data (:tokensBefore 1234 :summary "Done")))
-            (should (equal (reverse prepared-texts) '("queued during compaction")))))
-      (kill-buffer chat-buf)
-      (kill-buffer input-buf))))
+(ert-deftest pilish-test-aborted-manual-compaction-rejection-releases-stop ()
+  "A rejected manual compact command cannot leave stale local stop intent."
+  (pilish-test-with-rpc-session (chat _input proc commands)
+    (with-current-buffer chat
+      (let (shown-message)
+        (cl-letf (((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (pilish-compact)
+          (let ((request (car commands)))
+            (pilish-abort)
+            (should pilish--aborted)
+            (pilish--dispatch-response
+             proc (list :type "response" :id (plist-get request :id)
+                        :command "compact" :success :false :error "not started"))))
+        (should (equal shown-message "Pi: Compact failed: not started"))
+        (should-not (pilish--session-busy-p))
+        (should-not pilish--aborted)))))
 
 (ert-deftest pilish-test-compact-response-failure-reports-without-event ()
-  "A failed compact RPC response reports plumbing failure when no event ended it."
-  (let ((chat-buf (get-buffer-create "*pilish-test-compact-response-failure*"))
-        (input-buf (get-buffer-create "*pilish-test-compact-response-failure-input*"))
-        (shown-message nil))
-    (unwind-protect
-        (progn
-          (with-current-buffer input-buf
-            (pilish-input-mode)
-            (setq pilish--chat-buffer chat-buf))
-          (with-current-buffer chat-buf
-            (pilish-chat-mode)
-            (setq pilish--status 'compacting
-                  pilish--input-buffer input-buf
-                  pilish--followup-queue '("queued during failed compact"))
-            (pilish--set-activity-phase "compact"))
-          (cl-letf (((symbol-function 'message)
-                     (lambda (fmt &rest args)
-                       (setq shown-message (apply #'format fmt args)))))
-            (pilish--handle-manual-compaction-response
-             chat-buf
-             '(:success :false :error "transport failed before compaction event")))
-          (with-current-buffer chat-buf
-            (should (eq pilish--status 'idle))
-            (should (equal pilish--activity-phase "idle"))
-            (should (null pilish--followup-queue))
-            (should-not (string-match-p "Compacted from" (buffer-string))))
-          (with-current-buffer input-buf
-            (should (equal (buffer-string) "queued during failed compact")))
-          (should (equal shown-message
-                         "Pi: Compact failed: transport failed before compaction event")))
-      (kill-buffer chat-buf)
-      (kill-buffer input-buf))))
+  "A command-level failure releases its reservation and restores unsent FIFO."
+  (pilish-test-with-rpc-session (chat input proc commands)
+    (with-current-buffer chat
+      (let (shown-message)
+        (cl-letf (((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (pilish-compact)
+          (should (pilish--session-busy-p))
+          (setq pilish--followup-queue '("queued during failed compact"))
+          (pilish--dispatch-response
+           proc (list :type "response" :id (plist-get (car commands) :id)
+                      :command "compact" :success :false :error "not started")))
+        (should (equal shown-message "Pi: Compact failed: not started"))
+        (should-not (pilish--session-busy-p))
+        (should (equal pilish--activity-phase "idle"))
+        (should-not pilish--followup-queue)
+        (should-not (string-match-p "Compacted from" (buffer-string)))))
+    (with-current-buffer input
+      (should (equal (buffer-string) "queued during failed compact")))))
 
 (ert-deftest pilish-test-compact-dead-process-keeps-idle ()
   "Manual compact should not transition state when process is dead."
@@ -2766,12 +2775,11 @@ replaced by the resumed or forked history."
         (pilish-fork-at-point))
       (should-not rpc-called))))
 
-(ert-deftest pilish-test-fork-at-point-followup-drain-guard ()
-  "Fork-at-point skips RPC while a local follow-up drain is pending."
+(ert-deftest pilish-test-fork-at-point-settlement-guard ()
+  "Fork-at-point skips RPC while the run is awaiting settlement."
   (with-temp-buffer
     (pilish-chat-mode)
-    (let ((pilish--status 'idle)
-          (pilish--followup-drain-timer 'fake-drain-timer)
+    (let ((pilish--status 'sending)
           (pilish--process 'mock-proc)
           (rpc-called nil))
       (let ((inhibit-read-only t))

--- a/test/pilish-render-test.el
+++ b/test/pilish-render-test.el
@@ -1975,35 +1975,15 @@ block is closed."
 
 (ert-deftest pilish-test-send-displays-user-message ()
   "Accepted prompt preflight displays the user message in chat."
-  (let ((chat-buf (get-buffer-create "*pilish-test-chat*"))
-        (input-buf (get-buffer-create "*pilish-test-input*"))
-        (rpc-callback nil)
-        (fake-proc (start-process "test" nil "cat")))
-    (unwind-protect
-        (progn
-          (with-current-buffer chat-buf
-            (pilish-chat-mode)
-            (setq pilish--input-buffer input-buf))
-          (with-current-buffer input-buf
-            (pilish-input-mode)
-            (setq pilish--chat-buffer chat-buf)
-            (insert "Hello from test")
-            (cl-letf (((symbol-function 'pilish--get-process)
-                       (lambda () fake-proc))
-                      ((symbol-function 'pilish--get-chat-buffer)
-                       (lambda () chat-buf))
-                      ((symbol-function 'pilish--rpc-async)
-                       (lambda (_proc _msg cb) (setq rpc-callback cb))))
-              (pilish-send)))
-          (with-current-buffer chat-buf
-            (should-not (string-match-p "Hello from test" (buffer-string)))
-            (funcall rpc-callback '(:success t))
-            ;; Check chat buffer has the message with You setext heading and content.
-            (should (string-match-p "^You" (buffer-string)))
-            (should (string-match-p "Hello from test" (buffer-string)))))
-      (delete-process fake-proc)
-      (kill-buffer chat-buf)
-      (kill-buffer input-buf))))
+  (pilish-test-with-rpc-session (chat input proc commands)
+    (with-current-buffer input (insert "Hello from test") (pilish-send))
+    (with-current-buffer chat
+      (should-not (string-match-p "Hello from test" (buffer-string)))
+      (pilish--dispatch-response
+       proc (list :type "response" :id (plist-get (car commands) :id)
+                  :command "prompt" :success t))
+      (should (string-match-p "^You" (buffer-string)))
+      (should (string-match-p "Hello from test" (buffer-string))))))
 
 (ert-deftest pilish-test-send-slash-command-not-displayed-locally ()
   "Slash commands are NOT displayed locally - pi sends back expanded content.
@@ -13658,7 +13638,7 @@ Multiple deltas should replace the preview instead of appending forever."
       (should (= 2 (length (pilish-test--all-tool-overlays)))))))
 
 (ert-deftest pilish-test-metadata-less-toolcall-start-finalizes-at-end ()
-  "Tagged Pi 0.84.2 falls back cleanly when start metadata is unavailable."
+  "Incomplete start metadata is reconciled by the authoritative toolcall_end."
   (pilish-test--with-streaming-assistant
     (pilish-test--send-assistant-message-update
      '(:type "toolcall_start" :contentIndex 0))
@@ -14383,12 +14363,12 @@ Commands with embedded newlines should not have any lines deleted."
      '(:type "compaction_start" :reason "threshold"))
     (should (equal pilish--activity-phase "compact"))))
 
-(ert-deftest pilish-test-activity-phase-idle-on-agent-end ()
-  "Activity phase becomes idle on agent_end."
-  (with-temp-buffer
-    (pilish-chat-mode)
-    (setq pilish--activity-phase "thinking")
+(ert-deftest pilish-test-activity-phase-idle-only-on-agent-settled ()
+  "The activity phase remains busy between agent_end and agent_settled."
+  (pilish-test--with-streaming-assistant
     (pilish--handle-display-event '(:type "agent_end"))
+    (should (equal pilish--activity-phase "thinking"))
+    (pilish--handle-display-event '(:type "agent_settled"))
     (should (equal pilish--activity-phase "idle"))))
 
 (ert-deftest pilish-test-activity-phase-idle-on-compaction-end ()
@@ -14404,7 +14384,8 @@ Commands with embedded newlines should not have any lines deleted."
   "Activity phase stays busy while Pi's automatic retry is pending."
   (with-temp-buffer
     (pilish-chat-mode)
-    (setq pilish--activity-phase "compact")
+    (setq pilish--status 'sending)
+    (pilish--handle-display-event '(:type "compaction_start" :reason "overflow"))
     (pilish--handle-display-event
      '(:type "compaction_end"
        :reason "overflow"
@@ -14495,7 +14476,8 @@ Commands with embedded newlines should not have any lines deleted."
   (with-temp-buffer
     (pilish-chat-mode)
     (let ((sent-text nil))
-      (setq pilish--status 'compacting)
+      (setq pilish--status 'sending)
+      (pilish--handle-display-event '(:type "compaction_start" :reason "overflow"))
       (setq pilish--followup-queue '("queued behind retry"))
       (cl-letf (((symbol-function 'pilish--send-prompt)
                  (lambda (text &optional on-success &rest _)
@@ -14513,6 +14495,47 @@ Commands with embedded newlines should not have any lines deleted."
       (should (eq pilish--status 'sending))
       (should (equal pilish--followup-queue '("queued behind retry")))
       (should (null sent-text)))))
+
+(ert-deftest pilish-test-lifecycle-interturn-compaction-reopens-assistant-section ()
+  "Continued thinking, text and tools belong to Assistant, not Compaction."
+  (let ((pilish-thinking-display 'visible))
+    (pilish-test--with-streaming-assistant
+      (let (shown-message)
+        (cl-letf (((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (pilish-test--send-assistant-message-update
+           '(:type "text_delta" :contentIndex 0 :delta "Before compaction."))
+          (dolist (event '((:type "message_end" :message (:role "assistant"))
+                           (:type "turn_end")
+                           (:type "compaction_start" :reason "threshold")
+                           (:type "compaction_end" :aborted :false :willRetry :false
+                            :result (:tokensBefore 1000 :summary "Saved context."))
+                           (:type "turn_start")
+                           (:type "message_start" :message (:role "assistant"))))
+            (pilish--handle-display-event event))
+          (dolist (update '((:type "thinking_start" :contentIndex 0)
+                            (:type "thinking_delta" :contentIndex 0
+                             :delta "Continued reasoning.")
+                            (:type "thinking_end" :contentIndex 0
+                             :content "Continued reasoning.")
+                            (:type "text_delta" :contentIndex 1
+                             :delta "Continued answer.\n")
+                            (:type "toolcall_start" :contentIndex 2
+                             :id "continued-tool" :toolName "read")
+                            (:type "toolcall_delta" :contentIndex 2
+                             :delta "{\"path\":\"/tmp/continued.txt\"}")))
+            (pilish-test--send-assistant-message-update update))
+          (should (equal shown-message "Pi: Compacted from 1,000 tokens"))
+          (should (= 2 (pilish-test--count-matches
+                        "^Assistant\n=+" (buffer-string))))
+          (goto-char (point-min))
+          (dolist (text '("Before compaction." "Compaction\n" "Saved context."
+                          "Assistant\n" "> Continued reasoning."
+                          "Continued answer." "read /tmp/continued.txt"))
+            (should (search-forward text nil t)))
+          (should (= 1 (pilish-test--count-matches
+                        "Before compaction\\." (buffer-string)))))))))
 
 (ert-deftest pilish-test-display-handler-handles-compaction-end ()
   "Display handler processes compaction_end with current Pi result shape."

--- a/test/pilish-test-common.el
+++ b/test/pilish-test-common.el
@@ -317,6 +317,35 @@ Uses tool call ID \"call_1\" and contentIndex 0."
 
 ;;;; Mock Session
 
+(cl-defmacro pilish-test-with-rpc-session ((chat input proc commands) &rest body)
+  "Run BODY with linked CHAT/INPUT buffers and real PROC request correlation.
+Capture outbound JSON as COMMANDS (newest first), without sending it to Pi.
+Tests can deliver events and correlated responses through the production
+handlers; no mock bypasses pending request registration or removal."
+  (declare (indent 1) (debug ((symbolp symbolp symbolp symbolp) body)))
+  `(let ((,chat (generate-new-buffer " *pilish-rpc-chat*"))
+         (,input (generate-new-buffer " *pilish-rpc-input*"))
+         (,proc (start-process "pilish-test-rpc" nil "cat"))
+         ,commands)
+     (unwind-protect
+         (progn
+           (set-process-query-on-exit-flag ,proc nil)
+           (with-current-buffer ,chat
+             (pilish-chat-mode)
+             (setq pilish--process ,proc pilish--input-buffer ,input))
+           (with-current-buffer ,input
+             (pilish-input-mode)
+             (setq pilish--chat-buffer ,chat))
+           (process-put ,proc 'pilish-chat-buffer ,chat)
+           (pilish--register-display-handler ,proc)
+           (cl-letf (((symbol-function 'pilish--send-string)
+                      (lambda (_process line)
+                        (push (pilish--parse-json-line line) ,commands)))
+                     ((symbol-function 'pilish--refresh-header) #'ignore))
+             ,@body))
+       (pilish-test--kill-live-buffers ,input ,chat)
+       (when (process-live-p ,proc) (delete-process ,proc)))))
+
 (defmacro pilish-test-with-mock-session (dir &rest body)
   "Execute BODY with a mocked pi session in DIR, cleaning up after.
 DIR should be a unique directory path, typically created with

--- a/test/pilish-ui-test.el
+++ b/test/pilish-ui-test.el
@@ -1126,8 +1126,12 @@ other family names there."
   (should (pilish--pi-version-outdated-p "0.79.0"))
   (should (pilish--pi-version-outdated-p "0.80.99"))
   (should (pilish--pi-version-outdated-p "0.84.1"))
-  (should-not (pilish--pi-version-outdated-p "0.84.2"))
-  (should-not (pilish--pi-version-outdated-p "0.84.3"))
+  (should (pilish--pi-version-outdated-p "0.84.2"))
+  (should (pilish--pi-version-outdated-p "0.84.4"))
+  (should (pilish--pi-version-outdated-p "0.84.99"))
+  (should-not (pilish--pi-version-outdated-p "0.85.0"))
+  (should-not (pilish--pi-version-outdated-p "0.85.1"))
+  (should-not (pilish--pi-version-outdated-p "0.86.0"))
   (should-not (pilish--pi-version-outdated-p "1.0.0")))
 
 (ert-deftest pilish-test-finish-pi-version-process-parses-stderr ()
@@ -1285,61 +1289,65 @@ other family names there."
         (delete-process proc)))))
 
 (ert-deftest pilish-test-probe-process-version-warns-when-pi-too-old ()
-  "Version probe warns clearly for unsupported pi versions."
-  (let ((callback nil)
-        (warning-text nil)
-        (noninteractive nil)
-        (proc (start-process "pilish-test-proc-old" nil "cat")))
-    (unwind-protect
-        (with-temp-buffer
-          (pilish-chat-mode)
-          (cl-letf (((symbol-function 'pilish--request-pi-version-async)
-                     (lambda (cb)
-                       (setq callback cb)
-                       nil))
-                    ((symbol-function 'message) #'ignore)
-                    ((symbol-function 'display-warning)
-                     (lambda (_type message &rest _)
-                       (setq warning-text message))))
-            (pilish--set-process proc)
-            (should callback)
-            (funcall callback "0.79.0")
-            (should (equal pilish--process-version "0.79.0"))
-            (should (string-match-p "0.79.0" warning-text))
-            (should (string-match-p "0.84.2" warning-text))
-            (should (string-match-p
-                     "npm install -g @earendil-works/pi-coding-agent"
-                     warning-text))
-            (should-not (string-match-p
-                         "npm install -g @earendil-works/pi-coding-agent@"
-                         warning-text))))
-      (when (process-live-p proc)
-        (delete-process proc)))))
+  "Version probe warns clearly for every tested below-minimum pi version."
+  (dolist (version '("0.84.4" "0.84.2" "0.84.99" "0.79.0"))
+    (ert-info ((format "Unsupported Pi %s" version))
+      (let ((callback nil)
+            (warnings nil)
+            (noninteractive nil)
+            (proc (start-process "pilish-test-proc-old" nil "cat")))
+        (unwind-protect
+            (with-temp-buffer
+              (pilish-chat-mode)
+              (cl-letf (((symbol-function 'pilish--request-pi-version-async)
+                         (lambda (cb)
+                           (setq callback cb)
+                           nil))
+                        ((symbol-function 'message) #'ignore)
+                        ((symbol-function 'display-warning)
+                         (lambda (&rest args)
+                           (push args warnings))))
+                (pilish--set-process proc)
+                (should callback)
+                (funcall callback version)
+                (should (equal pilish--process-version version))
+                (should
+                 (equal warnings
+                        (list
+                         (list 'pi
+                               (format
+                                "Pi CLI version %s is older than the supported minimum 0.85.0. Upgrade with: npm install -g @earendil-works/pi-coding-agent"
+                                version)
+                               :warning))))))
+          (when (process-live-p proc)
+            (delete-process proc)))))))
 
 (ert-deftest pilish-test-probe-process-version-does-not-warn-when-supported ()
-  "Version probe accepts the minimum supported pi version."
-  (let ((callback nil)
-        (warning-called nil)
-        (noninteractive nil)
-        (proc (start-process "pilish-test-proc-supported" nil "cat")))
-    (unwind-protect
-        (with-temp-buffer
-          (pilish-chat-mode)
-          (cl-letf (((symbol-function 'pilish--request-pi-version-async)
-                     (lambda (cb)
-                       (setq callback cb)
-                       nil))
-                    ((symbol-function 'message) #'ignore)
-                    ((symbol-function 'display-warning)
-                     (lambda (&rest _)
-                       (setq warning-called t))))
-            (pilish--set-process proc)
-            (should callback)
-            (funcall callback "0.84.2")
-            (should (equal pilish--process-version "0.84.2"))
-            (should-not warning-called)))
-      (when (process-live-p proc)
-        (delete-process proc)))))
+  "Version probe accepts Pi 0.85.0 exactly and newer versions without warning."
+  (dolist (version '("0.85.0" "0.85.1" "0.86.0" "1.0.0"))
+    (ert-info ((format "Supported Pi %s" version))
+      (let ((callback nil)
+            (warning-called nil)
+            (noninteractive nil)
+            (proc (start-process "pilish-test-proc-supported" nil "cat")))
+        (unwind-protect
+            (with-temp-buffer
+              (pilish-chat-mode)
+              (cl-letf (((symbol-function 'pilish--request-pi-version-async)
+                         (lambda (cb)
+                           (setq callback cb)
+                           nil))
+                        ((symbol-function 'message) #'ignore)
+                        ((symbol-function 'display-warning)
+                         (lambda (&rest _)
+                           (setq warning-called t))))
+                (pilish--set-process proc)
+                (should callback)
+                (funcall callback version)
+                (should (equal pilish--process-version version))
+                (should-not warning-called)))
+          (when (process-live-p proc)
+            (delete-process proc)))))))
 
 ;;; Copy Visible Text
 
@@ -2601,6 +2609,66 @@ Catches wiring bugs like requiring deleted modules."
                            "nul-session"))
             (should-not (plist-get pilish--state :session-file))))
       (kill-buffer chat-buf))))
+
+(ert-deftest pilish-test-rereview-snapshot-initializes-idle-ui ()
+  "Without an event-owned busy phase, UI initialization adopts remote status."
+  (dolist (snapshot '((:false :false idle) (t :false streaming)
+                      (:false t compacting) (t t streaming)))
+    (with-temp-buffer
+      (pilish-chat-mode)
+      (should (eq pilish--status 'idle))
+      (pilish--apply-state-response
+       (current-buffer)
+       (list :success t :data (list :isStreaming (car snapshot)
+                                   :isCompacting (cadr snapshot)
+                                   :thinkingLevel "high")))
+      (should (equal (plist-get pilish--state :thinking-level) "high"))
+      (should (eq pilish--status (nth 2 snapshot)))
+      (should (eq (plist-get pilish--state :status) (nth 2 snapshot))))))
+
+(ert-deftest pilish-test-rereview-snapshot-preserves-post-run-ownership ()
+  "Core/UI refreshes cannot invent agent_start during post-run work or compaction.
+Pi's isStreaming includes post-run processing, not just the low-level loop."
+  (dolist (path '(core ui))
+    (dolist (compaction '(nil t))
+      (ert-info ((format "%s refresh; post-run compaction %s" path compaction))
+        (pilish-test-with-rpc-session (chat _input proc commands)
+          (with-current-buffer chat
+            (cl-letf (((symbol-function 'message) #'ignore))
+              (pilish--handle-display-event '(:type "agent_start"))
+              (pilish--handle-display-event '(:type "agent_end" :messages []))
+              (when compaction
+                (pilish--handle-display-event
+                 '(:type "compaction_start" :reason "threshold")))
+              (setq pilish--followup-queue '("next"))
+              (if (eq path 'ui)
+                  (pilish--refresh-thinking-level-state proc chat)
+                (pilish--rpc-async
+                 proc '(:type "get_state")
+                 (lambda (response)
+                   (with-current-buffer chat
+                     (pilish--update-state-from-response response)))))
+              (pilish--dispatch-response
+               proc (list :type "response" :id (plist-get (car commands) :id)
+                          :command "get_state" :success t
+                          :data (list :isStreaming t
+                                      :isCompacting (if compaction t :false)
+                                      :thinkingLevel "high")))
+              (should (equal (plist-get pilish--state :thinking-level) "high"))
+              (should (eq pilish--status (if compaction 'compacting 'sending)))
+              (should (eq (plist-get pilish--state :status) pilish--status))
+              (when compaction
+                (should (eq pilish--pre-compaction-status 'sending))
+                (pilish--handle-display-event
+                 '(:type "compaction_end" :reason "threshold"
+                   :aborted :false :willRetry :false
+                   :result (:summary "Done" :tokensBefore 1000))))
+              (should (eq pilish--status 'sending))
+              (should (= 1 (length commands)))
+              (pilish--handle-display-event '(:type "agent_settled"))
+              (should (= 2 (length commands)))
+              (should (equal (plist-get (car commands) :type) "prompt"))
+              (should (equal (plist-get (car commands) :message) "next")))))))))
 
 (ert-deftest pilish-test-apply-state-response-keeps-local-prompt-start-busy ()
   "Stale idle get_state must not erase local prompt preflight state."

--- a/test/support/fake-pi-contract.md
+++ b/test/support/fake-pi-contract.md
@@ -2,7 +2,8 @@
 
 This note defines the supported fake-pi surface used by deterministic tests.
 The fake is a protocol double for the RPC subprocess boundary, not a mock
-of internal Emacs functions.
+of internal Emacs functions. It targets Pi 0.85.0 and later; references to
+older releases below are historical comparisons, not compatibility guarantees.
 
 ## Scope and seam
 
@@ -52,7 +53,7 @@ These are still worth covering at the real subprocess boundary:
   - `get_fork_messages`
 - Integration prompt lifecycle:
   - immediate `prompt` success plus delayed streamed events
-  - `agent_start` / `message_start` / `message_update` / `message_end` / `agent_end`
+  - `agent_start` / `message_start` / `message_update` / `message_end` / `agent_end` / `agent_settled`
   - idle state after completion
   - persisted message count change
 - Integration distinct behaviors:
@@ -94,6 +95,7 @@ The current fake supports:
 - `get_commands`
 - `prompt`
 - `abort`
+- `clear_queue`
 - `steer`
 - `new_session`
 - `get_fork_messages`
@@ -116,6 +118,8 @@ Required now:
 
 - `agent_start`
 - `agent_end`
+- `agent_settled`
+- `queue_update` (the empty queue notification from `clear_queue`)
 - `message_start`
 - `message_update`
 - `message_end`
@@ -173,8 +177,13 @@ Required behavior:
    `assistantMessageEvent.type: "text_delta"`
 5. emit `message_end`
 6. emit `agent_end`
-7. update `get_state.isStreaming` and `messageCount`
-8. persist enough session data to back session-file assertions
+7. expose idle state and emit `agent_settled` only after all continuations finish
+8. persist enough session data to back session-file and `messageCount` assertions
+
+`agent_end` is a low-level completion boundary, not permission to send a new
+prompt. Consumers waiting for the whole run must wait for `agent_settled`.
+Completed tool finalization and cooling in the frontend still happen at
+`agent_end`.
 
 A `prompt` may include `images`, which must be a JSON array.  Every item must
 be an object with `type: "image"`, nonempty string `data`, and nonempty string
@@ -188,6 +197,20 @@ prompt images on its ordinary user message.  The extension-owned
 `extension_dialog` and `custom_message` prompt behaviors reject nonempty image
 arrays before reporting prompt success.  No new scenario type is implied.
 
+### Abort and queue clearing
+
+`clear_queue` removes the pending text-only steering message and returns
+`data: {"steering": ["removed text"], "followUp": []}` (empty arrays when
+nothing was queued). It emits `queue_update` with empty arrays before its
+correlated response. The fake does not model a complete queue-update stream.
+
+`abort` waits for the worker to settle before acknowledging. Like Pi, abort
+alone does not discard a pending steering continuation: the text-stream
+scenario emits the aborted low-level `agent_end`, starts that continuation,
+and emits exactly one `agent_settled` after the final run. Sending `clear_queue`
+before `abort` prevents that continuation. The existing fake still has one
+pending steering slot, not a general follow-up queue.
+
 ### Tool execution path
 
 For deterministic GUI and benchmark tests, the fake must emit the current
@@ -200,12 +223,13 @@ lifecycle:
 4. `tool_execution_start`, optional updates with accumulated `partialResult`,
    and `tool_execution_end`;
 5. a correlated `toolResult` message; and
-6. the final assistant response before `agent_end`.
+6. the final assistant response before `agent_end`, then `agent_settled`.
 
 Every `message_update` carries cumulative `usage`, and carries neither the
-legacy top-level `message` nor nested `partial` fields.  Published Pi 0.84.2
-starts may omit `id` and `toolName`; `toolcall_end.toolCall` remains
-authoritative.
+legacy top-level `message` nor nested `partial` fields. `toolcall_start`
+carries `id` and `toolName`; `toolcall_end.toolCall` remains authoritative.
+The renderer's missing-metadata reconciliation handles incomplete events
+defensively; it does not promise support for below-minimum Pi releases.
 
 Required fields currently consumed by Emacs rendering:
 

--- a/test/support/fake_pi.py
+++ b/test/support/fake_pi.py
@@ -379,8 +379,15 @@ class FakePiHarness:
             case "prompt":
                 self._handle_prompt(command)
             case "abort":
-                self._abort_requested.set()
+                self._stop_active_run()
                 self._respond(command)
+            case "clear_queue":
+                steering = self._take_pending_steer()
+                self._write_json({"type": "queue_update", "steering": [], "followUp": []})
+                self._respond(
+                    command,
+                    data={"steering": [steering] if steering is not None else [], "followUp": []},
+                )
             case "steer":
                 self._handle_steer(command)
             case "new_session":
@@ -647,8 +654,23 @@ class FakePiHarness:
                 ),
             )
             if not completed:
-                self._finish_aborted_run(assistant_message)
-                return
+                if assistant_message:
+                    self._persist_assistant_message(assistant_message)
+                    self._write_json({"type": "message_end", "message": assistant_message})
+                pending_steer = self._take_pending_steer()
+                self._finish_run(
+                    [assistant_message] if assistant_message else [],
+                    settled=pending_steer is None,
+                )
+                if pending_steer is None:
+                    return
+                # Like Pi, abort alone does not discard queued continuations.
+                self._abort_requested.clear()
+                emitted_messages = []
+                current_message = pending_steer
+                current_images = ()
+                self._write_json({"type": "agent_start"})
+                continue
             emitted_messages.append(assistant_message)
             pending_steer = self._take_pending_steer()
             if pending_steer is None:
@@ -1004,14 +1026,16 @@ class FakePiHarness:
         self._pending_steer_message = None
         return message
 
-    def _finish_run(self, messages: list[JsonDict]) -> None:
-        """Emit agent_end and reset transient run state."""
+    def _finish_run(self, messages: list[JsonDict], *, settled: bool = True) -> None:
+        """End a low-level run, settling only when no continuation remains."""
         self._write_json(
             {"type": "agent_end", "messages": messages, "willRetry": False}
         )
-        self.state.is_streaming = False
-        self._abort_requested.clear()
-        self._pending_steer_message = None
+        if settled:
+            self.state.is_streaming = False
+            self._abort_requested.clear()
+            self._pending_steer_message = None
+            self._write_json({"type": "agent_settled"})
 
     def _finish_aborted_run(self, message: JsonDict | None = None) -> None:
         """Finish the current run, emitting an active aborted MESSAGE first."""


### PR DESCRIPTION
Require pi 0.85.0 or newer; update installation guidance, version warnings and the CI baseline.

Keep queued input, Stop and session actions consistent while pi compacts or finishes work. Preserve late prompt acknowledgments and show continued replies under Assistant.

Replace the queue-drain delay with lifecycle events and correlated request ownership.

The follow-up fixes three ownership races:
- Keep steering local after `agent_end` while waiting for settlement, rather than stranding it in Pi's backend queue.
- Defer retry-failure recovery of unresolved FIFO work until the correlated prompt acknowledgment decides acceptance or rejection, preserving successors and newer drafts without duplicate submission.
- Preserve event-owned retry state across normal and thinking-level state refreshes, so snapshots neither disable valid retry steering nor resurrect a finished retry.

## Validation

- Final `make check check-parens`: compilation, checkdoc, package-lint and parens passed; **1,733 unit tests passed, one existing skip, zero unexpected results**. The skip is `pilish-test-installed-md-ts-03-keeps-link-label-unbuttonized`.
- Final `make test-integration-fake`: **15 passed, 15 real variants intentionally skipped, zero unexpected results**. This final gate did not run real integration tests.
- **20/20 final terminal smoke cases passed**, each using real `emacs -nw -Q` in tmux with production source loading and RPC filtering: five happy paths against installed **Pi 0.85.1**, plus fifteen controlled JSONL OS-subprocess edge cases.
  - Happy paths: prompt completion; FIFO follow-ups and steering; manual compaction; Stop clearing server steering and local queues; new-session refresh/reset.
  - Edges cover held/rejected/late prompt acknowledgments, no-turn idle probing, end-to-settlement steering/FIFO ownership, exhausted retry recovery, automatic/manual compaction ordering, delayed starts after Stop, newer run ownership, process exit/reload, and stale state refreshes. Public normal/thinking refresh paths were terminal-tested; the internal core state-updater branch is covered by ERT only.
- Earlier branch validation also passed all three benchmark smokes.

Terminal evidence was audited locally; these results summarize local validation, not a published GitHub artifact.

## Known upstream limits

Settlement events lack run identity. Once overlapping extension-started runs have both ended, old and new settlements cannot universally be distinguished, even with `get_state`. Stop cancels the current response or compaction; it does not guarantee cancellation of every future extension-created run.
