### PR TITLE
Find later messages in session browser search

### DIFF
--- a/README.org
+++ b/README.org
@@ -326,6 +326,15 @@ scope, =f= for named sessions only, =r= to rename, and =d= to delete a
 closed session after confirmation (using Emacs's trash when configured).
 Press =?= to see these commands in a small browser menu.
 
+Session search matches names, first messages, and all saved user/assistant
+text, including inactive branches.  It does not add thinking, tool
+arguments/results, images, or summaries to the searchable text; the
+existing first-message fallback can still contain text from any role.
+Whitespace-separated regexp tokens must all match.  Large scans yield
+between lines, but file reads, individual records, text joining, and
+searching/rendering results remain synchronous and can pause Emacs.
+Press =q= to hide the browser without cancelling its scan.
+
 In the main transient (=C-c C-p=), Session =r= opens =sessions= and
 Context =w= opens the disk-backed conversation =tree=.  In the tree
 browser, =f= cycles no-tools/default/user-only/labeled-only/all

--- a/pilish-browse.el
+++ b/pilish-browse.el
@@ -484,17 +484,15 @@ Returns the updated RESULT list."
 
 (defun pilish--session-filter-search (items tokens)
   "Filter ITEMS by search TOKENS.
-Matches against session name, first message, and allMessagesText."
+Match prepared :searchText, or name/first-message text for metadata items."
   (if (null tokens)
       items
     (cl-remove-if-not
      (lambda (item)
-       (let ((text (concat
-                    (or (plist-get item :name) "")
-                    " "
-                    (or (plist-get item :firstMessage) "")
-                    " "
-                    (or (plist-get item :allMessagesText) ""))))
+       (let ((text (or (plist-get item :searchText)
+                       (concat (or (plist-get item :name) "") " "
+                               (or (plist-get item :firstMessage) "") " "
+                               (or (plist-get item :allMessagesText) "")))))
          (pilish--matches-filter-p text tokens)))
      items)))
 
@@ -695,14 +693,17 @@ Inherits section navigation from `magit-section-mode'."
   "Render the session browser in BUF from its buffer-local state."
   (with-current-buffer buf
     (let* ((inhibit-read-only t)
-           (items (or pilish--session-browser-items '()))
-           ;; Apply filters
-           (filtered (if pilish--session-browser-named-only
-                        (pilish--session-filter-named items)
-                      items))
-           (filtered (pilish--session-filter-search
-                      filtered
-                      pilish--session-browser-search-tokens)))
+           (items pilish--session-browser-items)
+           ;; Loading/error screens retain the old snapshot but need not
+           ;; search its potentially large corpus just to display status.
+           (filtered
+            (unless (or pilish--session-browser-loading
+                        pilish--session-browser-error (null items))
+              (pilish--session-filter-search
+               (if pilish--session-browser-named-only
+                   (pilish--session-filter-named items)
+                 items)
+               pilish--session-browser-search-tokens))))
       (magit-insert-section (root)
         (cond
          (pilish--session-browser-loading
@@ -839,7 +840,10 @@ Message count and age are rendered as a right-margin overlay."
   (message "Pi: Scope: %s" pilish--session-browser-scope))
 
 (defun pilish-session-browser-search ()
-  "Set or clear search filter in the session browser."
+  "Search names, first messages and all user/assistant text on disk.
+Whitespace-separated regexp tokens must all match.  Text on inactive
+branches is included; thinking, tools, images and summaries are not added.
+The legacy first-message fallback can still match text from any role."
   (interactive)
   (let ((query (read-string "Filter (regexp tokens): "
                             pilish--session-browser-search-query))
@@ -1773,67 +1777,73 @@ Unreadable or missing directories are skipped silently (empty)."
                      (error nil)))
                  dirs)))
 
-(defun pilish--browse-scan-session-files (buf token files items callback)
-  "Scan FILES for sessions in 25 ms time slices, then call CALLBACK once.
-Each slice processes whole files until 25 ms elapse (a single huge file
-is atomic — one ~0.2 s hiccup is possible, documented), then defers
-the rest to the next slice via `(run-at-time 0 nil ...)`.  The FIRST
-slice is scheduled the same way, so a superseding fetch drops an older
-scan before any slice runs and the callback is uniformly asynchronous.
-A slice is dropped when BUF died or a newer fetch bumped the fetch
-TOKEN, and a dropped scan never calls CALLBACK.  ITEMS accumulates the
-session plists (already in the browse dialect: the scan is an identity
-mapping over `pilish-jsonl-read-session-info' output).
+(defun pilish--browse-session-scan-current-p (buf token)
+  "Return non-nil if BUF still owns the session scan generation TOKEN."
+  (and (buffer-live-p buf)
+       (eq token (buffer-local-value 'pilish--session-browser-fetch-token buf))))
 
-The exactly-once contract also holds when a slice is interrupted: the
-slice loop runs inside a `condition-case' with explicit `quit' and
-`error' handlers, so a `quit' during a slice (C-g against a slow
-scan) or an `error' abandons the scan and reports through CALLBACK
-once with the failure string — `quit' is not an `error', so without
-its own handler the callback would never run and the browser would
-sit on its loading state forever (same contract as the deferred read
-in `pilish--browse-load-tree')."
-  (if (and (buffer-live-p buf)
-           (eq token (buffer-local-value
-                      'pilish--session-browser-fetch-token buf)))
-      (let ((deadline (+ (float-time) 0.025))
-            (failure nil)
-            (finished nil))
-        ;; CALLBACK is invoked only below, OUTSIDE the condition-case:
-        ;; a signaling callback must not re-enter a handler and report
-        ;; twice.
-        (condition-case err
-            (progn
-              (while (and files (< (float-time) deadline))
-                (let ((info (pilish-jsonl-read-session-info
-                             (car files))))
-                  (when info (push info items)))
-                (setq files (cdr files)))
-              (if files
-                  (run-at-time 0 nil #'pilish--browse-scan-session-files
-                               buf token files items callback)
-                (setq finished t)))
-          (quit
-           (setq failure "Session scan was interrupted"))
-          (error
-           (setq failure (format "Session scan failed: %s"
-                                 (error-message-string err)))))
-        (cond (failure
-               ;; Same one-shot report a failed fetch uses: nil items
-               ;; plus the error string (see
-               ;; `pilish--browse-load-sessions').
-               (funcall callback nil failure))
-              (finished
-               (funcall callback (nreverse items) nil))))
-    ;; Stale or orphaned fetch: drop silently.
-    nil))
+(defun pilish--browse-scan-session-files
+    (buf token files items callback &optional state)
+  "Advance FILES and accumulated ITEMS for BUF's generation TOKEN.
+STATE is the optional in-progress JSONL scan for the first file.  Each
+slice shares a 10 ms deadline across opens and line processing.  A
+positive-delay continuation allows a command-loop turn; it is not a
+latency guarantee.  Whole-file IO, individual records, joining, GC, and
+final synchronous filtering/rendering can exceed the budget.
+
+At most one file state is retained by a pending continuation.  Completion,
+errors and quit close it before CALLBACK receives (ITEMS ERROR).  A stale
+or dead owner drops work and closes its state when the continuation next
+runs, without a callback.  Hiding the browser with q does not cancel it."
+  (let (transferred finished failure)
+    (unwind-protect
+        (when (pilish--browse-session-scan-current-p buf token)
+          (condition-case err
+              (let ((deadline (+ (float-time) 0.010))
+                    yield)
+                (while (and files (not yield) (< (float-time) deadline))
+                  (let (result)
+                    (condition-case nil
+                        (progn
+                          (unless state
+                            (setq state (pilish-jsonl-open-session-info
+                                         (car files) t)))
+                          (when state
+                            (setq result (pilish-jsonl-step-session-info
+                                          state deadline))))
+                      ;; Ordinary file failures skip just this file.  Quit
+                      ;; instead reaches the scan-level interruption handler.
+                      (error (setq result '(done))))
+                    (if (or (null state) result)
+                        (progn
+                          (when (cdr result) (push (cdr result) items))
+                          (pilish-jsonl-close-session-info state)
+                          (setq state nil files (cdr files)))
+                      (setq yield t))))
+                ;; File handlers can run Lisp and supersede/kill the owner.
+                (when (pilish--browse-session-scan-current-p buf token)
+                  (if files
+                      (progn
+                        (run-at-time 0.001 nil #'pilish--browse-scan-session-files
+                                     buf token files items callback state)
+                        (setq transferred t))
+                    (setq finished t))))
+            (quit (setq failure "Session scan was interrupted"))
+            (error (setq failure (format "Session scan failed: %s"
+                                        (error-message-string err))))))
+      (unless transferred (pilish-jsonl-close-session-info state)))
+    ;; Outside handlers and after resource cleanup: a signaling consumer
+    ;; must not be called again as an error callback.
+    (when (pilish--browse-session-scan-current-p buf token)
+      (cond (failure (funcall callback nil failure))
+            (finished (funcall callback (nreverse items) nil))))))
 
 (defun pilish--browse-load-sessions (scope callback)
   "Load session items for SCOPE, then call CALLBACK with (ITEMS ERROR).
 ITEMS is a list of session plists in the browse session dialect:
 \(:path :id :cwd :name? :parentSessionPath? :created :modified
-:messageCount :firstMessage) — the identity over
-`pilish-jsonl-read-session-info' output.  ERROR is an error
+:messageCount :firstMessage :searchText) — the optional search-corpus
+output of `pilish-jsonl-read-session-info'.  ERROR is an error
 string or nil.  SCOPE is \"current\" (one project directory) or \"all\" (every
 munged directory under the sessions root).  The scan is
 chunked (see `pilish--browse-scan-session-files'), shows a

--- a/pilish-jsonl.el
+++ b/pilish-jsonl.el
@@ -25,7 +25,7 @@
 
 ;;; Commentary:
 
-;; Pure functions over pi session JSONL files: reading entries, building
+;; Disk-data APIs over pi session JSONL files: reading entries, building
 ;; the raw nested session tree, projecting that tree to the flat display
 ;; dialect the tree browser consumes, formatting tool-call previews,
 ;; computing tree-navigation targets and byte-preserving rewritten line
@@ -35,8 +35,9 @@
 ;; This ports pi's session-manager getTree (plus label folding), the RPC tree
 ;; projection, navigateTree's
 ;; leaf rule, core format-tool-call, and config/session-dir path munging.
-;; Depends only on core; nothing here touches buffers, processes, or
-;; state.
+;; Depends only on core; does not manage UI/session state or processes.
+;; Reading uses temporary buffers.  Resumable scans expose caller-owned
+;; parser state whose decoded scratch buffer must be explicitly closed.
 ;;
 ;; Normalization conventions (JSON in, plists out):
 ;;
@@ -253,84 +254,143 @@ carries no trailing slash; Windows drives munge like \"C:\\x\" to
          (munged (replace-regexp-in-string "[/\\:]" "-" stripped)))
     (concat (file-name-as-directory base) "--" munged "--")))
 
-(defun pilish--jsonl-scan-session-info (path mtime)
-  "Scan the current buffer for session metadata.
-PATH and MTIME feed the :path and :modified keys; see
-`pilish-jsonl-read-session-info' for the full contract.
-Return the session plist, or nil when the first nonblank line is not
-the session header (`pilish--jsonl-parse-session-header's
-rule)."
-  (goto-char (point-min))
-  ;; Same trim rule as `pilish-jsonl-read-file': skip
-  ;; whitespace-only leading lines (CR included) for the header check;
-  ;; they are never entries.
-  (while (and (not (eobp))
-              (looking-at-p "[ \t\r]*$"))
-    (forward-line 1))
-  (let ((header (pilish--jsonl-parse-session-header
-                 (buffer-substring-no-properties
-                  (point) (line-end-position))))
-        (name nil)
-        (message-count 0)
-        (first-message nil)
-        (fallback-message nil)
-        (parsed-messages 0))
-    (when header
-      (forward-line 1)
-      (while (not (eobp))
-        (cond
-         ((pilish--jsonl-line-type-p "message")
-          (setq message-count (1+ message-count))
-          (when (and (null first-message) (< parsed-messages 5))
-            (setq parsed-messages (1+ parsed-messages))
-            (let ((data (pilish--jsonl-parse-current-line)))
-              (when (consp data)
-                (let* ((message (plist-get data :message))
-                       (text (pilish--jsonl-extract-text
-                              (plist-get message :content))))
-                  (cond
-                   ((and (equal (plist-get message :role) "user")
-                         (not (string-empty-p text)))
-                    (setq first-message text))
-                   ((null fallback-message)
-                    (setq fallback-message text))))))))
-         ((pilish--jsonl-line-type-p "session_info")
-          (when-let* ((data (pilish--jsonl-parse-current-line)))
-            (let ((raw (pilish--normalize-string-or-null
-                        (plist-get data :name))))
-              ;; Latest parseable entry wins; absent or blank names clear.
-              (setq name
-                    (when raw
-                      (let ((trimmed (string-trim raw)))
-                        (unless (string-empty-p trimmed) trimmed)))))))
-         ;; Later session lines, blanks, label/custom/unknown lines:
-         ;; skip without parsing.
-         (t nil))
-        (forward-line 1))
-      (let ((id (pilish--normalize-string-or-null
-                 (plist-get header :id)))
-            (cwd (pilish--normalize-string-or-null
-                  (plist-get header :cwd)))
-            (parent (pilish--normalize-string-or-null
-                     (plist-get header :parentSession)))
-            (created (pilish--normalize-string-or-null
-                      (plist-get header :timestamp)))
-            (first (or first-message
-                       (and (not (string-empty-p
-                                  (or fallback-message "")))
-                            fallback-message))))
-        (append (list :path path)
-                (when id (list :id id))
-                (when cwd (list :cwd cwd))
-                (when name (list :name name))
-                (when parent (list :parentSessionPath parent))
-                (when created (list :created created))
-                (list :modified
-                      (format-time-string "%Y-%m-%dT%H:%M:%SZ" mtime t)
-                      :messageCount message-count)
-                (when first (list :firstMessage first)))))))
+(cl-defstruct (pilish--jsonl-info
+               (:constructor pilish--jsonl-info-create))
+  "Resumable session scan; the decoded buffer's point is its cursor."
+  buffer path mtime header name first fallback texts search-text
+  (phase 'header) (message-count 0) (parsed-messages 0))
 
-(defun pilish-jsonl-read-session-info (path)
+(defun pilish-jsonl-open-session-info (path &optional search-text)
+  "Open PATH for a resumable metadata scan, optionally collecting SEARCH-TEXT.
+Return an opaque state, or nil on an ordinary read/stat failure.  The
+caller must close the state with `pilish-jsonl-close-session-info',
+including after errors or quit.  Whole-file IO and decoding are atomic;
+line processing starts in `pilish-jsonl-step-session-info'."
+  (let (buffer state)
+    (unwind-protect
+        (condition-case nil
+            (when (file-readable-p path)
+              (setq buffer (generate-new-buffer " *pilish-session-scan*"))
+              (with-current-buffer buffer
+                (insert-file-contents path)
+                (goto-char (point-min))
+                (setq state
+                      (pilish--jsonl-info-create
+                       :buffer buffer :path path :search-text search-text
+                       :mtime (file-attribute-modification-time
+                               (file-attributes path))))))
+          (error nil))
+      (unless state
+        (when (buffer-live-p buffer) (kill-buffer buffer))))))
+
+(defun pilish-jsonl-close-session-info (state)
+  "Release STATE's decoded buffer and accumulated text; safe to call twice."
+  (when state
+    (when (buffer-live-p (pilish--jsonl-info-buffer state))
+      (kill-buffer (pilish--jsonl-info-buffer state)))
+    (setf (pilish--jsonl-info-buffer state) nil
+          (pilish--jsonl-info-header state) nil
+          (pilish--jsonl-info-name state) nil
+          (pilish--jsonl-info-first state) nil
+          (pilish--jsonl-info-fallback state) nil
+          (pilish--jsonl-info-texts state) nil)))
+
+(defun pilish--jsonl-info-scan-line (state)
+  "Reduce the current message or name line into STATE.
+Keep the legacy preview budget independent of optional full-text parsing."
+  (cond
+   ((pilish--jsonl-line-type-p "message")
+    (cl-incf (pilish--jsonl-info-message-count state))
+    (let ((preview-p (and (null (pilish--jsonl-info-first state))
+                         (< (pilish--jsonl-info-parsed-messages state) 5))))
+      ;; Malformed lines consume a preview attempt too.
+      (when preview-p (cl-incf (pilish--jsonl-info-parsed-messages state)))
+      (when (or preview-p (pilish--jsonl-info-search-text state))
+        (let ((data (pilish--jsonl-parse-current-line)))
+          (when (consp data)
+            (let* ((message (plist-get data :message))
+                   (role (plist-get message :role))
+                   (search-p (and (pilish--jsonl-info-search-text state)
+                                  (member role '("user" "assistant"))))
+                   (text (when (or preview-p search-p)
+                           (pilish--jsonl-extract-text
+                            (plist-get message :content)))))
+              (when preview-p
+                (cond
+                 ((and (equal role "user") (not (string-empty-p text)))
+                  (setf (pilish--jsonl-info-first state) text))
+                 ((null (pilish--jsonl-info-fallback state))
+                  (setf (pilish--jsonl-info-fallback state) text))))
+              (when (and search-p (not (string-empty-p text)))
+                (push text (pilish--jsonl-info-texts state)))))))))
+   ((pilish--jsonl-line-type-p "session_info")
+    (when-let* ((data (pilish--jsonl-parse-current-line)))
+      (let ((raw (pilish--normalize-string-or-null (plist-get data :name))))
+        ;; Latest parseable entry wins; absent or blank names clear.
+        (setf (pilish--jsonl-info-name state)
+              (when raw
+                (let ((trimmed (string-trim raw)))
+                  (unless (string-empty-p trimmed) trimmed)))))))))
+
+(defun pilish--jsonl-info-result (state)
+  "Build STATE's metadata and optional single prepared search corpus."
+  (when-let* ((header (pilish--jsonl-info-header state)))
+    (let ((id (pilish--normalize-string-or-null (plist-get header :id)))
+          (cwd (pilish--normalize-string-or-null (plist-get header :cwd)))
+          (parent (pilish--normalize-string-or-null
+                   (plist-get header :parentSession)))
+          (created (pilish--normalize-string-or-null
+                    (plist-get header :timestamp)))
+          (name (pilish--jsonl-info-name state))
+          (first (or (pilish--jsonl-info-first state)
+                     (let ((fallback (pilish--jsonl-info-fallback state)))
+                       (unless (string-empty-p (or fallback "")) fallback)))))
+      (append (list :path (pilish--jsonl-info-path state))
+              (when id (list :id id))
+              (when cwd (list :cwd cwd))
+              (when name (list :name name))
+              (when parent (list :parentSessionPath parent))
+              (when created (list :created created))
+              (list :modified
+                    (format-time-string "%Y-%m-%dT%H:%M:%SZ"
+                                        (pilish--jsonl-info-mtime state) t)
+                    :messageCount (pilish--jsonl-info-message-count state))
+              (when first (list :firstMessage first))
+              (when (pilish--jsonl-info-search-text state)
+                ;; Join once, including the legacy prefix.  Do not retain
+                ;; a second history-sized string or deduplicate firstMessage.
+                (let ((texts (nreverse (pilish--jsonl-info-texts state))))
+                  (list :searchText
+                        (mapconcat #'identity
+                                   (cons (or name "")
+                                         (cons (or first "") (or texts '(""))))
+                                   " "))))))))
+
+(defun pilish-jsonl-step-session-info (state &optional deadline)
+  "Advance STATE until DEADLINE, an absolute `float-time', or completion.
+Return nil while incomplete, or (done . INFO); INFO is nil for a
+non-session file.  Nil DEADLINE runs to completion without clock checks.
+Check between decoded lines, including leading blanks, and before result
+joining.  IO, one JSON line, joining and GC can exceed the caller's budget.
+Close STATE after completion or failure; do not step a completed state."
+  (with-current-buffer (pilish--jsonl-info-buffer state)
+    (while (and (not (eobp))
+                (not (eq (pilish--jsonl-info-phase state) 'invalid))
+                (or (null deadline) (< (float-time) deadline)))
+      (if (eq (pilish--jsonl-info-phase state) 'header)
+          (unless (looking-at-p "[ \t\r]*$")
+            (setf (pilish--jsonl-info-header state)
+                  (pilish--jsonl-parse-session-header
+                   (buffer-substring-no-properties (point) (line-end-position)))
+                  (pilish--jsonl-info-phase state)
+                  (if (pilish--jsonl-info-header state) 'messages 'invalid)))
+        (pilish--jsonl-info-scan-line state))
+      (forward-line 1))
+    (when (and (or (eobp) (eq (pilish--jsonl-info-phase state) 'invalid))
+               (or (null deadline) (< (float-time) deadline)))
+      (cons 'done (pilish--jsonl-info-result state)))))
+
+(defun pilish-jsonl-read-session-info (path &optional search-text)
   "Read session metadata for the file at PATH, without building trees.
 Return a plist in the browse session dialect — (:path :id :cwd :name?
 :parentSessionPath? :created? :modified :messageCount :firstMessage?)
@@ -348,16 +408,21 @@ otherwise the first parsed message of any role is the fallback.
 :name replays session_info lines in file order with latest-wins
 trimming.  label and custom entries are ignored.  :created is the
 header timestamp; :modified is the file mtime as a second-resolution
-UTC ISO string (see the deviation note in the Commentary)."
-  (condition-case nil
-      (when (file-readable-p path)
-        (with-temp-buffer
-          (insert-file-contents path)
-          (pilish--jsonl-scan-session-info
-           path
-           (file-attribute-modification-time
-            (file-attributes path)))))
-    (error nil)))
+UTC ISO string (see the deviation note in the Commentary).
+
+Non-nil SEARCH-TEXT additionally parses every type-first message line,
+collecting user/assistant string content and text blocks across all disk
+branches, not thinking, tools, images or summaries.  :searchText is one
+prepared corpus: name, firstMessage, then these texts, separated by spaces.
+The legacy firstMessage prefix is preserved even for an any-role fallback.
+Nil SEARCH-TEXT retains the cheap metadata-only parsing budget and keys."
+  (let (state)
+    (unwind-protect
+        (condition-case nil
+            (when (setq state (pilish-jsonl-open-session-info path search-text))
+              (cdr (pilish-jsonl-step-session-info state)))
+          (error nil))
+      (pilish-jsonl-close-session-info state))))
 
 ;;;; Building Raw Trees
 

--- a/test/pilish-browse-test.el
+++ b/test/pilish-browse-test.el
@@ -1962,13 +1962,13 @@ and non-munged directories.  scope=current scans one directory."
 
 (ert-deftest pilish-test-load-sessions-chunked ()
   "--browse-load-sessions chunks long scans and reports once.
-The per-file reader is slowed past the 25 ms slice budget so the scan
-spans several slices.  Synchronous timers deliver exactly one final
-callback with every item, and a superseded fetch's callback is dropped
+The resumable reader is slowed so the scan spans several slices.
+Synchronous timers deliver exactly one final callback with every item, and a superseded fetch's callback is dropped
 by the fetch token."
   (let* ((root (pilish-test--make-temp-directory "pi-chunk-root"))
          (sessions (expand-file-name "sessions" root))
          (dir (expand-file-name "--home-fake-a--" sessions))
+         (step-session-info (symbol-function 'pilish-jsonl-step-session-info))
          (paths nil))
     (make-directory dir t)
     (dotimes (i 60)
@@ -1986,16 +1986,11 @@ by the fetch token."
                    process-environment)))
         (cl-letf (((symbol-function 'pilish--session-list-directory)
                    (lambda (&optional _chat-buf) nil))
-                  ;; 2 ms per file: 60 files need several 25 ms slices.
-                  ((symbol-function 'pilish-jsonl-read-session-info)
-                   (lambda (path)
+                  ;; 2 ms per step: 60 files need several 10 ms slices.
+                  ((symbol-function 'pilish-jsonl-step-session-info)
+                   (lambda (state &optional deadline)
                      (sleep-for 0 2)
-                     (list :path path
-                           :id (file-name-nondirectory path)
-                           :cwd "/home/fake/a"
-                           :created pilish-test--browse-timestamp
-                           :modified "2026-03-02T10:00:00Z"
-                           :messageCount 0))))
+                     (funcall step-session-info state deadline))))
           ;; Synchronous timers: one final callback, all 60 items.
           (let ((calls nil))
             (cl-letf (((symbol-function 'run-at-time)
@@ -2027,7 +2022,7 @@ by the fetch token."
             (pcase-let ((`(,items ,error) (car calls-b)))
               (should-not error)
               (should (= (length items) 60))))
-          ;; Mid-flight supersession: A completes one slice (~12 files)
+          ;; Mid-flight supersession: A completes one slice (a few files)
           ;; before B supersedes it; the token still drops A at its next
           ;; slice boundary, and B reports alone with every item.
           (let ((calls-a nil) (calls-b nil) (queue nil))
@@ -2097,8 +2092,8 @@ and the browser names the interruption."
                    process-environment)))
         (cl-letf (((symbol-function 'pilish--session-list-directory)
                    (lambda (&optional _chat-buf) nil))
-                  ((symbol-function 'pilish-jsonl-read-session-info)
-                   (lambda (_path) (signal 'quit nil)))
+                  ((symbol-function 'pilish-jsonl-step-session-info)
+                   (lambda (&rest _) (signal 'quit nil)))
                   ((symbol-function 'run-at-time)
                    (lambda (_secs _repeat fn &rest args) (apply fn args))))
           ;; The seam reports the interruption exactly once.
@@ -2115,6 +2110,317 @@ and the browser names the interruption."
         (should (string-match-p "interrupted"
                                 pilish--session-browser-error))
         (should (string-match-p "interrupted" (buffer-string)))))))
+
+;;;; Full-message Search Regressions
+
+(ert-deftest pilish-test-browse-search-late-messages-from-disk ()
+  "The real browser and search command find later text on either disk branch."
+  (let* ((root (pilish-test--make-temp-directory "pi-search-disk"))
+         (default-directory root)
+         (process-environment (copy-sequence process-environment))
+         browser)
+    (setenv "PI_CODING_AGENT_DIR" root)
+    (let* ((dir (pilish-jsonl-session-dir-for-cwd root))
+           (path (expand-file-name "session.jsonl" dir)))
+      (make-directory dir t)
+      (pilish-test--write-session-lines
+       path
+       (list (pilish-test--make-session-header "search-disk")
+             (pilish-test--user-line "opening" nil "plain opening")
+             (pilish-test--jsonl-line
+              "message" "inactive" "opening"
+              :message '(:role "assistant"
+                         :content [(:type "text" :text "quasar269token 東京")]))
+             (pilish-test--user-line "active" "opening" "nebula269token")
+             (pilish-test--jsonl-line
+              "session_info" "name" "active" :name "Search fixture")))
+      (save-window-excursion
+        (unwind-protect
+            (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+              ;; Real discovery, reader, timers, and final Magit rendering.
+              (pilish-session-browser)
+              (setq browser (current-buffer))
+              (let ((deadline (+ (float-time) pilish-test-rpc-timeout)))
+                (while (and pilish--session-browser-loading
+                            (< (float-time) deadline))
+                  (sit-for 0.01)))
+              (should-not pilish--session-browser-loading)
+              (should-not pilish--session-browser-error)
+              (should (equal (mapcar (lambda (i) (plist-get i :path))
+                                    pilish--session-browser-items)
+                             (list path)))
+              (dolist (query '("Search" "plain" "quasar269token" "nebula269token"
+                               "東京" "Search nebula269token"
+                               "quasar269token.*nebula269token"))
+                (cl-letf (((symbol-function 'read-string) (lambda (&rest _) query)))
+                  (call-interactively #'pilish-session-browser-search))
+                (ert-info ((format "Disk-backed search query: %S" query))
+                  (should-not (string-match-p "No matching sessions" (buffer-string)))
+                  (should (string-match-p "Search fixture" (buffer-string))))))
+          (when (buffer-live-p browser) (kill-buffer browser)))))))
+
+(ert-deftest pilish-test-session-search-prepared-corpus-semantics ()
+  "Prepared text preserves regexp AND, case folding, boundaries and anchors."
+  (let* ((text "Name first first Alpha\nBeta omega 東京")
+         (prepared (list :name "Name" :firstMessage "first" :searchText text))
+         (legacy '(:name "Name" :firstMessage "first"
+                   :allMessagesText "first Alpha\nBeta omega 東京")))
+    (dolist (case-fold-search '(t nil))
+      (dolist (tokens '(nil ("Name") ("first.*Alpha") ("Beta.*omega")
+                           ("Name" "東京") ("alpha") ("Alpha")
+                           ("\\`Name") ("東京\\'") ("Alpha.*Beta")
+                           ("missing") ("Name" "missing")))
+        (should (eq (not (null (pilish--session-filter-search (list prepared) tokens)))
+                    (not (null (pilish--session-filter-search (list legacy) tokens)))))))))
+
+(ert-deftest pilish-test-session-search-prepared-corpus-not-rejoined ()
+  "Searching a prepared item does not copy its corpus for each query."
+  (let* ((item '(:name "Name" :firstMessage "first"
+                 :searchText "Name first first late"))
+         (original (symbol-function 'concat))
+         (copies 0))
+    (cl-letf (((symbol-function 'concat)
+               (lambda (&rest strings)
+                 (cl-incf copies)
+                 (apply original strings))))
+      (should (equal (pilish--session-filter-search (list item) '("late"))
+                     (list item))))
+    (should (= copies 0))))
+
+(ert-deftest pilish-test-session-search-loading-error-do-not-filter-old-items ()
+  "Loading and error screens don't search the previous full-text snapshot."
+  (dolist (state '(loading error))
+    (with-temp-buffer
+      (pilish-session-browser-mode)
+      (setq pilish--session-browser-items
+            '((:name "Old session" :searchText "old full text"))
+            pilish--session-browser-search-tokens '("full")
+            pilish--session-browser-loading (eq state 'loading)
+            pilish--session-browser-error (and (eq state 'error) "test failure"))
+      (let ((filters 0)
+            (original (symbol-function 'pilish--session-filter-search)))
+        (cl-letf (((symbol-function 'pilish--session-filter-search)
+                   (lambda (&rest args)
+                     (cl-incf filters)
+                     (apply original args))))
+          (pilish--session-browser-render (current-buffer)))
+        (should (string-match-p (if (eq state 'loading) "Loading sessions" "test failure")
+                                (buffer-string)))
+        (should (= filters 0))))))
+
+(defmacro pilish-test--with-search-scan (&rest body)
+  "Run BODY with a disk PATH, owner BROWSER, queued timers and scan tracking.
+QUEUE contains (DELAY FUNCTION . ARGS); CALLS records final deliveries.
+SCAN-BUFFERS tracks actual file-read buffers, not private scanner fields.
+The controlled clock forces line-level yielding without elapsed-time assertions."
+  (declare (indent 0) (debug t))
+  `(let* ((dir (pilish-test--make-temp-directory "pi-search-slice"))
+          (path (expand-file-name "session.jsonl" dir))
+          (browser (generate-new-buffer " *pi-search-owner*"))
+          (queue nil) (calls nil) (scan-buffers nil) (clock 0.0)
+          (read-file (symbol-function 'insert-file-contents)))
+     (pilish-test--write-session-lines
+      path
+      (append (list (pilish-test--make-session-header "sliced")
+                    (pilish-test--user-line "first" nil "opening"))
+              (cl-loop for n below 40 collect
+                       (pilish-test--jsonl-line
+                        "message" (format "a%d" n) "first"
+                        :message (list :role "assistant" :content (format "text%d" n))))
+              (list (pilish-test--user-line "last" "first" "finál 東京 🚀"))))
+     (unwind-protect
+         (with-current-buffer browser
+           (pilish-session-browser-mode)
+           (setq pilish--session-browser-fetch-token 1)
+           (cl-letf (((symbol-function 'float-time)
+                      (lambda (&optional _time) (cl-incf clock 0.002)))
+                     ((symbol-function 'run-at-time)
+                      (lambda (delay _repeat fn &rest args)
+                        (setq queue (nconc queue (list (cons delay (cons fn args)))))))
+                     ((symbol-function 'insert-file-contents)
+                      (lambda (file &rest args)
+                        (when (equal file path) (push (current-buffer) scan-buffers))
+                        (apply read-file file args))))
+             ,@body))
+       (when (buffer-live-p browser) (kill-buffer browser))
+       ;; Dispose queued work even when an assertion interrupted BODY.
+       (dolist (job queue) (apply (cadr job) (cddr job)))
+       (dolist (buffer scan-buffers)
+         (when (buffer-live-p buffer) (kill-buffer buffer))))))
+
+(ert-deftest pilish-test-session-search-scan-yields-within-one-file ()
+  "A single file stays incomplete across positive-delay continuations."
+  (pilish-test--with-search-scan
+    (pilish--browse-scan-session-files
+     browser 1 (list path) nil (lambda (items error) (push (list items error) calls)))
+    (should-not calls)
+    (should (= (length queue) 1))
+    (should (cl-some #'buffer-live-p scan-buffers))
+    (let ((slices 0))
+      (while queue
+        (should (< (cl-incf slices) 200))
+        (let ((job (pop queue)))
+          (should (> (car job) 0))
+          (apply (cadr job) (cddr job))))
+      (should (> slices 1)))
+    (should (= (length calls) 1))
+    (should-not (cadar calls))
+    (should (equal (mapcar (lambda (i) (plist-get i :path)) (caar calls)) (list path)))
+    (should (pilish--session-filter-search (caar calls) '("text0.*text39" "finál" "東京" "🚀")))
+    (should-not (cl-some #'buffer-live-p scan-buffers))))
+
+(ert-deftest pilish-test-session-search-scan-stale-and-dead-cleanup ()
+  "Superseded and dead owners drop in-flight same-file work and its buffer."
+  (dolist (cancel '(supersede kill))
+    (pilish-test--with-search-scan
+      (pilish--browse-scan-session-files
+       browser 1 (list path) nil (lambda (&rest args) (push args calls)))
+      (should queue)
+      (should-not calls)
+      (should (cl-some #'buffer-live-p scan-buffers))
+      (if (eq cancel 'supersede)
+          (cl-incf pilish--session-browser-fetch-token)
+        (kill-buffer browser))
+      (let ((job (pop queue))) (apply (cadr job) (cddr job)))
+      (should-not queue)
+      (should-not calls)
+      (should-not (cl-some #'buffer-live-p scan-buffers)))))
+
+(ert-deftest pilish-test-session-search-scan-reentrant-invalidation ()
+  "An owner invalidated inside file IO cannot receive even a final callback."
+  (dolist (cancel '(supersede kill))
+    (pilish-test--with-search-scan
+      (let ((original (symbol-function 'insert-file-contents)))
+        (cl-letf (((symbol-function 'insert-file-contents)
+                   (lambda (&rest args)
+                     (prog1 (apply original args)
+                       (if (eq cancel 'supersede)
+                           (with-current-buffer browser
+                             (cl-incf pilish--session-browser-fetch-token))
+                         (kill-buffer browser))))))
+          (pilish--browse-scan-session-files
+           browser 1 (list path) nil (lambda (&rest args) (push args calls)))))
+      (should-not calls)
+      (should-not queue)
+      (should-not (cl-some #'buffer-live-p scan-buffers)))))
+
+(ert-deftest pilish-test-session-search-scan-callback-error-once-after-cleanup ()
+  "A signaling consumer is called only once, after file resources are released."
+  (pilish-test--with-search-scan
+    (let ((callback (lambda (&rest args)
+                      (push args calls)
+                      (should-not (cl-some #'buffer-live-p scan-buffers))
+                      (error "consumer failed"))))
+      ;; No artificial deadline: isolate delivery from scheduling assertions.
+      (cl-letf (((symbol-function 'float-time) (lambda (&optional _) 0.0)))
+        (should (equal
+                 (should-error
+                  (pilish--browse-scan-session-files browser 1 (list path) nil callback)
+                  :type 'error)
+                 '(error "consumer failed")))))
+    (should (= (length calls) 1))
+    (should (= (length (caar calls)) 1))
+    (should-not (cadar calls))
+    (should-not queue)))
+
+(ert-deftest pilish-test-session-search-scan-late-error-skips-file ()
+  "An ordinary late parse failure skips its file, not the remaining sessions."
+  (pilish-test--with-search-scan
+    (let ((good (expand-file-name "good.jsonl" dir))
+          (original (symbol-function 'pilish--jsonl-parse-current-line)))
+      (pilish-test--write-session-lines
+       good (list (pilish-test--make-session-header "survivor")))
+      (cl-letf (((symbol-function 'pilish--jsonl-parse-current-line)
+                 (lambda ()
+                   (when (looking-at-p ".*text5") (error "injected late failure"))
+                   (funcall original))))
+        (pilish--browse-scan-session-files
+         browser 1 (list path (expand-file-name "missing.jsonl" dir) good) nil
+         (lambda (&rest args) (push args calls)))
+        (while queue
+          (let ((job (pop queue))) (apply (cadr job) (cddr job)))))
+      (should (= (length calls) 1))
+      (should-not (cadar calls))
+      (should (equal (mapcar (lambda (i) (plist-get i :id)) (caar calls))
+                     '("survivor")))
+      (should-not (cl-some #'buffer-live-p scan-buffers)))))
+
+(ert-deftest pilish-test-session-search-scan-late-quit-cleans-up ()
+  "Quit during later text extraction reports once rather than leaving loading."
+  (pilish-test--with-search-scan
+    (let ((original (symbol-function 'pilish--jsonl-parse-current-line)))
+      (cl-letf (((symbol-function 'pilish--jsonl-parse-current-line)
+                 (lambda ()
+                   (when (looking-at-p ".*text5") (signal 'quit nil))
+                   (funcall original))))
+        (pilish--browse-scan-session-files
+         browser 1 (list path) nil (lambda (&rest args) (push args calls)))
+        (while queue
+          (let ((job (pop queue))) (apply (cadr job) (cddr job)))))
+      (should (equal calls '((nil "Session scan was interrupted"))))
+      (should-not (cl-some #'buffer-live-p scan-buffers)))))
+
+(ert-deftest pilish-test-session-search-scan-slice-error-cleans-up ()
+  "A scan-level scheduling failure releases the retained file and reports once."
+  (pilish-test--with-search-scan
+    (pilish--browse-scan-session-files
+     browser 1 (list path) nil (lambda (&rest args) (push args calls)))
+    (should queue)
+    (should-not calls)
+    (should (cl-some #'buffer-live-p scan-buffers))
+    ;; The next slice owns an already open file, including while it sets
+    ;; its deadline.  Budget/timer errors must not bypass that ownership.
+    (cl-letf (((symbol-function 'float-time)
+               (lambda (&optional _) (error "clock failed"))))
+      (let ((job (pop queue))) (apply (cadr job) (cddr job))))
+    (should (equal calls '((nil "Session scan failed: clock failed"))))
+    (should-not queue)
+    (should-not (cl-some #'buffer-live-p scan-buffers))))
+
+(ert-deftest pilish-test-session-search-quit-window-keeps-inflight-scan ()
+  "The q binding hides the browser without cancelling its in-flight scan."
+  (pilish-test--with-search-scan
+    (save-window-excursion
+      (pop-to-buffer browser)
+      (pilish--browse-scan-session-files
+       browser 1 (list path) nil (lambda (&rest args) (push args calls)))
+      (should queue)
+      (call-interactively (key-binding (kbd "q")))
+      (should (buffer-live-p browser))
+      (should-not (get-buffer-window browser t))
+      (should (= (buffer-local-value 'pilish--session-browser-fetch-token browser) 1))
+      (while queue
+        (let ((job (pop queue))) (apply (cadr job) (cddr job))))
+      (should (= (length calls) 1))
+      (should (pilish--session-filter-search (caar calls) '("finál")))
+      (should-not (get-buffer-window browser t))
+      (should-not (cl-some #'buffer-live-p scan-buffers)))))
+
+(ert-deftest pilish-test-session-search-invalid-and-cleared-query ()
+  "Invalid regexps preserve the previous query; clearing restores all rows."
+  (with-temp-buffer
+    (pilish-session-browser-mode)
+    (setq pilish--session-browser-items
+          '((:path "/fake/one" :name "One" :searchText "One first late")
+            (:path "/fake/two" :name "Two" :searchText "Two other text")))
+    (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "One")))
+      (call-interactively #'pilish-session-browser-search))
+    (let ((before (buffer-string)) (messages nil))
+      (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "["))
+                ((symbol-function 'message)
+                 (lambda (format-string &rest args)
+                   (push (apply #'format format-string args) messages))))
+        (call-interactively #'pilish-session-browser-search))
+      (should (= (length messages) 1))
+      (should (string-match-p "Pi: Invalid regexp:" (car messages)))
+      (should (equal pilish--session-browser-search-query "One"))
+      (should (equal pilish--session-browser-search-tokens '("One")))
+      (should (equal (buffer-string) before)))
+    (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "")))
+      (call-interactively #'pilish-session-browser-search))
+    (should-not pilish--session-browser-search-tokens)
+    (should (string-match-p "One" (buffer-string)))
+    (should (string-match-p "Two" (buffer-string)))))
 
 ;;;; Phase 2: Fetch Relaxation
 

--- a/test/pilish-jsonl-test.el
+++ b/test/pilish-jsonl-test.el
@@ -1308,6 +1308,137 @@ through `date-to-time' and orders lexicographically like time."
       (should (string< mod-a mod-b))
       (should (string> mod-b mod-a)))))
 
+;;;; Optional Session Search Corpus
+
+(ert-deftest pilish-test-jsonl-session-search-corpus-scope-and-metadata ()
+  "Opt-in search includes text on all branches, never hidden payloads."
+  (let* ((dir (pilish-test--make-temp-directory "pi-jsonl-search"))
+         (path (expand-file-name "session.jsonl" dir)))
+    (pilish-test--write-jsonl
+     path
+     (list '(:type "session" :id "headerneedle" :cwd "/metadata-needle")
+           '(:type "message" :id "u1" :parentId nil
+             :message (:role "user" :content "opening"))
+           '(:type "message" :id "a1" :parentId "u1"
+             :message (:role "assistant" :content "inactive alpha"))
+           '(:type "message" :id "u2" :parentId "u1"
+             :message (:role "user"
+                       :content [(:type "text" :text "active")
+                                 (:type "image" :data "imageneedle" :text "imagetextneedle")
+                                 (:type "text" :text "beta")]))
+           '(:type "message" :id "a2" :parentId "u2"
+             :message (:role "assistant"
+                       :content [(:type "thinking" :thinking "thinkingneedle")
+                                 (:type "toolCall" :name "toolnameneedle"
+                                  :arguments (:text "argsneedle"))
+                                 (:type "text" :text "omega")
+                                 (:type "text" :text "")
+                                 (:type "text" :text 42)]))
+           '(:type "message" :message (:role "toolResult" :content "toolneedle"))
+           '(:type "message" :message (:role "custom" :content "customroleneedle"))
+           '(:type "message" :message (:role "system" :content "systemneedle"))
+           '(:type "message" :message (:role "user" :content nil))
+           '(:type "branch_summary" :summary "branchneedle")
+           '(:type "compaction" :summary "compactneedle")
+           '(:type "custom" :message (:role "user" :content "customentryneedle"))
+           '(:type "label" :label "labelneedle")
+           '(:type "session_info" :name " Name ")))
+    ;; Canonical type-first routing remains intentional, and malformed late
+    ;; message/name lines neither lose prior text nor clear the latest name.
+    (with-temp-buffer
+      (insert "{\"id\":\"noncanonical\",\"type\":\"message\",\"message\":{\"role\":\"user\",\"content\":\"orderneedle\"}}\n"
+              "{\"type\":\"message\",broken\n"
+              "{\"type\":\"session_info\",broken\n")
+      (write-region (point-min) (point-max) path t 'silent))
+    (let* ((metadata (pilish-jsonl-read-session-info path))
+           (full (pilish-jsonl-read-session-info path t))
+           (without-corpus (copy-sequence full)))
+      (cl-remf without-corpus :searchText)
+      (should (equal without-corpus metadata))
+      (should-not (plist-member metadata :searchText))
+      (should-not (plist-member full :allMessagesText))
+      (should (equal (plist-get full :searchText)
+                     "Name opening opening inactive alpha active beta omega ")))))
+
+(ert-deftest pilish-test-jsonl-session-search-unicode-eof-and-decoding ()
+  "Full search preserves Unicode and embedded whitespace through decoded EOF."
+  (let* ((dir (pilish-test--make-temp-directory "pi-jsonl-search-utf8"))
+         (path (expand-file-name "session.jsonl" dir)))
+    (dolist (coding '(utf-8-unix utf-8-dos utf-8-with-signature-dos))
+      (let ((coding-system-for-write coding))
+        (with-temp-file path
+          (insert " \t\n"
+                  (json-encode pilish-test--jsonl-header) "\n"
+                  (json-encode '(:type "message" :message (:role "user" :content "first")))
+                  "\n"
+                  ;; Deliberately no final newline, regardless of encoding.
+                  (json-encode '(:type "message"
+                                 :message (:role "assistant" :content "finál\n東京\t🚀"))))))
+      (should (equal (plist-get (pilish-jsonl-read-session-info path t) :searchText)
+                     " first first finál\n東京\t🚀")))))
+
+(ert-deftest pilish-test-jsonl-session-search-default-preview-budget ()
+  "Default metadata parses only the legacy preview budget and name records."
+  (let* ((dir (pilish-test--make-temp-directory "pi-jsonl-search-budget"))
+         (path (expand-file-name "session.jsonl" dir))
+         (original (symbol-function 'pilish--jsonl-parse-current-line))
+         (parsed 0))
+    (with-temp-file path
+      (insert (json-encode pilish-test--jsonl-header) "\n"
+              "{\"type\":\"message\",broken\n")
+      (dotimes (_ 4)
+        (insert (json-encode '(:type "message" :message (:role "toolResult" :content "legacy fallback"))) "\n"))
+      (dotimes (_ 20)
+        (insert (json-encode '(:type "message" :message (:role "user" :content "late user"))) "\n"))
+      (insert (json-encode '(:type "session_info" :name " Old ")) "\n"
+              (json-encode '(:type "session_info" :name "  ")) "\n"))
+    (cl-letf (((symbol-function 'pilish--jsonl-parse-current-line)
+               (lambda () (cl-incf parsed) (funcall original))))
+      (let ((metadata (pilish-jsonl-read-session-info path)))
+        (should (= parsed 7))
+        (should (= (plist-get metadata :messageCount) 25))
+        (should (equal (plist-get metadata :firstMessage) "legacy fallback"))
+        (should-not (plist-member metadata :name))
+        (should-not (plist-member metadata :searchText))))))
+
+(ert-deftest pilish-test-jsonl-session-search-legacy-empty-fallback ()
+  "Full extraction doesn't overwrite the first-five any-role preview choice."
+  (let* ((dir (pilish-test--make-temp-directory "pi-jsonl-search-fallback"))
+         (path (expand-file-name "session.jsonl" dir)))
+    (dolist (first '("" "legacy tool"))
+      (pilish-test--write-jsonl
+       path
+       (append (list pilish-test--jsonl-header
+                     `(:type "message" :message (:role "toolResult" :content ,first)))
+               (make-list 4 '(:type "message" :message (:role "toolResult" :content "excluded later tool")))
+               (list '(:type "message" :message (:role "user" :content "late user")))))
+      (let* ((metadata (pilish-jsonl-read-session-info path))
+             (full (pilish-jsonl-read-session-info path t))
+             (without-corpus (copy-sequence full)))
+        (cl-remf without-corpus :searchText)
+        (should (equal metadata without-corpus))
+        (should (equal (plist-get full :searchText) (concat " " first " late user")))
+        (should (equal (plist-get full :firstMessage) (unless (equal first "") first)))))))
+
+(ert-deftest pilish-test-jsonl-session-search-invalid-and-unreadable-files ()
+  "Opt-in reading skips bad headers and read failures, like metadata-only."
+  (let* ((dir (pilish-test--make-temp-directory "pi-jsonl-search-invalid"))
+         (path (expand-file-name "session.jsonl" dir)))
+    (dolist (contents '("" "garbage\n{\"type\":\"session\"}\n"
+                        "{\"type\":\"message\"}\n"))
+      (with-temp-file path (insert contents))
+      (should-not (pilish-jsonl-read-session-info path t)))
+    (should-not (pilish-jsonl-read-session-info (expand-file-name "missing.jsonl" dir) t))
+    (pilish-test--write-jsonl path (list pilish-test--jsonl-header))
+    (let (scan-buffer)
+      (cl-letf (((symbol-function 'insert-file-contents)
+                 (lambda (&rest _)
+                   (setq scan-buffer (current-buffer))
+                   (signal 'file-error '("read failed")))))
+        (should-not (pilish-jsonl-read-session-info path t)))
+      (should (bufferp scan-buffer))
+      (should-not (buffer-live-p scan-buffer)))))
+
 ;;;; Navigation
 
 (defun pilish-test--jsonl-line-string (line)


### PR DESCRIPTION
Session browser search now includes text from every user and assistant message, including older branches, alongside session names and first messages.

Large session files are scanned in small steps so the browser can respond while loading. Tool output and hidden content stay out of the added search text. Very large individual records, searches, and rendering can still briefly pause the browser.

Validation: make check (1,751 passed, 1 skipped), source and compiled module tests, 200 GUI smoke operations, lifecycle cleanup checks, and reload/resume smoke tests.

Fixes #269
